### PR TITLE
Fix the execop implementation in the AVM

### DIFF
--- a/avm/src/vm/opcode.rs
+++ b/avm/src/vm/opcode.rs
@@ -2046,17 +2046,17 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       match output {
         Err(e) => {
           hand_mem.push_fixed(args[2], 127);
-          hand_mem.write_fractal(args[2], &vec![(0, 0)]);
+          hand_mem.push_fractal(args[2], &vec![(0, 0)]);
           let error_string = e.to_string();
-          hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&error_string));
+          hand_mem.push_fractal(args[2], &HandlerMemory::str_to_fractal(&error_string));
         },
         Ok(output_res) => {
           let status_code = output_res.status.code().unwrap_or(127) as i64;
           hand_mem.push_fixed(args[2], status_code);
           let stdout_str = String::from_utf8(output_res.stdout).unwrap_or("".to_string());
-          hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&stdout_str));
+          hand_mem.push_fractal(args[2], &HandlerMemory::str_to_fractal(&stdout_str));
           let stderr_str = String::from_utf8(output_res.stderr).unwrap_or("".to_string());
-          hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&stderr_str));
+          hand_mem.push_fractal(args[2], &HandlerMemory::str_to_fractal(&stderr_str));
         },
       };
     })

--- a/bdd/spec/030_cmd_spec.sh
+++ b/bdd/spec/030_cmd_spec.sh
@@ -1,0 +1,36 @@
+Include build_tools.sh
+
+Describe "@std/cmd"
+  Describe "exec"
+    before() {
+      sourceToAll "
+        import @std/app
+        import @std/cmd
+
+        on app.start {
+          const executionResult: cmd.ExecRes = cmd.exec('echo 1')
+          app.print(executionResult.stdout)
+          emit app.exit 0
+        }
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanTemp
+    }
+    AfterAll after
+
+    EXECOUTPUT="1"
+
+    It "runs js"
+      When run node temp.js
+      The output should eq "$EXECOUTPUT"
+    End
+
+    It "runs agc"
+      When run alan run temp.agc
+      The output should eq "$EXECOUTPUT"
+    End
+  End
+End

--- a/bdd/spec/030_cmd_spec.sh
+++ b/bdd/spec/030_cmd_spec.sh
@@ -25,12 +25,12 @@ Describe "@std/cmd"
 
     It "runs js"
       When run node temp.js
-      The first word of first line of output should eq "$EXECOUTPUT"
+      The output should start with "$EXECOUTPUT"
     End
 
     It "runs agc"
       When run alan run temp.agc
-      The first word of first line of output should eq "$EXECOUTPUT"
+      The output should start with "$EXECOUTPUT"
     End
   End
 End

--- a/bdd/spec/030_cmd_spec.sh
+++ b/bdd/spec/030_cmd_spec.sh
@@ -25,12 +25,12 @@ Describe "@std/cmd"
 
     It "runs js"
       When run node temp.js
-      The first line of output should eq "$EXECOUTPUT"
+      The first word of first line of output should eq "$EXECOUTPUT"
     End
 
     It "runs agc"
       When run alan run temp.agc
-      The first line of output should eq "$EXECOUTPUT"
+      The first word of first line of output should eq "$EXECOUTPUT"
     End
   End
 End

--- a/bdd/spec/030_cmd_spec.sh
+++ b/bdd/spec/030_cmd_spec.sh
@@ -25,12 +25,12 @@ Describe "@std/cmd"
 
     It "runs js"
       When run node temp.js
-      The output should eq "$EXECOUTPUT"
+      The first line of output should eq "$EXECOUTPUT"
     End
 
     It "runs agc"
       When run alan run temp.agc
-      The output should eq "$EXECOUTPUT"
+      The first line of output should eq "$EXECOUTPUT"
     End
   End
 End


### PR DESCRIPTION
Our usage of `exec` in `@std/deps` was not complete enough to catch this as only the status code is apparently used?

Thanks to @MareinK for finding this and providing a great test application. :)