### PR TITLE
Simplify scope.deepGet dramatically by only allowing string-based queries

### DIFF
--- a/compiler/src/lntoamm/Box.ts
+++ b/compiler/src/lntoamm/Box.ts
@@ -215,10 +215,10 @@ class Box {
     // TODO: This code is becoming very overloaded with different meanings in different contexts
     // Should probably split this up into multiple functions instead of trying to have this function
     // guess which context it's running in.
-    
+
     // TODO: Review if any of the extra logic after deepGet is needed anymore
-    const typename = assignmentAst.varn().getText();
-    let typeBox = scope.deepGet(assignmentAst.varn());
+    const typename = assignmentAst.varn().getText()
+    let typeBox = scope.deepGet(assignmentAst.varn().getText())
 
     let type: Type
 
@@ -303,11 +303,11 @@ class Box {
     }
     if (!!basicAssignable.calls()) {
       // TODO: Support generating global constants from function calls at some point
-      // return Function.callFromAst(basicAssignable.calls(), scope);
+      // return Function.callFromAst(basicAssignable.calls(), scope)
       return new Box() // Void it for now
     }
     if (!!basicAssignable.varn()) {
-      return scope.deepGet(basicAssignable.varn());
+      return scope.deepGet(basicAssignable.varn().getText())
     }
     if (!!basicAssignable.groups()) {
       // TODO: Suppor this later

--- a/compiler/src/lntoamm/Event.ts
+++ b/compiler/src/lntoamm/Event.ts
@@ -23,7 +23,7 @@ class Event {
 
   static fromAst(eventAst: any, scope: Scope) { // TODO: Eliminate ANTLR
     const name = eventAst.VARNAME().getText()
-    const boxedVal = scope.deepGet(eventAst.varn())
+    const boxedVal = scope.deepGet(eventAst.varn().getText())
     if (boxedVal === null) {
       console.error("Could not find specified type: " + eventAst.varn().getText())
       process.exit(-8)

--- a/compiler/src/lntoamm/Microstatement.ts
+++ b/compiler/src/lntoamm/Microstatement.ts
@@ -923,7 +923,7 @@ class Microstatement {
     // can be pruned back off of the list to be reattached to a closure microstatement type.
     const constName = "_" + uuid().replace(/-/g, "_")
     if (blocklikesAst.varn() != null) { // TODO: Port to fromVarAst
-      const fnToClose = scope.deepGet(blocklikesAst.varn())
+      const fnToClose = scope.deepGet(blocklikesAst.varn().getText())
       if (fnToClose == null || fnToClose.functionval == null) {
         console.error(blocklikesAst.varn().getText() + " is not a function")
         process.exit(-111)
@@ -982,7 +982,7 @@ class Microstatement {
       // If there's an assignable value here, add it to the list of microstatements first, then
       // rewrite the final const assignment as the emit statement.
       Microstatement.fromAssignablesAst(emitsAst.assignables(), scope, microstatements)
-      const eventBox = scope.deepGet(emitsAst.varn()) // TODO: Port to fromVarAst when Box is removed
+      const eventBox = scope.deepGet(emitsAst.varn().getText()) // TODO: Port to fromVarAst when Box is removed
       if (eventBox.eventval == null) {
         console.error(emitsAst.varn().getText() + " is not an event!")
         console.error(
@@ -1025,7 +1025,7 @@ class Microstatement {
       ))
     } else {
       // Otherwise, create an emit statement with no value
-      const eventBox = scope.deepGet(emitsAst.varn()) // TODO: Port to fromVarAst
+      const eventBox = scope.deepGet(emitsAst.varn().getText()) // TODO: Port to fromVarAst
       if (eventBox.eventval == null) {
         console.error(emitsAst.varn().getText() + " is not an event!")
         console.error(

--- a/compiler/src/lntoamm/Module.ts
+++ b/compiler/src/lntoamm/Module.ts
@@ -175,7 +175,7 @@ class Module {
       const isPrefix = operatorAst.INFIX() === null
       const name = operatorAst.fntoop().operators().getText().trim()
       const precedence = parseInt(operatorAst.opprecedence().NUMBERCONSTANT().getText(), 10)
-      const fns = module.moduleScope.deepGet(operatorAst.fntoop().varn())
+      const fns = module.moduleScope.deepGet(operatorAst.fntoop().varn().getText())
       if (fns == null) {
         console.error("Operator " + name + " declared for unknown function " + operatorAst.varn().getText())
         process.exit(-31)
@@ -200,7 +200,7 @@ class Module {
     const exports = ast.exports()
     for (const exportAst of exports) {
       if (exportAst.varn() != null) {
-        const exportVar = module.moduleScope.deepGet(exportAst.varn())
+        const exportVar = module.moduleScope.deepGet(exportAst.varn().getText())
         const splitName = exportAst.varn().getText().split(".")
         module.moduleScope.put(splitName[splitName.length - 1], exportVar)
         module.exportScope.put(splitName[splitName.length - 1], exportVar)
@@ -249,9 +249,9 @@ class Module {
         const isPrefix = operatorAst.INFIX() == null
         const name = operatorAst.fntoop().operators().getText().trim()
         const precedence = parseInt(operatorAst.opprecedence().NUMBERCONSTANT().getText(), 10)
-        let fns = module.exportScope.deepGet(operatorAst.fntoop().varn())
+        let fns = module.exportScope.deepGet(operatorAst.fntoop().varn().getText())
         if (fns == null) {
-          fns = module.moduleScope.deepGet(operatorAst.fntoop().varn())
+          fns = module.moduleScope.deepGet(operatorAst.fntoop().varn().getText())
           if (fns != null) {
             console.error(
               "Exported operator " +
@@ -302,7 +302,7 @@ class Module {
     for (const handlerAst of handlers) {
       let eventBox = null
       if (handlerAst.eventref().varn() != null) {
-        eventBox = module.moduleScope.deepGet(handlerAst.eventref().varn())
+        eventBox = module.moduleScope.deepGet(handlerAst.eventref().varn().getText())
       } else if (handlerAst.eventref().calls() != null) {
         console.error("Not yet implemented!")
         process.exit(-19)
@@ -321,7 +321,7 @@ class Module {
       let fn = null
       if (handlerAst.varn() != null) {
         const fnName = handlerAst.varn().getText()
-        const fnBox = module.moduleScope.deepGet(handlerAst.varn())
+        const fnBox = module.moduleScope.deepGet(handlerAst.varn().getText())
         if (fnBox == null) {
           console.error("Could not find specified function: " + fnName)
           process.exit(-22)

--- a/compiler/src/lntoamm/Statement.ts
+++ b/compiler/src/lntoamm/Statement.ts
@@ -26,7 +26,7 @@ class Statement {
 
   static isCallPure(callAst: any, scope: Scope) { // TODO: Migrate off ANTLR
     // TODO: Add purity checking for chained method-style calls
-    const functionBox = scope.deepGet(callAst.varn(0))
+    const functionBox = scope.deepGet(callAst.varn(0).getText())
     if (functionBox == null) {
       // TODO: This function may be defined in the execution scope, we won't know until runtime
       // right now, but it should be determinable at "compile time". Need to fix this to check

--- a/compiler/src/lntoamm/Type.ts
+++ b/compiler/src/lntoamm/Type.ts
@@ -132,7 +132,7 @@ class Type {
       for (const lineAst of lines) {
         const propertyName = lineAst.VARNAME().getText()
         const typeName = lineAst.varn().getText()
-        const property = scope.deepGet(lineAst.varn())
+        const property = scope.deepGet(lineAst.varn().getText())
         if (property == null || property.type.typename !== "type") {
           if (type.generics.hasOwnProperty(typeName)) {
             type.properties[propertyName] = new Type(typeName, true, true)

--- a/compiler/src/lntoamm/UserFunction.ts
+++ b/compiler/src/lntoamm/UserFunction.ts
@@ -229,7 +229,7 @@ class UserFunction {
       statements.push(statement)
       // TODO: Infer the return type for anything other than calls or object literals
       if (assignablesAst.basicassignables() && assignablesAst.basicassignables().calls()) {
-        const fnCall = scope.deepGet(assignablesAst.basicassignables().calls().varn(0))
+        const fnCall = scope.deepGet(assignablesAst.basicassignables().calls().varn(0).getText())
         if (fnCall && fnCall.functionval) {
           // TODO: For now, also take the first matching function name, in the future
           // figure out the argument types provided recursively to select appropriately
@@ -311,7 +311,7 @@ class UserFunction {
     const condBlockFn = (cond.blocklikes(0).functionbody() ?
       UserFunction.fromFunctionbodyAst(cond.blocklikes(0).functionbody(), scope) :
       cond.blocklikes(0).varn() ?
-        scope.deepGet(cond.blocklikes(0).varn()).functionval[0] :
+        scope.deepGet(cond.blocklikes(0).varn().getText()).functionval[0] :
         UserFunction.fromFunctionsAst(cond.blocklikes(0).functions(), scope)
     ).maybeTransform()
     if (condBlockFn.statements[condBlockFn.statements.length - 1].isReturnStatement()) {
@@ -327,7 +327,7 @@ class UserFunction {
         const elseBlockFn = (cond.blocklikes(1).functionbody() ?
           UserFunction.fromFunctionbodyAst(cond.blocklikes(1).functionbody(), scope) :
           cond.blocklikes(1).varn() ?
-            scope.deepGet(cond.blocklikes(1).varn()).functionval[0] :
+            scope.deepGet(cond.blocklikes(1).varn().getText()).functionval[0] :
             UserFunction.fromFunctionsAst(cond.blocklikes(1).functions(), scope)
         ).maybeTransform()
         if (elseBlockFn.statements[elseBlockFn.statements.length - 1].isReturnStatement()) {


### PR DESCRIPTION
Part of a series of PRs to reduce code in the compiler and make it easier to reason about. If landed in-order, it's *supposed* to automatically retarget the master branch now, I've been told.