### PR TITLE
Add an environment check at the beginning of make build to avoid misleading problems on build issues

### DIFF
--- a/.envcheck.sh
+++ b/.envcheck.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+echo "Checking build commands..."
+
+# First check the needed commands exist
+if ! command -v node &> /dev/null; then
+  echo "Node.js is required to build this project. Please install Node >=10.20.1"
+  exit 1
+fi
+
+if ! command -v yarn &> /dev/null; then
+  echo "yarn is required to build this project.Please install yarn >=1.22.4"
+  exit 1
+fi
+
+if ! command -v rustc &> /dev/null; then
+  echo "Rust is required to build this project. Please install Rust >=1.41.1"
+  exit 1
+fi
+
+if ! command -v cargo &> /dev/null; then
+  echo "cargo is required to build this project. Please install cargo >=1.41.0"
+  exit 1
+fi
+
+# Next, confirm the command versions are up-to-date
+yarn add semver
+
+if ! ./.semver.js 10.20.1 $(node --version); then
+  echo "Node.js is out of date. Please use Node >=10.20.1"
+  exit 1
+fi
+
+if ! ./.semver.js 1.22.4 $(yarn --version); then
+  echo "yarn is out of date. Please use yarn >=1.22.4"
+  exit 1
+fi
+
+if ! ./.semver.js 1.41.1 $(rustc --version | sed 's/rustc //g;s/(.*$//g'); then
+  echo "Rust is out of date. Please use Rust >=1.41.1"
+  exit 1
+fi
+
+if ! ./.semver.js 1.41.0 $(cargo --version | sed 's/cargo //g;s/(.*$//g'); then
+  echo "cargo is out of date. Please use cargo >=1.40.0"
+  exit 1
+fi
+
+echo "Done!"
+exit 0

--- a/.semver.js
+++ b/.semver.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const semver = require('semver')
+
+const arglen = process.argv.length
+
+const expected = process.argv[arglen - 2]
+const actual = process.argv[arglen - 1]
+
+if (semver.gte(actual, expected)) {
+  process.exit(0)
+} else {
+  process.exit(1)
+}

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 SHELL = /bin/bash
 
 .PHONY: build
-build: build-compiler runtime/target/release/alan-runtime build-js-runtime
+build: env-check build-compiler runtime/target/release/alan-runtime build-js-runtime
 	echo Done
+
+.PHONY: env-check
+env-check:
+	./.envcheck.sh
 
 .PHONY: runtime-unit
 runtime-unit:


### PR DESCRIPTION
Resolves \#186 found by @Raynos

@depombo can you pull this branch locally and confirm that you can still `make clean && make bdd` on a Mac? While the OSX CI tests will *probably* pick up any issues, I would like a confirmation on genuine hardware ;)