### PR TITLE
Move the builtinTypes from Box to Type where it makes more sense

### DIFF
--- a/compiler/src/lntoamm/Box.js
+++ b/compiler/src/lntoamm/Box.js
@@ -19,70 +19,70 @@ class Box {
     const Float64 = require('./Float64')
     const Event = require('./Event')
     if (args.length === 0) {
-      this.type = Box.builtinTypes.void
+      this.type = Type.builtinTypes.void
       this.readonly = true
     } else if (args.length === 1) {
       if (typeof args[0] === "boolean") {
-        this.type = Box.builtinTypes.void
+        this.type = Type.builtinTypes.void
         this.readonly = args[0]
       } else if (args[0] instanceof Type) {
-        this.type = Box.builtinTypes.type
+        this.type = Type.builtinTypes.type
         this.typeval = args[0]
         this.readonly = true // Type declarations are always read-only
       } else if (args[0] instanceof Scope) {
-        this.type = Box.builtinTypes.scope
+        this.type = Type.builtinTypes.scope
         this.scopeval = args[0]
         this.readonly = true // Boxed scopes are always read-only
       } else if (args[0] instanceof Microstatement) {
-        this.type = Box.builtinTypes.microstatement
+        this.type = Type.builtinTypes.microstatement
         this.microstatementval = args[0]
         this.readonly = true
       } else if (args[0] instanceof Array) {
         // This is only operator declarations right now
-        this.type = Box.builtinTypes.operator
+        this.type = Type.builtinTypes.operator
         this.operatorval = args[0]
         this.readonly = true
       }
     } else if (args.length === 2) {
       if (args[0] instanceof Int8) {
-        this.type = Box.builtinTypes.int8
+        this.type = Type.builtinTypes.int8
         this.int8val = args[0]
         this.readonly = args[1]
       } else if (args[0] instanceof Int16) {
-        this.type = Box.builtinTypes.int16
+        this.type = Type.builtinTypes.int16
         this.int16val = args[0]
         this.readonly = args[1]
       } else if (args[0] instanceof Int32) {
-        this.type = Box.builtinTypes.int32
+        this.type = Type.builtinTypes.int32
         this.int32val = args[0]
         this.readonly = args[1]
       } else if (args[0] instanceof Int64) {
-        this.type = Box.builtinTypes.int64
+        this.type = Type.builtinTypes.int64
         this.int64val = args[0]
         this.readonly = args[1]
       } else if (args[0] instanceof Float32) {
-        this.type = Box.builtinTypes.float32
+        this.type = Type.builtinTypes.float32
         this.float32val = args[0]
         this.readonly = args[1]
       } else if (args[0] instanceof Float64) {
-        this.type = Box.builtinTypes.float64
+        this.type = Type.builtinTypes.float64
         this.float64val = args[0]
         this.readonly = args[1]
       } else if (typeof args[0] === "boolean") {
-        this.type = Box.builtinTypes.bool
+        this.type = Type.builtinTypes.bool
         this.boolval = args[0]
         this.readonly = args[1]
       } else if (typeof args[0] === "string") {
-        this.type = Box.builtinTypes.string
+        this.type = Type.builtinTypes.string
         this.stringval = args[0]
         this.readonly = args[1]
       } else if (args[0] instanceof Array) {
         // This is only function declarations right now
-        this.type = Box.builtinTypes["function"]
+        this.type = Type.builtinTypes["function"]
         this.functionval = args[0]
         this.readonly = args[1]
       } else if (args[0] instanceof Event) {
-        this.type = Box.builtinTypes.Event
+        this.type = Type.builtinTypes.Event
         this.eventval = args[0]
         this.readonly = args[1]
       }
@@ -101,7 +101,7 @@ class Box {
         this.readonly = args[2]
       } else if (args[0] instanceof Object) {
         // It's an event or user-defined type
-        if (args[1].originalType == Box.builtinTypes.Event) {
+        if (args[1].originalType == Type.builtinTypes.Event) {
           let eventval = new Event(args[0].name.stringval, args[1].properties.type, false)
           this.eventval = eventval
           this.readonly = args[2]
@@ -398,51 +398,6 @@ class Box {
     return null
   }
 
-}
-
-Box.builtinTypes = {
-  void: new Type("void", true),
-  int8: new Type("int8", true),
-  int16: new Type("int16", true),
-  int32: new Type("int32", true),
-  int64: new Type("int64", true),
-  float32: new Type("float32", true),
-  float64: new Type("float64", true),
-  bool: new Type("bool", true),
-  string: new Type("string", true),
-  Error: new Type("Error", true, {
-    message: new Type("string", true, true),
-    code: new Type("int64", true, true),
-  }),
-  "Array": new Type("Array", true, {
-    records: new Type("V", true, true),
-  }, {
-    V: 0,
-  }),
-  Map: new Type("Map", true, {
-    key: new Type("K", true, true),
-    value: new Type("V", true, true),
-  }, {
-    K: 0,
-    V: 1,
-  }),
-  KeyVal: new Type("KeyVal", true, {
-    key: new Type("K", true, true),
-    value: new Type("V", true, true),
-  }, {
-    K: 0,
-    V: 1,
-  }),
-  "function": new Type("function", true),
-  operator: new Type("operator", true),
-  Event: new Type("Event", true, {
-    type: new Type("E", true, true),
-  }, {
-    E: 0,
-  }),
-  type: new Type("type", true),
-  scope: new Type("scope", true),
-  microstatement: new Type("microstatement", true),
 }
 
 module.exports = Box

--- a/compiler/src/lntoamm/Interface.js
+++ b/compiler/src/lntoamm/Interface.js
@@ -1,4 +1,3 @@
-const Type = require('./Type')
 const FunctionType = require('./FunctionType')
 
 class Interface {
@@ -17,8 +16,9 @@ class Interface {
   }
 
   typeApplies(typeToCheck, scope) {
+    // Circulary dependency nonsense
+    const Type = require('./Type')
     // Solve circular dependency issue
-    const Box = require('./Box')
     for (const requiredProperty of Object.keys(this.requiredProperties)) {
       if (!typeToCheck.properties.hasOwnProperty(requiredProperty)) return false
     }
@@ -28,7 +28,7 @@ class Interface {
       const potentialFunctionsBox = scope.deepGet(functionType.functionname)
       if (
         potentialFunctionsBox == null ||
-        potentialFunctionsBox.type != Box.builtinTypes["function"]
+        potentialFunctionsBox.type != Type.builtinTypes["function"]
       ) {
         console.error(functionType.functionname + " is not the name of a function")
         process.exit(-48)
@@ -67,7 +67,9 @@ class Interface {
   }
 
   static fromAst(interfaceAst, scope) {
+    // Circulary dependency nonsense
     const Box = require('./Box')
+    const Type = require('./Type')
     // Construct the basic interface, the wrapper type, and insert it into the scope
     // This is all necessary so the interface can self-reference when constructing the function and
     // operator types.

--- a/compiler/src/lntoamm/Microstatement.js
+++ b/compiler/src/lntoamm/Microstatement.js
@@ -3,6 +3,7 @@ const { v4: uuid, } = require('uuid')
 const { LnParser, } = require('../ln')
 const StatementType = require('./StatementType')
 const Box = require('./Box')
+const Type = require('./Type')
 const UserFunction = require('./UserFunction')
 
 class Microstatement {
@@ -14,7 +15,7 @@ class Microstatement {
       this.pure = args[2]
       this.outputName = args[3]
       this.alias = ""
-      this.outputType = Box.builtinTypes.void
+      this.outputType = Type.builtinTypes.void
       this.inputNames = []
       this.fns = []
       this.closureStatements = args[4]
@@ -328,7 +329,7 @@ class Microstatement {
         scope,
         true,
         constName,
-        Box.builtinTypes["string"],
+        Type.builtinTypes["string"],
         [last.outputType.typename],
         [],
       ))
@@ -405,7 +406,7 @@ class Microstatement {
         scope,
         true,
         lenName,
-        Box.builtinTypes['int64'],
+        Type.builtinTypes['int64'],
         [`${arrayLiteralContents.length}`],
         [],
       ))
@@ -608,7 +609,7 @@ class Microstatement {
       scope,
       true, // TODO: Figure out if this is true or not
       constName,
-      Box.builtinTypes['function'],
+      Type.builtinTypes['function'],
       innerMicrostatements
     ))
   }
@@ -732,7 +733,7 @@ class Microstatement {
         )
         process.exit(-102)
       }
-      if (eventBox.eventval.type != Box.builtinTypes.void) {
+      if (eventBox.eventval.type != Type.builtinTypes.void) {
         console.error(emitsAst.varn().getText() + " must have a value emitted to it!")
         console.error(
           emitsAst.getText() +
@@ -748,7 +749,7 @@ class Microstatement {
         scope,
         true,
         eventBox.eventval.name,
-        Box.builtinTypes.void,
+        Type.builtinTypes.void,
         [],
         [],
       ))
@@ -1044,7 +1045,7 @@ class Microstatement {
       // C.
       const type = (
         scope.deepGet(letTypeHint) && scope.deepGet(letTypeHint).typeval
-      ) || Box.builtinTypes.void
+      ) || Type.builtinTypes.void
       if (type.originalType && type.originalType.typename === 'Array') {
         const opcodeScope = require('./opcodes').exportScope // Unfortunate circular dep issue
         const constName = "_" + uuid().replace(/-/g, "_")
@@ -1053,7 +1054,7 @@ class Microstatement {
           scope,
           true,
           constName,
-          Box.builtinTypes.int64,
+          Type.builtinTypes.int64,
           ["0"],
           [],
         ))
@@ -1088,7 +1089,7 @@ class Microstatement {
         true,
         letName,
         letAlias,
-        Box.builtinTypes.void,
+        Type.builtinTypes.void,
         [],
         [],
       ))
@@ -1198,7 +1199,7 @@ class Microstatement {
         scope,
         true,
         constName,
-        Box.builtinTypes.void,
+        Type.builtinTypes.void,
         ["void"],
         [],
       )
@@ -1210,7 +1211,7 @@ class Microstatement {
         true,
         constName,
         constAlias,
-        Box.builtinTypes.void,
+        Type.builtinTypes.void,
         [],
         [],
       ))

--- a/compiler/src/lntoamm/Module.js
+++ b/compiler/src/lntoamm/Module.js
@@ -315,7 +315,7 @@ class Module {
         console.error("Could not find specified event: " + handlerAst.eventref().getText())
         process.exit(-20)
       }
-      if (eventBox.type !== Box.builtinTypes["Event"]) {
+      if (eventBox.type !== Type.builtinTypes["Event"]) {
         console.error(eventBox)
         console.error(handlerAst.eventref().getText() + " is not an event")
         process.exit(-21)
@@ -329,7 +329,7 @@ class Module {
           console.error("Could not find specified function: " + fnName)
           process.exit(-22)
         }
-        if (fnBox.type !== Box.builtinTypes["function"]) {
+        if (fnBox.type !== Type.builtinTypes["function"]) {
           console.error(fnName + " is not a function")
           process.exit(-23)
         }
@@ -363,7 +363,7 @@ class Module {
         process.exit(-24)
       }
       if (Object.keys(fn.getArguments()).length > 1 ||
-        (evt.type === Box.builtinTypes["void"] && Object.keys(fn.getArguments()).length !== 0)
+        (evt.type === Type.builtinTypes["void"] && Object.keys(fn.getArguments()).length !== 0)
       ) {
         console.error("Function provided for " + handlerAst.eventref().getText() + " has invalid argument signature")
         process.exit(-25)

--- a/compiler/src/lntoamm/Scope.js
+++ b/compiler/src/lntoamm/Scope.js
@@ -1,4 +1,5 @@
 const Box = require('./Box')
+const Type = require('./Type')
 const { LnParser, } = require('../ln')
 
 class Scope {
@@ -29,7 +30,7 @@ class Scope {
         } else if (boxedVar === null) {
           return null
         } else {
-          if (boxedVar.type === Box.builtinTypes['scope']) {
+          if (boxedVar.type === Type.builtinTypes['scope']) {
             boxedVar = boxedVar.scopeval.get(fullVar[i])
           } else if (boxedVar.typevalval !== null) {
             boxedVar = boxedVar.typevalval[fullVar[i]]
@@ -50,7 +51,7 @@ class Scope {
           if (varSegment.METHODSEP() != null) continue // Skip these, they're just periods
           if (varSegment.VARNAME() != null) {
             // This path is like the original deepGet
-            if (boxedVar.type === Box.builtinTypes["scope"]) {
+            if (boxedVar.type === Type.builtinTypes["scope"]) {
               boxedVar = boxedVar.scopeval.get(varSegment.getText())
             } else if (boxedVar.typevalval !== null) { // User-defined type instance
               boxedVar = boxedVar.typevalval[varSegment.getText()]
@@ -66,9 +67,9 @@ class Scope {
               null,
               true
             )
-            if (boxedVar.type.originalType !== null && boxedVar.type.originalType === Box.builtinTypes["Array"]) {
+            if (boxedVar.type.originalType !== null && boxedVar.type.originalType === Type.builtinTypes["Array"]) {
               boxedVar = boxedVar.arrayval.get(arrayAccessBox.int64val)
-            } else if (boxedVar.type.originalType != null && boxedVar.type.originalType == Box.builtinTypes["Map"]) {
+            } else if (boxedVar.type.originalType != null && boxedVar.type.originalType == Type.builtinTypes["Map"]) {
               boxedVar = boxedVar.mapval.get(arrayAccessBox)
               if (boxedVar == null) {
                 boxedVar = opcodeScope.get("_")
@@ -80,7 +81,7 @@ class Scope {
                 process.exit(-38)
               }
               const arrayAccessStr = arrayAccessBox.stringval;
-              if (boxedVar.type == Box.builtinTypes["scope"]) {
+              if (boxedVar.type == Type.builtinTypes["scope"]) {
                 boxedVar = boxedVar.scopeval.get(arrayAccessStr)
               } else if (boxedVar.typevalval !== null) { // User-defined type instance
                 boxedVar = boxedVar.typevalval[arrayAccessStr]
@@ -128,7 +129,7 @@ class Scope {
       if (boxedVar === null) {
         boxedVar = this.deepGet(fullVar[i])
       } else {
-        if (boxedVar.type === Box.builtinTypes["scope"]) {
+        if (boxedVar.type === Type.builtinTypes["scope"]) {
           boxedVar = boxedVar.scopeval.get(fullVar[i])
         } else if (boxedVar.typevalval !== null) { // User-defined type instance
           boxedVar = boxedVar.typevalval[fullVar[i]]
@@ -138,7 +139,7 @@ class Scope {
         }
       }
     }
-    if (boxedVar.type === Box.builtinTypes["scope"]) {
+    if (boxedVar.type === Type.builtinTypes["scope"]) {
       boxedVar.scopeval.put(fullVar[fullVar.length - 1], val)
     } else if (boxedVar.typevalval != null) {
       boxedVar.typevalval[fullVar[fullVar.length - 1]] = val

--- a/compiler/src/lntoamm/Statement.js
+++ b/compiler/src/lntoamm/Statement.js
@@ -1,4 +1,4 @@
-const Box = require('./Box')
+const Type = require('./Type')
 const { LnParser, } = require('../ln')
 
 // Only implements the pieces necessary for the first stage compiler
@@ -28,7 +28,7 @@ class Statement {
       // if prior statements defined it, for now, just assume it exists and is not pure
       return false
     }
-    if (functionBox.type !== Box.builtinTypes["function"]) {
+    if (functionBox.type !== Type.builtinTypes["function"]) {
       console.error(callAst.varn(0).getText() + " is not a function")
       process.exit(-17)
     }

--- a/compiler/src/lntoamm/Type.js
+++ b/compiler/src/lntoamm/Type.js
@@ -219,4 +219,49 @@ class Type {
   }
 }
 
+Type.builtinTypes = {
+  void: new Type("void", true),
+  int8: new Type("int8", true),
+  int16: new Type("int16", true),
+  int32: new Type("int32", true),
+  int64: new Type("int64", true),
+  float32: new Type("float32", true),
+  float64: new Type("float64", true),
+  bool: new Type("bool", true),
+  string: new Type("string", true),
+  Error: new Type("Error", true, {
+    message: new Type("string", true, true),
+    code: new Type("int64", true, true),
+  }),
+  "Array": new Type("Array", true, {
+    records: new Type("V", true, true),
+  }, {
+    V: 0,
+  }),
+  Map: new Type("Map", true, {
+    key: new Type("K", true, true),
+    value: new Type("V", true, true),
+  }, {
+    K: 0,
+    V: 1,
+  }),
+  KeyVal: new Type("KeyVal", true, {
+    key: new Type("K", true, true),
+    value: new Type("V", true, true),
+  }, {
+    K: 0,
+    V: 1,
+  }),
+  "function": new Type("function", true),
+  operator: new Type("operator", true),
+  Event: new Type("Event", true, {
+    type: new Type("E", true, true),
+  }, {
+    E: 0,
+  }),
+  type: new Type("type", true),
+  scope: new Type("scope", true),
+  microstatement: new Type("microstatement", true),
+}
+
 module.exports = Type

--- a/compiler/src/lntoamm/UserFunction.js
+++ b/compiler/src/lntoamm/UserFunction.js
@@ -1,9 +1,9 @@
 const { v4: uuid, } = require('uuid')
 
 const Ast = require('./Ast')
-const Box = require('./Box')
 const Statement = require('./Statement')
 const StatementType = require('./StatementType')
+const Type = require('./Type')
 const { LnParser, } = require('../ln')
 
 // This only implements the parts required for the compiler
@@ -51,7 +51,7 @@ class UserFunction {
 
   static fromFunctionbodyAst(functionbodyAst, closureScope) {
     let args = {}
-    const returnType = Box.builtinTypes.void
+    const returnType = Type.builtinTypes.void
     let pure = true // Assume purity and then downgrade if needed
     let statements = []
     const statementsAst = functionbodyAst.statements()
@@ -80,7 +80,7 @@ class UserFunction {
                 console.error("Could not find type " + argsAst.argtype(i).getText() + " for argument " + argName)
                 process.exit(-39)
               }
-              if (getArgType.type !== Box.builtinTypes["type"]) {
+              if (getArgType.type !== Type.builtinTypes["type"]) {
                 console.error("Function argument is not a valid type: " + argsAst.argtype(i).getText())
                 process.exit(-50);
               }
@@ -105,7 +105,7 @@ class UserFunction {
                     console.error("Could not find type " + othertype.getText() + " for argument " + argName)
                     process.exit(-59)
                   }
-                  if (othertypeBox.type != Box.builtinTypes["type"]) {
+                  if (othertypeBox.type != Type.builtinTypes["type"]) {
                     console.error("Function argument is not a valid type: " + othertype.getText())
                     process.exit(-60)
                   }
@@ -125,7 +125,7 @@ class UserFunction {
             getArgType = new Box(union)
           }
         }
-        if (getArgType.type != Box.builtinTypes["type"]) {
+        if (getArgType.type != Type.builtinTypes["type"]) {
           console.error("Function argument is not a valid type: " + argsAst.argtype(i).getText())
           process.exit(-13)
         }
@@ -136,14 +136,14 @@ class UserFunction {
     if (functionAst.argtype() !== null) {
       if (functionAst.argtype().othertype().length === 1) {
         let getReturnType = closureScope.deepGet(functionAst.argtype().getText())
-        if (getReturnType == null || getReturnType.type != Box.builtinTypes["type"]) {
+        if (getReturnType == null || getReturnType.type != Type.builtinTypes["type"]) {
           if (functionAst.argtype().othertype(0).typegenerics() != null) {
             getReturnType = closureScope.deepGet(functionAst.argtype().othertype(0).typename().getText())
             if (getReturnType == null) {
               console.error("Could not find type " + functionAst.argtype().getText() + " for function " + functionAst.VARNAME().getText())
               process.exit(-59)
             }
-            if (getReturnType.type !== Box.builtinTypes["type"]) {
+            if (getReturnType.type !== Type.builtinTypes["type"]) {
               console.error("Function return is not a valid type: " + functionAst.argtype().getText())
               process.exit(-60)
             }
@@ -170,7 +170,7 @@ class UserFunction {
                 console.error("Could not find return type " + othertype.getText() + " for function " + functionAst.VARNAME().getText())
                 process.exit(-59)
               }
-              if (othertypeBox.type !== Box.builtinTypes["type"]) {
+              if (othertypeBox.type !== Type.builtinTypes["type"]) {
                 console.error("Function argument is not a valid type: " + othertype.getText())
                 process.exit(-60)
               }
@@ -190,7 +190,7 @@ class UserFunction {
       }
     } else {
       // TODO: Infer the return type by finding the return value and tracing backwards
-      returnType = Box.builtinTypes["void"]
+      returnType = Type.builtinTypes["void"]
     }
     let pure = true
     let statements = []

--- a/compiler/src/lntoamm/opcodes.js
+++ b/compiler/src/lntoamm/opcodes.js
@@ -13,19 +13,19 @@ const opcodeScope = new Scope()
 const opcodeModule = new Module(opcodeScope)
 
 // Base types
-const addBuiltIn = (name) => { opcodeScope.put(name, new Box(Box.builtinTypes[name])) }
+const addBuiltIn = (name) => { opcodeScope.put(name, new Box(Type.builtinTypes[name])) }
 ([
   'void', 'int8', 'int16', 'int32', 'int64', 'float32', 'float64', 'bool', 'string', 'function',
   'operator', 'Error', 'Array', 'Map', 'KeyVal',
 ].map(addBuiltIn))
-Box.builtinTypes['Array'].solidify(['string'], opcodeScope)
-Box.builtinTypes['Map'].solidify(['string', 'string'], opcodeScope)
+Type.builtinTypes['Array'].solidify(['string'], opcodeScope)
+Type.builtinTypes['Map'].solidify(['string', 'string'], opcodeScope)
 opcodeScope.put('any', new Box(new Type('any', true, new Interface('any'))))
-Box.builtinTypes['Array'].solidify(['any'], opcodeScope)
-Box.builtinTypes['Map'].solidify(['any', 'any'], opcodeScope)
-Box.builtinTypes['KeyVal'].solidify(['any', 'any'], opcodeScope)
-Box.builtinTypes['Array'].solidify(['KeyVal<any, any>'], opcodeScope)
-opcodeScope.put("start", new Box(new Event("_start", Box.builtinTypes.void, true), true))
+Type.builtinTypes['Array'].solidify(['any'], opcodeScope)
+Type.builtinTypes['Map'].solidify(['any', 'any'], opcodeScope)
+Type.builtinTypes['KeyVal'].solidify(['any', 'any'], opcodeScope)
+Type.builtinTypes['Array'].solidify(['KeyVal<any, any>'], opcodeScope)
+opcodeScope.put("start", new Box(new Event("_start", Type.builtinTypes.void, true), true))
 const t = (str) => opcodeScope.get(str).typeval
 
 // opcode declarations
@@ -37,7 +37,7 @@ const addopcodes = (opcodes) => {
     const opcodeObj = {
       getName: () => opcodeName,
       getArguments: () => args,
-      getReturnType: () => returnType || Box.builtinTypes.void,
+      getReturnType: () => returnType || Type.builtinTypes.void,
       isNary: () => false,
       isPure: () => true,
       microstatementInlining: (realArgNames, scope, microstatements) => {


### PR DESCRIPTION
Some code cleanup while I'm thinking about options on array methods in the background. In order to eventually delete Box from the repo, we need to peel off the useful pieces of it to where they belong (or delete them if they're not needed anymore). This first one moves the builtin types to the Type class, which should eventually help with the circular dependency stuff (though there's still the Type <-> Interface circular dep).