### PR TITLE
Implement most of @std/seq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ node_modules: build
 	npm init -y
 	yarn add ./compiler
 	yarn add ./js-runtime
+	cp -r ./js-runtime/* ./node_modules/alan-compile/node_modules/alan-js-runtime
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ node_modules: build
 	yarn add ./compiler
 	yarn add ./js-runtime
 	cp -r ./js-runtime/* ./node_modules/alan-compile/node_modules/alan-js-runtime
+	cp -r ./js-runtime/* ./compiler/node_modules/alan-js-runtime
 
 .PHONY: clean
 clean:

--- a/bdd/spec/023_http_spec.sh
+++ b/bdd/spec/023_http_spec.sh
@@ -96,7 +96,6 @@ Describe "@std/http"
     After afterEach
 
     It "runs js"
-      cat temp.js > what.js
       node temp.js 1>/dev/null 2>/dev/null &
       PID=$!
       sleep 1

--- a/bdd/spec/023_http_spec.sh
+++ b/bdd/spec/023_http_spec.sh
@@ -96,6 +96,7 @@ Describe "@std/http"
     After afterEach
 
     It "runs js"
+      cat temp.js > what.js
       node temp.js 1>/dev/null 2>/dev/null &
       PID=$!
       sleep 1

--- a/bdd/spec/027_seq_spec.sh
+++ b/bdd/spec/027_seq_spec.sh
@@ -187,10 +187,9 @@ error: sequence out-of-bounds"
     }
     AfterAll after
 
-    RECURSEOUTPUT="10"
+    RECURSEOUTPUT="34"
 
     It "runs js"
-      Pending compiler-closure-fixes
       When run node temp.js
       The output should eq "$RECURSEOUTPUT"
     End

--- a/bdd/spec/027_seq_spec.sh
+++ b/bdd/spec/027_seq_spec.sh
@@ -1,0 +1,204 @@
+Include build_tools.sh
+
+Describe "@std/seq"
+  Describe "seq and next"
+    before() {
+      sourceToAll "
+        from @std/app import start, print, exit
+        from @std/seq import seq, next
+
+        on start {
+          let s = seq(2)
+          print(s.next())
+          print(s.next())
+          print(s.next())
+          emit exit 0
+        }
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanTemp
+    }
+    AfterAll after
+
+    NEXTOUTPUT="0
+1
+error: sequence out-of-bounds"
+
+    It "runs js"
+      When run node temp.js
+      The output should eq "$NEXTOUTPUT"
+    End
+
+    It "runs agc"
+      Pending runtime-support
+      When run alan-runtime run temp.agc
+      The output should eq "$NEXTOUTPUT"
+    End
+  End
+
+  Describe "each"
+    before() {
+      sourceToAll "
+        from @std/app import start, print, exit
+        from @std/seq import seq, each
+
+        on start {
+          let s = seq(3)
+          s.each(fn (i: int64) = print(i))
+          emit exit 0
+        }
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanTemp
+    }
+    AfterAll after
+
+    EACHOUTPUT="0
+1
+2"
+
+    It "runs js"
+      When run node temp.js
+      The output should eq "$EACHOUTPUT"
+    End
+
+    It "runs agc"
+      Pending runtime-support
+      When run alan-runtime run temp.agc
+      The output should eq "$EACHOUTPUT"
+    End
+  End
+
+  Describe "while"
+    before() {
+      sourceToAll "
+        from @std/app import start, print, exit
+        from @std/seq import seq, while
+
+        on start {
+          let s = seq(100)
+          let sum = 0
+          // TODO: Get type inference working for one-liner closures
+          s.while(fn (): bool = sum < 10, fn {
+            sum = sum + 1
+          })
+          print(sum)
+          emit exit 0
+        }
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanTemp
+    }
+    AfterAll after
+
+    WHILEOUTPUT="10"
+
+    It "runs js"
+      When run node temp.js
+      The output should eq "$WHILEOUTPUT"
+    End
+
+    It "runs agc"
+      Pending runtime-support
+      When run alan-runtime run temp.agc
+      The output should eq "$WHILEOUTPUT"
+    End
+  End
+
+  Describe "do-while"
+    before() {
+      sourceToAll "
+        from @std/app import start, print, exit
+        from @std/seq import seq, doWhile
+
+        on start {
+          let s = seq(100)
+          let sum = 0
+          // TODO: Get type inference working for one-liner closures
+          s.doWhile(fn (): bool {
+            sum = sum + 1
+            return sum < 10
+          })
+          print(sum)
+          emit exit 0
+        }
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanTemp
+    }
+    AfterAll after
+
+    DOWHILEOUTPUT="10"
+
+    It "runs js"
+      When run node temp.js
+      The output should eq "$DOWHILEOUTPUT"
+    End
+
+    It "runs agc"
+      Pending runtime-support
+      When run alan-runtime run temp.agc
+      The output should eq "$DOWHILEOUTPUT"
+    End
+  End
+
+  Describe "recurse"
+    before() {
+      sourceToAll "
+        from @std/app import start, print, exit
+        from @std/seq import seq, Self, recurse
+
+        on start {
+          print(seq(100).recurse(fn fibonacci(self: Self, i: int64): Result<int64> {
+            if i < 2 {
+              return some(1)
+            } else {
+              const prev = self.recurse(i - 1)
+              const prevPrev = self.recurse(i - 2)
+              if prev.isErr() {
+                return prev
+              }
+              if prevPrev.isErr() {
+                return prevPrev
+              }
+              return some((prev || 1) + (prevPrev || 1))
+            }
+          }, 8))
+          emit exit 0
+        }
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanTemp
+    }
+    AfterAll after
+
+    RECURSEOUTPUT="10"
+
+    It "runs js"
+      Pending compiler-closure-fixes
+      When run node temp.js
+      The output should eq "$RECURSEOUTPUT"
+    End
+
+    It "runs agc"
+      Pending runtime-support
+      When run alan-runtime run temp.agc
+      The output should eq "$RECURSEOUTPUT"
+    End
+  End
+End

--- a/bdd/spec/027_seq_spec.sh
+++ b/bdd/spec/027_seq_spec.sh
@@ -33,7 +33,6 @@ error: sequence out-of-bounds"
     End
 
     It "runs agc"
-      Pending runtime-support
       When run alan-runtime run temp.agc
       The output should eq "$NEXTOUTPUT"
     End
@@ -69,7 +68,6 @@ error: sequence out-of-bounds"
     End
 
     It "runs agc"
-      Pending runtime-support
       When run alan-runtime run temp.agc
       The output should eq "$EACHOUTPUT"
     End
@@ -108,7 +106,6 @@ error: sequence out-of-bounds"
     End
 
     It "runs agc"
-      Pending runtime-support
       When run alan-runtime run temp.agc
       The output should eq "$WHILEOUTPUT"
     End
@@ -148,7 +145,6 @@ error: sequence out-of-bounds"
     End
 
     It "runs agc"
-      Pending runtime-support
       When run alan-runtime run temp.agc
       The output should eq "$DOWHILEOUTPUT"
     End

--- a/bdd/spec/027_seq_spec.sh
+++ b/bdd/spec/027_seq_spec.sh
@@ -156,7 +156,8 @@ error: sequence out-of-bounds"
 
   Describe "recurse"
     before() {
-      sourceToAll "
+      # TODO: Restore sourceToAll once ammtoaga bug is fixed
+      sourceToTemp "
         from @std/app import start, print, exit
         from @std/seq import seq, Self, recurse
 
@@ -179,6 +180,8 @@ error: sequence out-of-bounds"
           emit exit 0
         }
       "
+      tempToAmm
+      tempToJs
     }
     BeforeAll before
 

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@types/node": "^14.0.5",
     "@types/uuid": "^8.0.0",
-    "alan-js-runtime": "^0.0.3",
+    "alan-js-runtime": "0.0.4",
     "antlr4": "^4.8.0",
     "commander": "^5.1.0",
     "uuid": "^8.0.0"

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alan-compile",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Compile of alan to amm and javascript",
   "scripts": {
     "test": "yarn run prepare && yarn run bundle && cypress run",

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@types/node": "^14.0.5",
     "@types/uuid": "^8.0.0",
-    "alan-js-runtime": "0.0.3",
+    "alan-js-runtime": "^0.0.3",
     "antlr4": "^4.8.0",
     "commander": "^5.1.0",
     "uuid": "^8.0.0"

--- a/compiler/src/ammtojs.ts
+++ b/compiler/src/ammtojs.ts
@@ -56,7 +56,7 @@ const assignableToJsText = (assignable: LPNode, indent: string) => {
     if (args.get(1)) {
       argnames.push(args.get(1).get('arg').get('variable').t)
     }
-    outText += `(${argnames.join(', ')}) => {\n`
+    outText += `async (${argnames.join(', ')}) => {\n`
     outText += functionbodyToJsText(assignable.get('functions').get('functionbody'), indent + "  ")
     outText += indent + '  }' // End this closure
   } else if (assignable.has('calls')) {

--- a/compiler/src/lntoamm/Microstatement.ts
+++ b/compiler/src/lntoamm/Microstatement.ts
@@ -872,7 +872,7 @@ ${withOperatorsAst.getText()}`
     // if closure is not void return the last inner statement
     // TODO: Revisit this, if the closure doesn't have a type defined, sometimes it can only be
     // determined in the calling context and shouldn't be assumed to be `void`
-    if (userFunction.returnType !== Type.builtinTypes.void) {
+    if (innerMicrostatements.length > 0 && userFunction.returnType !== Type.builtinTypes.void) {
       const last = innerMicrostatements[innerMicrostatements.length - 1]
       innerMicrostatements.push(new Microstatement(
         StatementType.EXIT,

--- a/compiler/src/lntoamm/Microstatement.ts
+++ b/compiler/src/lntoamm/Microstatement.ts
@@ -842,8 +842,9 @@ ${withOperatorsAst.getText()}`
     // compatible types such that the microstatements would not be a simple type replacement away
     // inject arguments as const declarations into microstatements arrays with the variable names
     // and remove them later so we can parse the closure and keep the logic contained to this method
+    const fn = userFunction.maybeTransform(new Map()) // TODO: Interface mangling is probably needed
     const idx = microstatements.length
-    const args = Object.entries(userFunction.args)
+    const args = Object.entries(fn.args)
     for (const [name, type] of args) {
       if (name !== "" && type.typename != "") {
         microstatements.push(new Microstatement(
@@ -856,7 +857,7 @@ ${withOperatorsAst.getText()}`
       }
     }
     const len = microstatements.length - args.length
-    for (const s of userFunction.statements) {
+    for (const s of fn.statements) {
       if (s.statementOrAssignableAst instanceof LnParser.StatementsContext) {
         Microstatement.fromStatementsAst(s.statementOrAssignableAst, scope, microstatements)
       } else {
@@ -872,7 +873,7 @@ ${withOperatorsAst.getText()}`
     // if closure is not void return the last inner statement
     // TODO: Revisit this, if the closure doesn't have a type defined, sometimes it can only be
     // determined in the calling context and shouldn't be assumed to be `void`
-    if (innerMicrostatements.length > 0 && userFunction.returnType !== Type.builtinTypes.void) {
+    if (innerMicrostatements.length > 0 && fn.returnType !== Type.builtinTypes.void) {
       const last = innerMicrostatements[innerMicrostatements.length - 1]
       innerMicrostatements.push(new Microstatement(
         StatementType.EXIT,
@@ -891,10 +892,10 @@ ${withOperatorsAst.getText()}`
       [],
       [],
       '',
-      userFunction.pure,
+      fn.pure,
       innerMicrostatements,
-      userFunction.args,
-      userFunction.returnType,
+      fn.args,
+      fn.returnType,
     ))
   }
 

--- a/compiler/src/lntoamm/Type.ts
+++ b/compiler/src/lntoamm/Type.ts
@@ -577,6 +577,17 @@ export class Type {
       body: new Type('string', true),
       connId: new Type('int64', true),
     }),
+    Seq: new Type("Seq", true, false, {
+      counter: new Type("int64", true, true),
+      limit: new Type("int64", true, true),
+    }),
+    Self: new Type("Self", true, false, {
+      seq: new Type("Seq", true, false, {
+        counter: new Type("int64", true, true),
+        limit: new Type("int64", true, true),
+      }),
+      recurseFn: new Type("function", true),
+    }),
     "function": new Type("function", true),
     operator: new Type("operator", true),
     Event: new Type("Event", true, false, {

--- a/compiler/src/lntoamm/UserFunction.ts
+++ b/compiler/src/lntoamm/UserFunction.ts
@@ -358,7 +358,11 @@ ${statements[i].statementOrAssignableAst.getText().trim()} on line ${statements[
               `.trim() + '\n')
               replacementStatements.push(remainingBlock)
             }
+          } else {
+            replacementStatements.push(s)
           }
+        } else {
+          replacementStatements.push(s)
         }
       } else {
         replacementStatements.push(s)

--- a/compiler/src/lntoamm/opcodes.ts
+++ b/compiler/src/lntoamm/opcodes.ts
@@ -16,15 +16,20 @@ const addBuiltIn = (name: string) => {
 }
 ([
   'void', 'int8', 'int16', 'int32', 'int64', 'float32', 'float64', 'bool', 'string', 'function',
-  'operator', 'Error', 'Maybe', 'Result', 'Either', 'Array', 'ExecRes', 'InitialReduce', 'InternalResponse'
+  'operator', 'Error', 'Maybe', 'Result', 'Either', 'Array', 'ExecRes', 'InitialReduce',
+  'InternalResponse', 'Seq', 'Self',
 ].map(addBuiltIn))
 Type.builtinTypes['Array'].solidify(['string'], opcodeScope)
 opcodeScope.put('any', new Type('any', true, false, {}, {}, null, new Interface('any')))
-opcodeScope.put('anythingElse', new Type('anythingElse', true, false, {}, {}, null, new Interface('anythingElse')))
+opcodeScope.put(
+  'anythingElse',
+  new Type('anythingElse', true, false, {}, {}, null, new Interface('anythingElse')),
+)
 Type.builtinTypes['Array'].solidify(['any'], opcodeScope)
 Type.builtinTypes['Array'].solidify(['anythingElse'], opcodeScope)
 Type.builtinTypes.Maybe.solidify(['any'], opcodeScope)
 Type.builtinTypes.Result.solidify(['any'], opcodeScope)
+Type.builtinTypes.Result.solidify(['anythingElse'], opcodeScope)
 Type.builtinTypes.Result.solidify(['int64'], opcodeScope)
 Type.builtinTypes.Result.solidify(['string'], opcodeScope)
 Type.builtinTypes.Either.solidify(['any', 'anythingElse'], opcodeScope)
@@ -130,7 +135,12 @@ const addopcodes = (opcodes: object) => {
                     baseType.solidify([newInnerType.typename], scope) :
                     returnType
                   return newReturnType
-                } else  {
+                } else if (['selfrec'].includes(opcodeName)) {
+                  // TODO: This is absolute crap. How to fix?
+                  return Microstatement.fromVarName(
+                    inputs[0].inputNames[1], scope, microstatements
+                  ).closureOutputType
+                } else {
                   // Path 2: the opcode returns solidified generic type with an interface generic
                   // that mathces the interface type of an input
                   const returnIfaces = Object.values(returnType.properties)
@@ -437,6 +447,13 @@ addopcodes({
   dsdel: [{ ns: t('string'), key: t('string'), }, t('bool')],
   dsgetf: [{ ns: t('string'), key: t('string'), }, t('Result<any>')],
   dsgetv: [{ ns: t('string'), key: t('string'), }, t('Result<any>')],
+  newseq: [{ limit: t('int64'), }, t('Seq')],
+  seqnext: [{ seq: t('Seq'), }, t('Result<int64>')],
+  seqeach: [{ seq: t('Seq'), func: t('function'), }, t('void')],
+  seqwhile: [{ seq: t('Seq'), condFn: t('function'), bodyFn: t('function'), }],
+  seqdo: [{ seq: t('Seq'), bodyFn: t('function'), }, t('void')],
+  selfrec: [{ self: t('Self'), arg: t('any'), }, t('Result<anythingElse>')],
+  seqrec: [{ seq: t('Seq'), recurseFn: t('function'), }, t('Self')],
 })
 
 export default opcodeModule

--- a/compiler/src/lntoamm/opcodes.ts
+++ b/compiler/src/lntoamm/opcodes.ts
@@ -137,9 +137,9 @@ const addopcodes = (opcodes: object) => {
                   return newReturnType
                 } else if (['selfrec'].includes(opcodeName)) {
                   // TODO: This is absolute crap. How to fix?
-                  return Microstatement.fromVarName(
+                  return inputs[0].inputNames[1] ? Microstatement.fromVarName(
                     inputs[0].inputNames[1], scope, microstatements
-                  ).closureOutputType
+                  ).closureOutputType : returnType
                 } else {
                   // Path 2: the opcode returns solidified generic type with an interface generic
                   // that mathces the interface type of an input

--- a/compiler/yarn.lock
+++ b/compiler/yarn.lock
@@ -110,7 +110,7 @@ ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-alan-js-runtime@0.0.3:
+alan-js-runtime@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/alan-js-runtime/-/alan-js-runtime-0.0.3.tgz#107c3b657f9b6008baf77af8848bce4b28d853ff"
   integrity sha512-bx61JRL1H41tN8tLAouAbdgWK0jjtvDMKcyFlGnL+KbAciBPWrI4vj2o8TpnGm8yAopV9wpgyxbmvgCU5QSDYQ==
@@ -2325,9 +2325,9 @@ vm-browserify@^1.0.0:
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
 whatwg-fetch@>=0.10.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz#e11de14f4878f773fbebcde8871b2c0699af8b30"
-  integrity sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
+  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
 
 which@^1.2.9:
   version "1.3.1"

--- a/compiler/yarn.lock
+++ b/compiler/yarn.lock
@@ -110,10 +110,10 @@ ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-alan-js-runtime@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/alan-js-runtime/-/alan-js-runtime-0.0.3.tgz#107c3b657f9b6008baf77af8848bce4b28d853ff"
-  integrity sha512-bx61JRL1H41tN8tLAouAbdgWK0jjtvDMKcyFlGnL+KbAciBPWrI4vj2o8TpnGm8yAopV9wpgyxbmvgCU5QSDYQ==
+alan-js-runtime@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/alan-js-runtime/-/alan-js-runtime-0.0.4.tgz#ee77e8172adae843cf4274c8b80abe45596e8405"
+  integrity sha512-CwEljAQ/AlKBCpv24akWgtIpr+76Too79Oz+njuNAeZC09ck9oGMft7fBZP2pPnBX+LuhawlN+vk5ukwHMm30A==
   dependencies:
     isomorphic-fetch "^2.2.1"
     xxhashjs "^0.2.2"

--- a/js-runtime/index.js
+++ b/js-runtime/index.js
@@ -635,7 +635,7 @@ module.exports = {
       return [ false, e.toString() ]
     }
   },
-  httplsn:  port => {
+  httplsn:  async (port) => {
     const server = http.createServer((req, res) => {
       const connId = hashf(Math.random().toString())
       httpConns[connId] = {
@@ -655,7 +655,7 @@ module.exports = {
         ])
       })
     })
-    return new Promise(resolve => {
+    return await new Promise(resolve => {
       server.on('error', e => resolve([ false, e.code, ]))
       server.listen({
         port,

--- a/js-runtime/index.js
+++ b/js-runtime/index.js
@@ -373,7 +373,7 @@ module.exports = {
 
   // Ternary functions
   // TODO: pair and condarr after arrays are figured out
-  condfn:  (cond, fn) => cond ? fn() : undefined,
+  condfn:  async (cond, fn) => cond ? await fn() : undefined,
 
   // Copy opcodes (for let reassignment)
   copyi8:   a => JSON.parse(JSON.stringify(a)),
@@ -535,7 +535,7 @@ module.exports = {
   // IO opcodes
   asyncopcodes: [
     'waitop', 'execop', 'httpget', 'httppost', 'httplsn', 'httpsend', 'seqeach', 'seqwhile',
-    'seqdo', 'selfrec',
+    'seqdo', 'selfrec', 'condfn',
   ],
   httpget:  async url => {
     try {

--- a/js-runtime/index.js
+++ b/js-runtime/index.js
@@ -492,9 +492,51 @@ module.exports = {
       return [ false, 'namespace-key pair not found', ]
     }
   },
+  newseq:  (limit) => [0, limit],
+  seqnext: (seq) => {
+    if (seq[0] < seq[1]) {
+      const out = [true, seq[0]]
+      seq[0]++
+      return out
+    } else {
+      return [false, 'error: sequence out-of-bounds']
+    }
+  },
+  seqeach: async (seq, func) => {
+    while (seq[0] < seq[1]) {
+      await func(seq[0])
+      seq[0]++
+    }
+  },
+  seqwhile:async (seq, condFn, bodyFn) => {
+    while (seq[0] < seq[1] && await condFn()) {
+      await bodyFn()
+      seq[0]++
+    }
+  },
+  seqdo:   async (seq, bodyFn) => {
+    let ok = true
+    do {
+      ok = await bodyFn()
+      seq[0]++
+    } while (seq[0] < seq[1] && ok)
+  },
+  selfrec: async (self, arg) => {
+    const [seq, recurseFn] = self
+    if (seq[0] < seq[1]) {
+      seq[0]++
+      return recurseFn(self, arg)
+    } else {
+      return [false, 'error: sequence out-of-bounds']
+    }
+  },
+  seqrec: (seq, recurseFn) => [seq, recurseFn],
 
   // IO opcodes
-  asyncopcodes: ['waitop', 'execop', 'httpget', 'httppost', 'httplsn', 'httpsend'],
+  asyncopcodes: [
+    'waitop', 'execop', 'httpget', 'httppost', 'httplsn', 'httpsend', 'seqeach', 'seqwhile',
+    'seqdo', 'selfrec',
+  ],
   httpget:  async url => {
     try {
       const response = await fetch(url)

--- a/js-runtime/package.json
+++ b/js-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alan-js-runtime",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "The runtime component for alan-js. Separately licensed from the compiler.",
   "main": "index.js",
   "scripts": {

--- a/rfcs/007 - Sequential Algorithms RFC.md
+++ b/rfcs/007 - Sequential Algorithms RFC.md
@@ -16,7 +16,8 @@
 
 ### Implementation
 
-- [ ] Implemented: [One or more PRs](https://github.com/alantech/alan/some-pr-link-here) YYYY-MM-DD
+- [ ] Implemented
+  - [x] [Implement most of @std/seq](https://github.com/alantech/alan/pull/266) 2020-09-09
 - [ ] Revoked/Superceded by: [RFC ###](./000 - RFC Template.md) YYYY-MM-DD
 
 ## Author(s)

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "alan-runtime"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "byteorder",
  "clap",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ license = "AGPL-3.0"
 homepage = "https://alan-lang.org"
 documentation = "https://docs.alan-lang.org"
 repository = "https://github.com/alantech/alan"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Luis de Pombo <lfdepombo@gmail.com>", "David Ellis <isv.damocles@gmail.com>"]
 edition = "2018"
 

--- a/std/seq.ln
+++ b/std/seq.ln
@@ -1,0 +1,38 @@
+/**
+ * @std/seq - Tools for sequential algorithms. Use if you must.
+ */
+
+// The `Seq` opaque type used by these algorithms to guarantee halting
+export Seq
+
+// The `seq` constructor function
+export fn seq(limit: int64): Seq = newseq(limit)
+
+// A basic iterator function, unlikely to be useful outside of these functions
+export fn next(seq: Seq): Result<int64> = seqnext(seq)
+
+// An automatic iterator that executes the provided function in sequence until the limit is reached
+export fn each(seq: Seq, func: function): void = seqeach(seq, func)
+
+// A while loop with an initial conditional check
+export fn while(seq: Seq, condFn: function, bodyFn: function): void = seqwhile(seq, condFn, bodyFn)
+
+// A do-while loop that returns the conditional check
+export fn doWhile(seq: Seq, bodyFn: function): void = seqdo(seq, bodyFn)
+
+// Recursive functions in Alan require a "trampoline" outside of the grammar of the language to work
+// so a special "Self" type exists that internally references the Seq type and the relevant function
+// and provides the mechanism to re-schedule the recursive function to call with a new argument.
+export Self
+
+// There are two `recurse` functions. The first is on the `self` object that has an internal
+// reference to the relevant seq and recursive function to be called and is meant to be used within
+// the recursive function. The second sets it all off with a sequence operator, the recursive
+// function in question, and the query argument, and is using the first function under the hood.
+export fn recurse(self: Self, arg: any): Result<anythingElse> = selfrec(self, arg)
+export fn recurse(seq: Seq, recurseFn: function, arg: any): Result<anythingElse> {
+  let self = seqrec(seq, recurseFn)
+  return selfrec(self, arg)
+}
+
+// TODO: Add the generator piece of the seq rfc


### PR DESCRIPTION
Working so far:

* js-runtime
  * seq
  * next
  * each
  * while
  * doWhile
  * recurse
* AVM
  * seq
  * next
  * each
  * while
  * doWhile

Not yet working:

* js-runtime
  * generator
* AVM
  * recurse
  * generator

Fixed some bugs with conditional rewriting and closure generation that fixed `recurse` and probably a lot of other uses of closure functions. But I know the AVM still has the hard limit on closures (besides `condfn` closures) being a single fragment so there needs to be a follow-up PR to fix that before `recurse` can be implemented for the AVM.