### PR TITLE
getOrExit function

### DIFF
--- a/bdd/spec/025_runtime_error_spec.sh
+++ b/bdd/spec/025_runtime_error_spec.sh
@@ -9,4 +9,43 @@ Describe "Runtime Errors"
       The error should include "File not found:"
     End
   End
+
+  Describe "getOrHalt"
+    before() {
+      sourceToAll "
+        from @std/app import start, print, exit
+
+        on start {
+          const xs = [0, 1, 2, 5];
+          const x1 = xs[1].getOrHalt();
+          print(x1);
+          const x2 = xs[2].getOrHalt();
+          print(x2);
+          const x5 = xs[5].getOrHalt();
+          print(x5);
+
+          emit exit 0;
+        }
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanTemp
+    }
+    AfterAll after
+
+    It "halts js on an error"
+      When run test_js
+      The status should eq "1"
+      The output should include ""
+      The error should eq "out-of-bounds access" # TODO: errors need stacktrace-like reporting
+    End 
+
+    It "halts agc on an error"
+      When run test_agc
+      The status should eq "1"
+      The error should eq "out-of-bounds access" # TODO: errors need stacktrace-like reporting
+    End 
+  End
 End

--- a/bdd/spec/025_runtime_error_spec.sh
+++ b/bdd/spec/025_runtime_error_spec.sh
@@ -10,18 +10,18 @@ Describe "Runtime Errors"
     End
   End
 
-  Describe "getOrHalt"
+  Describe "getOrExit"
     before() {
       sourceToAll "
         from @std/app import start, print, exit
 
         on start {
           const xs = [0, 1, 2, 5];
-          const x1 = xs[1].getOrHalt();
+          const x1 = xs[1].getOrExit();
           print(x1);
-          const x2 = xs[2].getOrHalt();
+          const x2 = xs[2].getOrExit();
           print(x2);
-          const x5 = xs[5].getOrHalt();
+          const x5 = xs[5].getOrExit();
           print(x5);
 
           emit exit 0;

--- a/std/root.ln
+++ b/std/root.ln
@@ -540,7 +540,7 @@ export fn toString(n: Result<Stringifiable>): string {
     return n.getErr(noerr()).toString();
   }
 }
-export fn getOrHalt(result: Result<any>): any {
+export fn getOrExit(result: Result<any>): any {
   if result.isErr() {
     stderrp(result.toString());
     exitop(1.toInt8());

--- a/std/root.ln
+++ b/std/root.ln
@@ -540,6 +540,14 @@ export fn toString(n: Result<Stringifiable>): string {
     return n.getErr(noerr()).toString();
   }
 }
+export fn getOrHalt(result: Result<any>): any {
+  if result.isErr() {
+    stderrp(result.toString());
+    exitop(1.toInt8());
+  } else {
+    return result.getR();
+  }
+}
 
 export fn main(val: any) = mainE(val, 0);
 export fn main(val: int8) = mainE(val, 8);


### PR DESCRIPTION
After see @ledwards' advent of code submissions, realized that this option is missing for CLI-type applications that really do want to halt on error instead of continuing. Providing a default value that is completely nonsensical will just produce nonsensical outputs.