### PR TITLE
Switch the compiler to use register instead of copyfrom, fix issues in the memory library not using registered addresses appropriately, and fix a bug in the 'some' opcode that caused it to intermittently fail

### DIFF
--- a/compiler/src/lntoamm/Microstatement.ts
+++ b/compiler/src/lntoamm/Microstatement.ts
@@ -215,9 +215,9 @@ ${varAst.getText()} on line ${varAst.start.line}:${varAst.start.column}`)
               [`${fieldNum}`],
               [],
             ))
-            // Insert a `copyfrom` opcode.
+            // Insert a `register` opcode.
             const opcodes = require('./opcodes').default
-            opcodes.exportScope.get('copyfrom')[0].microstatementInlining(
+            opcodes.exportScope.get('register')[0].microstatementInlining(
               [original.outputName, addrName],
               scope,
               microstatements,
@@ -237,7 +237,7 @@ ${varAst.getText()} on line ${varAst.start.line}:${varAst.start.column}`)
         }
         // An array access. This requires resolving the contents of the array access variable and
         // then using that value to find the correct index to read from. For now, that will be
-        // emitting a `copyfrom` opcode call. Also for now it is an error if the resolved type is
+        // emitting a `resfrom` opcode call. Also for now it is an error if the resolved type is
         // anything but `int64` for the array access path. Maps use the same syntax with the type
         // being the Map's Key type.
         if (segment.arrayaccess()) {
@@ -257,7 +257,7 @@ ${varAst.getText()} on line ${varAst.start.line}:${varAst.start.column}`)
             throw new Error(`${segment.getText()} cannot be used in an array lookup as it is not an int64
 ${varAst.getText()} on line ${varAst.start.line}:${varAst.start.column}`)
           }
-          // Insert a `copyfrom` opcode.
+          // Insert a `resfrom` opcode.
           const opcodes = require('./opcodes').default
           opcodes.exportScope.get('resfrom')[0].microstatementInlining(
             [original.outputName, lookup.outputName],
@@ -1126,7 +1126,7 @@ ${callsAst.getText()} on line ${callsAst.start.line}:${callsAst.start.column}`)
     // For reassigning to a variable, we need to determine that the root variable is a
     // `let`-defined mutable variable and then tease out if any array or property accesses are done,
     // and if so we need to `register` a mutable reference to the array memory space and then update
-    // the value with a `copyfrom` call from the assignables result address to the relevant inner
+    // the value with a `register` call from the assignables result address to the relevant inner
     // address of the last access argument. The format of a `varn` can only be the following:
     // `{moduleScope}.varName[arrayAccess].userProperty` where the array accesses and userProperties
     // can come in any order after the preamble. *Fortunately,* for this scenario, any situation
@@ -1138,7 +1138,7 @@ ${callsAst.getText()} on line ${callsAst.start.line}:${callsAst.start.column}`)
     // beyond the first one, we simply take the `assignable` microstatement output and turn it into
     // an `ASSIGNMENT` StatementType, otherwise we need to go through a more complicated procedure
     // to `register` the `n-1` remaining inner array segments to new variables as references and
-    // finally `copyfrom` the `assignable` into the location the last segment indicates.
+    // finally `register` the `assignable` into the location the last segment indicates.
     const segments = assignmentsAst.varn().varsegment()
     // Now, find the original variable and confirm that it actually is a let declaration
     const letName = segments[0].getText()

--- a/runtime/src/vm/opcode.rs
+++ b/runtime/src/vm/opcode.rs
@@ -2302,7 +2302,8 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     let len = arr.len() as i64;
     let instructions = frag.get_closure_instructions(args[1]);
     // array of potentially many levels of nested fractals
-    let output: Vec<i64> = (0..len).into_par_iter().map_with(instructions, |ins, idx| {
+    let output: bool = (0..len).into_par_iter().all(|idx| {
+      let ins = instructions.clone();
       let mut mem = hand_mem.clone();
       // array element is $1 argument of the closure memory space
       if !arr.has_nested_fractals() {
@@ -2329,13 +2330,9 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       });
       // return address is $0 argument of the closure memory space
       let val = mem.read_fixed(CLOSURE_ARG_MEM_START);
-      if val == 1 {
-        return Some(1);
-      } else {
-        return None;
-      }
-    }).while_some().collect();
-    if output.len() as i64 == len {
+      return val == 1;
+    });
+    if output {
       hand_mem.write_fixed(args[2], 1i64);
     } else {
       hand_mem.write_fixed(args[2], 0i64);

--- a/runtime/src/vm/opcode.rs
+++ b/runtime/src/vm/opcode.rs
@@ -2216,7 +2216,8 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     let len = arr.len() as i64;
     let instructions = frag.get_closure_instructions(args[1]);
     // array of potentially many levels of nested fractals
-    let output: Vec<i64> = (0..len).into_par_iter().map_with(instructions, |ins, idx| {
+    let output: bool = (0..len).into_par_iter().any(|idx| {
+      let ins = instructions.clone();
       let mut mem = hand_mem.clone();
       // array element is $1 argument of the closure memory space
       if !arr.has_nested_fractals() {
@@ -2243,13 +2244,9 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       });
       // return address is $0 argument of the closure memory space
       let val = mem.read_fixed(CLOSURE_ARG_MEM_START);
-      if val == 1 {
-        return Some(1);
-      } else {
-        return None;
-      }
-    }).while_some().collect();
-    if output.len() > 0 {
+      return val == 1
+    });
+    if output {
       hand_mem.write_fixed(args[2], 1i64);
     } else {
       hand_mem.write_fixed(args[2], 0i64);


### PR DESCRIPTION
Part 1 of (expected) 2 for \#164