### PR TITLE
Fix return statements in one of the branches for closures in the ammtoaga layer

### DIFF
--- a/compiler/src/ammtoaga.ts
+++ b/compiler/src/ammtoaga.ts
@@ -229,15 +229,12 @@ const loadStatements = (
       fnArgs = fnArgs.filter(t => t !== '')
     }
     const hasClosureArgs = isClosure && fnArgs.length > 0
-    const isClosureExit = idx === statements.length - 2 && statements[idx + 1].has('exits')
     let s = ''
     if (statement.has('declarations')) {
       const dec = statement.get('declarations').has('constdeclaration') ?
         statement.get('declarations').get('constdeclaration') :
         statement.get('declarations').get('letdeclaration')
-      // if this is 2nd to last statement and last statement exits this is a closure
-      let resultAddress = isClosureExit ?
-        CLOSURE_ARG_MEM_START : localMem[dec.get('decname').t.trim()]
+      let resultAddress = localMem[dec.get('decname').t.trim()]
       localMemToLine[dec.get('decname').t.trim()] = line
       const assignables = dec.get('assignables')
       if (assignables.has('functions')) {
@@ -425,7 +422,8 @@ const loadStatements = (
         } else return v
       }).map(a => typeof a === 'string' ? a : `@${a}`)
       while (args.length < 2) args.push('@0')
-      s += `@${CLOSURE_ARG_MEM_START} = copyarr(${args.join(', ')}) #${line}`
+      s += `@${CLOSURE_ARG_MEM_START} = error(${args.join(', ')}) #${line}`
+      // TODO: Better name and/or alias for this opcode?
     }
     vec.push(s)
     line += 1

--- a/compiler/src/ammtoaga.ts
+++ b/compiler/src/ammtoaga.ts
@@ -249,11 +249,15 @@ const loadStatements = (
           v => v.get('variable').t.trim()
         )
         const args = vars.map(v => {
-          if (localMem.hasOwnProperty(v)) return localMem[v]
-          else if (globalMem.hasOwnProperty(v)) return globalMem[v]
-          else if (hasClosureArgs) {
+          if (localMem.hasOwnProperty(v)) {
+            return localMem[v]
+          } else if (globalMem.hasOwnProperty(v)) {
+            return globalMem[v]
+          } else if (hasClosureArgs) {
             return CLOSURE_ARG_MEM_START + BigInt(1) + BigInt(fnArgs.indexOf(v))
-          } else return v
+          } else {
+            return v
+          }
         }).map(a => typeof a === 'string' ? a : `@${a}`)
         while (args.length < 2) args.push('@0')
         const deps = vars
@@ -409,6 +413,19 @@ const loadStatements = (
       if (deps.length > 0) {
         s += ` <- [${deps.join(', ')}]`
       }
+    } else if (statement.has('exits')) {
+      const exit = statement.get('exits')
+      const exitVar = exit.get('variable').t.trim()
+      const vars = [exitVar]
+      const args = vars.map(v => {
+        if (localMem.hasOwnProperty(v)) return localMem[v]
+        else if (globalMem.hasOwnProperty(v)) return globalMem[v]
+        else if (hasClosureArgs) {
+          return CLOSURE_ARG_MEM_START + BigInt(1) + BigInt(fnArgs.indexOf(v))
+        } else return v
+      }).map(a => typeof a === 'string' ? a : `@${a}`)
+      while (args.length < 2) args.push('@0')
+      s += `@${CLOSURE_ARG_MEM_START} = copyarr(${args.join(', ')}) #${line}`
     }
     vec.push(s)
     line += 1


### PR DESCRIPTION
This makes the Tree code correctly compile for the AVM and output *something.* The next change is to the AVM itself to do less copying and more referencing of existing data.