### PR TITLE
Fix importing unexpected values

### DIFF
--- a/bdd/spec/019_compiler_error_spec.sh
+++ b/bdd/spec/019_compiler_error_spec.sh
@@ -152,4 +152,47 @@ line 8:0 extraneous input '<EOF>' expecting {'const', 'let', 'return', 'emit', B
 Cannot read property 'basicassignables' of null"
     End
   End
+
+  Describe "Importing unexported values"
+    before() {
+      sourceToFile piece.ln "
+        type Piece {
+          owner: bool
+        }
+      "
+      sourceToTemp "
+        from @std/app import start, print, exit
+        from ./piece import Piece
+
+        on start {
+          const piece = new Piece {
+            owner = false
+          }
+          print('Hello World')
+          if piece.owner == true {
+            print('OK')
+          } else {
+            print('False')
+          }
+          emit exit 0
+        }
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanFile piece.ln
+      cleanTemp
+    }
+    AfterAll after
+
+    It "doesn't work"
+      When run alan compile temp.ln temp.amm
+      The status should not eq "0"
+      The error should eq "Piece is not a type
+new Piece {
+            owner = false
+          } on line 2:24"
+    End
+  End
 End

--- a/compiler/src/lntoamm/Module.ts
+++ b/compiler/src/lntoamm/Module.ts
@@ -81,7 +81,7 @@ class Module {
           } else {
             importName = moduleVar.varop(0).getText()
           }
-          const thing = importedModule.exportScope.get(exportName)
+          const thing = importedModule.exportScope.shallowGet(exportName)
           module.moduleScope.put(importName, thing)
           // Special behavior for interfaces. If there are any functions or operators that match
           // the interface, pull them in. Similarly any types that match the entire interface. This
@@ -159,7 +159,7 @@ class Module {
       if (newFunc.getName() == null) {
         throw new Error("Module-level functions must have a name")
       }
-      let fns = module.moduleScope.get(newFunc.getName())
+      let fns = module.moduleScope.shallowGet(newFunc.getName()) as Array<Fn>
       if (fns == null) {
         module.moduleScope.put(newFunc.getName(), [newFunc])
       } else {
@@ -220,7 +220,7 @@ class Module {
         // Exported scope must be checked first because it will fall through to the not-exported
         // scope by default. Should probably create a `getShallow` for this case, but reordering
         // the two if blocks below is enough to fix things here.
-        let expFns = module.exportScope.get(newFunc.getName()) as Array<Fn>
+        let expFns = module.exportScope.shallowGet(newFunc.getName()) as Array<Fn>
         if (!expFns) {
           module.exportScope.put(
             newFunc.getName(),
@@ -229,7 +229,7 @@ class Module {
         } else {
           expFns.push(newFunc)
         }
-        let modFns = module.moduleScope.get(newFunc.getName()) as Array<Fn>
+        let modFns = module.moduleScope.shallowGet(newFunc.getName()) as Array<Fn>
         if (!modFns) {
           module.moduleScope.put(
             newFunc.getName(),

--- a/compiler/src/lntoamm/Module.ts
+++ b/compiler/src/lntoamm/Module.ts
@@ -159,7 +159,7 @@ class Module {
       if (newFunc.getName() == null) {
         throw new Error("Module-level functions must have a name")
       }
-      let fns = module.moduleScope.shallowGet(newFunc.getName()) as Array<Fn>
+      let fns = module.moduleScope.get(newFunc.getName()) as Array<Fn>
       if (fns == null) {
         module.moduleScope.put(newFunc.getName(), [newFunc])
       } else {
@@ -218,8 +218,7 @@ class Module {
           throw new Error("Module-level functions must have a name")
         }
         // Exported scope must be checked first because it will fall through to the not-exported
-        // scope by default. Should probably create a `getShallow` for this case, but reordering
-        // the two if blocks below is enough to fix things here.
+        // scope by default.
         let expFns = module.exportScope.shallowGet(newFunc.getName()) as Array<Fn>
         if (!expFns) {
           module.exportScope.put(
@@ -229,7 +228,7 @@ class Module {
         } else {
           expFns.push(newFunc)
         }
-        let modFns = module.moduleScope.shallowGet(newFunc.getName()) as Array<Fn>
+        let modFns = module.moduleScope.get(newFunc.getName()) as Array<Fn>
         if (!modFns) {
           module.moduleScope.put(
             newFunc.getName(),

--- a/compiler/src/lntoamm/Scope.ts
+++ b/compiler/src/lntoamm/Scope.ts
@@ -37,6 +37,13 @@ class Scope {
     return null
   }
 
+  shallowGet(name: string) {
+    if (this.vals.hasOwnProperty(name)) {
+      return this.vals[name]
+    }
+    return null
+  }
+
   deepGet(fullName: string) {
     const fullVar = fullName.trim().split(".")
     let boxedVar: Boxish


### PR DESCRIPTION
Thanks to @LoPoHa for finding this bug! Resolves \#283

Creates a new `shallowGet` function for the Scope object to explicitly only get a value if it's in that exact scope, and not in the scope chain (the export scope has the unexported scope within its chain so exported functions still work).