### PR TITLE
Fix alan-compile

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alan-compile",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Compile of alan to amm and javascript",
   "scripts": {
     "test": "yarn run prepare && yarn run bundle && cypress run",
@@ -28,7 +28,7 @@
   "dependencies": {
     "@types/node": "^14.0.5",
     "@types/uuid": "^8.0.0",
-    "alan-js-runtime": "file:../js-runtime",
+    "alan-js-runtime": "0.0.1",
     "antlr4": "^4.8.0",
     "commander": "^5.1.0",
     "uuid": "^8.0.0"

--- a/compiler/yarn.lock
+++ b/compiler/yarn.lock
@@ -110,8 +110,10 @@ ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-"alan-js-runtime@file:../js-runtime":
+alan-js-runtime@0.0.1:
   version "0.0.1"
+  resolved "https://registry.yarnpkg.com/alan-js-runtime/-/alan-js-runtime-0.0.1.tgz#b3e8b255cf5a4f214699931957aaa5c5a0abc192"
+  integrity sha512-p528Ru0I+7DwSdBWMvgAGNgtkRAywHEq4pMIuIKjBgYjsZzb4ajFEj3cebE28AESqPl6zcfze7ZHAAmA95caJA==
   dependencies:
     isomorphic-fetch "^2.2.1"
     xxhashjs "^0.2.2"


### PR DESCRIPTION
Installing within the monorepo worked, but installing the published version did not, because of the dependency on alan-js-runtim