### PR TITLE
add toInt and toFloat type coercion aliases

### DIFF
--- a/bdd/spec/007_comparator_spec.sh
+++ b/bdd/spec/007_comparator_spec.sh
@@ -421,5 +421,39 @@ false"
       The output should eq "$GREATERTHANOREQUAL"
     End
   End
+
+  Describe "Type Coercion Aliases"
+    before() {
+      sourceToAll "
+        from @std/app import start, print, exit
+
+        on start {
+          print(toInt(0) == toInt64(0));
+          print(toFloat(0.0) == toFloat(0.0));
+
+          emit exit 0;
+        }
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanTemp
+    }
+    AfterAll after
+
+    TYPECOERCIONALIASES="true
+true"
+
+    It "runs js"
+      When run test_js
+      The output should eq "$TYPECOERCIONALIASES"
+    End
+
+    It "runs agc"
+      When run test_agc
+      The output should eq "$TYPECOERCIONALIASES"
+    End
+  End
 End
 

--- a/std/root.ln
+++ b/std/root.ln
@@ -39,6 +39,12 @@ export interface Orderable {
   gt(Orderable, Orderable): bool,
   gte(Orderable, Orderable): bool,
 }
+export interface canFloat64 {
+  toFloat64(canFloat64): float64
+}
+export interface canInt64 {
+  toInt64(canInt64): int64
+}
 
 // Type conversion functions
 export fn toFloat64(n: int8) = i8f64(n);
@@ -112,6 +118,10 @@ export fn toString(n: float32) = f32str(n);
 export fn toString(n: float64) = f64str(n);
 export fn toString(n: string) = n;
 export fn toString(n: bool) = boolstr(n);
+
+// Type alias conversion functions
+export fn toFloat(n: canFloat64): float = toFloat64(n)
+export fn toInt(n: canInt64): int = toInt64(n) 
 
 // Arithmetic functions
 export fn add(a: int8, b: int8) = addi8(a, b);


### PR DESCRIPTION
I'm not sure if this is the best way to do it. I couldn't find a way to simply do `toFloat = toFloat64`. Let me know if there is an easier way! I didn't add tests because there were no tests for the existing coercion functions.