### PR TITLE
Fixes to the Tree implementation

### DIFF
--- a/std/root.ln
+++ b/std/root.ln
@@ -699,7 +699,10 @@ export fn getNodeById(t: Tree<any>, i: int64): Node<any> {
 export fn getChildren(n: Node<any>): Array<Node<any>> {
   if length(n.tree.vals) > n.id {
     const childIds = getOr(n.tree.children[n.id], new Array<int64> [])
-    return childIds.map(fn (id: int64): Node<any> {
+    return childIds.filter(fn (id: int64): bool {
+      const parentId = n.tree.parents[id] || -1
+      return parentId == n.id
+    }).map(fn (id: int64): Node<any> {
       return new Node<any> {
         id = id
         tree = n.tree
@@ -728,7 +731,7 @@ export fn addChild(n: Node<any>, val: Node<any>): Node<any> {
   const tree = n.tree
   let parentStack = new Array<int64> [ n.id ]
   let nodeStack = new Array<int64> [ val.id ]
-  seqdo(newseq(pow(2, 62)), fn () {
+  seqdo(newseq(pow(2, 62)), fn (): bool {
     // Get the parentId, exit if none left
     const parentRes = parentStack.pop()
     if parentRes.isErr() {


### PR DESCRIPTION
While digging in on why the Tree implementation isn't working in the AVM, I discovered that the implementation's `getChildren` and most complex `addChild` functions were incorrect and it wasn't caught by the test suite because Javascript's type coercion of `undefined` to `false` masked the issue.

One more reason why we have two targets right now, makes finding this stuff easier. :)

There are definite compiler glitches in the ammtoaga layer, though, that I'll be targeting next.