### PR TITLE
AVM Perf Cleanup Part 1

### DIFF
--- a/avm/src/vm/event.rs
+++ b/avm/src/vm/event.rs
@@ -6,7 +6,7 @@ use tokio::task;
 
 use crate::vm::instruction::Instruction;
 use crate::vm::memory::HandlerMemory;
-use crate::vm::opcode::EmptyFuture;
+use crate::vm::opcode::HMFuture;
 use crate::vm::program::Program;
 use crate::vm::run::{EVENT_TX};
 
@@ -189,56 +189,65 @@ impl HandlerFragment {
   /// very high volume of small IO requests, but as most IO operations are several orders of
   /// magnitude slower than CPU operations, this is considered to be a very small minority of
   /// workloads and is ignored for now.
-  pub async fn run(mut self: HandlerFragment, mut hand_mem: HandlerMemory) -> HandlerMemory {
-    task::spawn(async move {
-      let mut instructions = self.get_instruction_fragment();
-      loop {
-        // io-bound fragment
-        if !instructions[0].opcode.pred_exec {
-          let mem = Arc::new(RwLock::new(hand_mem));
-          let futures: Vec<EmptyFuture> = instructions.iter().map(|ins| {
+  pub async fn run_local(mut self: HandlerFragment, mut hand_mem: HandlerMemory) -> HandlerMemory {
+    let mut instructions = self.get_instruction_fragment();
+    loop {
+      // io-bound fragment
+      if !instructions[0].opcode.pred_exec {
+        if instructions.len() > 1 {
+          let futures: Vec<HMFuture> = instructions.iter().map(|ins| {
             //eprintln!("{} {} {} {}", ins.opcode._name, ins.args[0], ins.args[1], ins.args[2]);
             let async_func = ins.opcode.async_func.unwrap();
-            return async_func(ins.args.clone(), mem.clone());
+            return async_func(ins.args.clone(), hand_mem.fork());
           }).collect();
-          hand_mem = task::spawn(async move {
-            join_all(futures).await;
-            let deref_res = Arc::try_unwrap(mem);
-            if deref_res.is_err() {
-              panic!("Arc for handler memory passed to io opcodes has more than one strong reference.");
-            };
-            deref_res.ok().unwrap().into_inner()
+          let hms = task::spawn(async move {
+            join_all(futures).await
           }).await.unwrap();
+          for hm in hms {
+            hand_mem.join(hm);
+          }
         } else {
-          // cpu-bound fragment
-          let self_and_hand_mem = task::block_in_place(move || {
-            instructions.iter().for_each( |i| {
-              //eprintln!("{} {} {} {}", i.opcode._name, i.args[0], i.args[1], i.args[2]);
-              let func = i.opcode.func.unwrap();
-              let event = func(i.args.as_slice(), &mut hand_mem);
-              if event.is_some() {
-                let event_tx = EVENT_TX.get().unwrap();
-                let event_sent = event_tx.send(event.unwrap());
-                if event_sent.is_err() {
-                  eprintln!("Event transmission error");
-                  std::process::exit(2);
-                }
+          let future = instructions[0].opcode.async_func.unwrap()(
+            instructions[0].args.clone(),
+            hand_mem
+          );
+          hand_mem = future.await;
+        }
+      } else {
+        // cpu-bound fragment
+        let self_and_hand_mem = task::block_in_place(move || {
+          instructions.iter().for_each( |i| {
+            //eprintln!("{} {} {} {}", i.opcode._name, i.args[0], i.args[1], i.args[2]);
+            let func = i.opcode.func.unwrap();
+            let event = func(i.args.as_slice(), &mut hand_mem);
+            if event.is_some() {
+              let event_tx = EVENT_TX.get().unwrap();
+              let event_sent = event_tx.send(event.unwrap());
+              if event_sent.is_err() {
+                eprintln!("Event transmission error");
+                std::process::exit(2);
               }
-            });
-            (self, hand_mem)
+            }
           });
-          self = self_and_hand_mem.0;
-          hand_mem = self_and_hand_mem.1;
-        }
-        let next_frag = self.get_next_fragment();
-        if next_frag.is_some() {
-          self = next_frag.unwrap();
-          instructions = self.get_instruction_fragment();
-        } else {
-          break;
-        }
+          (self, hand_mem)
+        });
+        self = self_and_hand_mem.0;
+        hand_mem = self_and_hand_mem.1;
       }
-      hand_mem
+      let next_frag = self.get_next_fragment();
+      if next_frag.is_some() {
+        self = next_frag.unwrap();
+        instructions = self.get_instruction_fragment();
+      } else {
+        break;
+      }
+    }
+    hand_mem
+  }
+
+  pub async fn run(mut self: HandlerFragment, mut hand_mem: HandlerMemory) -> HandlerMemory {
+    task::spawn(async move {
+      self.run_local(hand_mem).await
     }).await.unwrap()
   }
 }

--- a/avm/src/vm/event.rs
+++ b/avm/src/vm/event.rs
@@ -1,7 +1,4 @@
-use std::sync::Arc;
-
 use futures::future::join_all;
-use tokio::sync::RwLock;
 use tokio::task;
 
 use crate::vm::instruction::Instruction;
@@ -245,7 +242,7 @@ impl HandlerFragment {
     hand_mem
   }
 
-  pub async fn run(mut self: HandlerFragment, mut hand_mem: HandlerMemory) -> HandlerMemory {
+  pub async fn run(self: HandlerFragment, hand_mem: HandlerMemory) -> HandlerMemory {
     task::spawn(async move {
       self.run_local(hand_mem).await
     }).await.unwrap()

--- a/avm/src/vm/event.rs
+++ b/avm/src/vm/event.rs
@@ -192,6 +192,7 @@ impl HandlerFragment {
       // io-bound fragment
       if !instructions[0].opcode.pred_exec {
         if instructions.len() > 1 {
+          // TODO: Revive IO parallelization, again, once AGA dependency graph *actually* works
           /*let futures: Vec<HMFuture> = instructions.iter().map(|ins| {
             //eprintln!("{} {} {} {}", ins.opcode._name, ins.args[0], ins.args[1], ins.args[2]);
             let async_func = ins.opcode.async_func.unwrap();
@@ -212,8 +213,7 @@ impl HandlerFragment {
           for i in 0..instructions.len() {
             let ins = &instructions[i];
             let async_func = ins.opcode.async_func.unwrap();
-            let hm = async_func(ins.args.clone(), hand_mem.fork()).await;
-            hand_mem.join(hm);
+            hand_mem = async_func(ins.args.clone(), hand_mem).await;
           }
         } else {
           let future = instructions[0].opcode.async_func.unwrap()(

--- a/avm/src/vm/event.rs
+++ b/avm/src/vm/event.rs
@@ -192,7 +192,7 @@ impl HandlerFragment {
       // io-bound fragment
       if !instructions[0].opcode.pred_exec {
         if instructions.len() > 1 {
-          let futures: Vec<HMFuture> = instructions.iter().map(|ins| {
+          /*let futures: Vec<HMFuture> = instructions.iter().map(|ins| {
             //eprintln!("{} {} {} {}", ins.opcode._name, ins.args[0], ins.args[1], ins.args[2]);
             let async_func = ins.opcode.async_func.unwrap();
             return async_func(ins.args.clone(), hand_mem.fork());
@@ -200,7 +200,19 @@ impl HandlerFragment {
           let hms = task::spawn(async move {
             join_all(futures).await
           }).await.unwrap();
+          //eprintln!(">>>>>>>>>>>>>>>>>>");
+          //eprintln!("{:?}", &hand_mem);
+          //eprintln!("{:?}", &hms);
           for hm in hms {
+            hand_mem.join(hm);
+          }
+          //eprintln!("{:?}", &hand_mem);
+          //eprintln!("<<<<<<<<<<<<<<<<<");
+          */
+          for i in 0..instructions.len() {
+            let ins = &instructions[i];
+            let async_func = ins.opcode.async_func.unwrap();
+            let hm = async_func(ins.args.clone(), hand_mem.fork()).await;
             hand_mem.join(hm);
           }
         } else {

--- a/avm/src/vm/memory.rs
+++ b/avm/src/vm/memory.rs
@@ -207,47 +207,9 @@ impl HandlerMemory {
 
   /// Stores a nested fractal of data in a given address.
   pub fn write_fractal(self: &mut HandlerMemory, addr: i64, val: &[(usize, i64)]) {
-    if addr >= 0 && self.addr.0.len() > (addr as usize) {
-      let (a, b) = self.addr.0[addr as usize];
-      if b == std::usize::MAX {
-        let old_fractal = &self.mems[a];
-        for i in 0..old_fractal.len() {
-          if old_fractal[i].0 == self.mems.len() - 1 {
-            drop(old_fractal);
-            self.mems.pop();
-            break;
-          }
-        }
-        self.mems[a] = val.to_vec().clone();
-        self.set_addr(addr, a, std::usize::MAX);
-      } else {
-        let a = self.mems.len();
-        self.mems.push(val.to_vec().clone());
-        self.set_addr(addr, a, std::usize::MAX);
-      }
-    } else if addr <= CLOSURE_ARG_MEM_END && self.addr.1.len() > ((addr - CLOSURE_ARG_MEM_START) as usize) {
-      let (a, b) = self.addr.1[(addr - CLOSURE_ARG_MEM_START) as usize];
-      if b == std::usize::MAX {
-        let old_fractal = &self.mems[a];
-        for i in 0..old_fractal.len() {
-          if old_fractal[i].0 == self.mems.len() - 1 {
-            drop(old_fractal);
-            self.mems.pop();
-            break;
-          }
-        }
-        self.mems[a] = val.to_vec().clone();
-        self.set_addr(addr, a, std::usize::MAX);
-      } else {
-        let a = self.mems.len();
-        self.mems.push(val.to_vec().clone());
-        self.set_addr(addr, a, std::usize::MAX);
-      }
-    } else {
-      let a = self.mems.len();
-      self.mems.push(val.to_vec().clone());
-      self.set_addr(addr, a, std::usize::MAX);
-    }
+    let a = self.mems.len();
+    self.mems.push(val.to_vec().clone());
+    self.set_addr(addr, a, std::usize::MAX);
   }
 
   /// Pushes a fixed value into a fractal at a given address.

--- a/avm/src/vm/memory.rs
+++ b/avm/src/vm/memory.rs
@@ -218,9 +218,13 @@ impl HandlerMemory {
             break;
           }
         }
+        self.mems[a] = val.to_vec().clone();
+        self.set_addr(addr, a, std::usize::MAX);
+      } else {
+        let a = self.mems.len();
+        self.mems.push(val.to_vec().clone());
+        self.set_addr(addr, a, std::usize::MAX);
       }
-      self.mems[a] = val.to_vec().clone();
-      self.set_addr(addr, a, std::usize::MAX);
     } else if addr <= CLOSURE_ARG_MEM_END && self.addr.1.len() > ((addr - CLOSURE_ARG_MEM_START) as usize) {
       let (a, b) = self.addr.1[(addr - CLOSURE_ARG_MEM_START) as usize];
       if b == std::usize::MAX {
@@ -232,9 +236,13 @@ impl HandlerMemory {
             break;
           }
         }
+        self.mems[a] = val.to_vec().clone();
+        self.set_addr(addr, a, std::usize::MAX);
+      } else {
+        let a = self.mems.len();
+        self.mems.push(val.to_vec().clone());
+        self.set_addr(addr, a, std::usize::MAX);
       }
-      self.mems[a] = val.to_vec().clone();
-      self.set_addr(addr, a, std::usize::MAX);
     } else {
       let a = self.mems.len();
       self.mems.push(val.to_vec().clone());
@@ -535,17 +543,19 @@ impl HandlerMemory {
     }
     // Finally pull any addresses added by the old object into the new with a similar stitching
     if hm.addr.0.len() > self.addr.0.len() {
-      self.addr.0.resize(hm.addr.0.len(), (std::usize::MAX, 0));
+      self.addr.0.resize(hm.addr.0.len(), (0, 0));
     }
     for i in 0..hm.addr.0.len() {
       let (a, b) = hm.addr.0[i];
       let (c, _d) = self.addr.0[i];
-      if a > c || (a < std::usize::MAX && c == std::usize::MAX) {
-        if a >= s && a != std::usize::MAX {
+      if a != std::usize::MAX && (a >= c || c == std::usize::MAX) {
+        if a + offset >= s && a != std::usize::MAX {
           self.addr.0[i] = (a + offset, b);
         } else {
           self.addr.0[i] = (a, b);
         }
+      } else if a == c {
+        self.addr.0[i] = (a, b);
       }
     }
   }

--- a/avm/src/vm/memory.rs
+++ b/avm/src/vm/memory.rs
@@ -501,7 +501,7 @@ impl HandlerMemory {
     let s = hm.mem_addr; // The initial block that will be transferred (plus all following blocks)
     let s2 = self.mems.len(); // The new address of the initial block
     let offset = s2 - s; // Assuming it was made by `fork` this should be positive or zero
-    if (hm.addr.1.len() > 0) {
+    if hm.addr.1.len() > 0 {
       let (a, b) = hm.addr_to_idxs(CLOSURE_ARG_MEM_START); // The only address that can "escape"
       hm.mems.drain(..s); // Remove the irrelevant memory blocks
       self.mems.append(&mut hm.mems); // Append the relevant ones to the original HandlerMemory

--- a/avm/src/vm/memory.rs
+++ b/avm/src/vm/memory.rs
@@ -542,7 +542,7 @@ impl HandlerMemory {
       }
     }
     // Finally pull any addresses added by the old object into the new with a similar stitching
-    if hm.addr.0.len() > self.addr.0.len() {
+    /*if hm.addr.0.len() > self.addr.0.len() {
       self.addr.0.resize(hm.addr.0.len(), (0, 0));
     }
     for i in 0..hm.addr.0.len() {
@@ -557,7 +557,7 @@ impl HandlerMemory {
       } else if a == c {
         self.addr.0[i] = (a, b);
       }
-    }
+    }*/
   }
 
   /// Takes a UTF-8 string and converts it to fractal memory that can be stored inside of a

--- a/avm/src/vm/memory.rs
+++ b/avm/src/vm/memory.rs
@@ -547,8 +547,8 @@ impl HandlerMemory {
     }
     for i in 0..hm.addr.0.len() {
       let (a, b) = hm.addr.0[i];
-      let (c, _d) = self.addr.0[i];
-      if a != std::usize::MAX && (a >= c || c == std::usize::MAX) {
+      let (c, d) = self.addr.0[i];
+      if a != c || b != d {
         if a + offset >= s && a != std::usize::MAX {
           self.addr.0[i] = (a + offset, b);
         } else {

--- a/avm/src/vm/memory.rs
+++ b/avm/src/vm/memory.rs
@@ -45,7 +45,7 @@ pub struct HandlerMemory {
   ///    to nested memory. The second value indicates that the pointer is to an explicit value
   ///    within that block of memory.
   /// Virtual pointers are simply the indexes into the `mems` field.
-  pub mems: Vec<Vec<(usize, i64)>>,
+  mems: Vec<Vec<(usize, i64)>>,
   /// The address spaces for the handler memory that the handler can mutate. The first is the
   /// "normal" memory space, and the second is the args memory space. Global addresses are fixed
   /// for the application and do not need a mutable vector to parse.

--- a/avm/src/vm/opcode.rs
+++ b/avm/src/vm/opcode.rs
@@ -22,7 +22,6 @@ use once_cell::sync::Lazy;
 use rand::RngCore;
 use rand::rngs::OsRng;
 use regex::Regex;
-use tokio::sync::RwLock;
 use tokio::task;
 use tokio::time::delay_for;
 use twox_hash::XxHash64;
@@ -1651,7 +1650,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  io!("each", |args, mut hand_mem| {
+  io!("each", |args, hand_mem| {
     Box::pin(async move {
       let arr = hand_mem.read_fractal(args[0]);
       let len = arr.len();
@@ -2058,7 +2057,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     })
   });
   // IO opcodes
-  io!("waitop", |args, mut hand_mem| {
+  io!("waitop", |args, hand_mem| {
     Box::pin(async move {
       let ms = hand_mem.read_fixed(args[0]) as u64;
       delay_for(Duration::from_millis(ms)).await;
@@ -2251,7 +2250,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("dssetf", |args, mut hand_mem| {
+  io!("dssetf", |args, hand_mem| {
     Box::pin(async move {
       let val = hand_mem.read_fixed(args[2]);
       let mut hm = HandlerMemory::new(None, 1); 
@@ -2264,7 +2263,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("dssetv", |args, mut hand_mem| {
+  io!("dssetv", |args, hand_mem| {
     Box::pin(async move {
       let mut hm = HandlerMemory::new(None, 1);
       HandlerMemory::transfer(&hand_mem, args[2], &mut hm, 0);
@@ -2440,8 +2439,9 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hm.set_addr(CLOSURE_ARG_MEM_START + 1, a, b);
       hm.set_addr(CLOSURE_ARG_MEM_START + 2, c, d);
       let slf = hm.read_fractal(args[0]);
+      let a2 = slf[0].0;
       let recurse_fn = HandlerFragment::new(slf[1].1, 0);
-      let mut seq = hm.read_mut_fractal_idxs(slf[0].0, 0);
+      let seq = hm.read_mut_fractal_idxs(a2, 0);
       if seq[0].1 < seq[1].1 {
         seq[0].1 = seq[0].1 + 1;
         hm = recurse_fn.run(hm).await;

--- a/avm/src/vm/opcode.rs
+++ b/avm/src/vm/opcode.rs
@@ -2023,9 +2023,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       let cond = hand_mem.read_fixed(args[0]);
       let subhandler = HandlerFragment::new(args[1], 0);
       if cond == 1 {
-        let mut hm = hand_mem.clone();
-        hm = subhandler.run(hm).await;
-        hm.replace(&mut hand_mem);
+        hand_mem = subhandler.run(hand_mem).await;
       }
       hand_mem
     })

--- a/avm/src/vm/telemetry.rs
+++ b/avm/src/vm/telemetry.rs
@@ -22,5 +22,7 @@ pub async fn log() {
     ]
   });
   let client = reqwest::Client::new();
-  client.post(AMPLITUDE_URL).json(&body).send().await;
+  if client.post(AMPLITUDE_URL).json(&body).send().await.is_ok() {
+    // Do nothing
+  }
 }


### PR DESCRIPTION
Example code from @ledwards demonstrated a couple of pathological cases in the AVM:

1. When dropping a value that is an array of nested arrays, the nested arrays stay around until the handler completes in a semi-detached state, so code that causes that in a tight loop can quickly OOM the AVM.
2. Many opcodes are needlessly `clone`-ing the handler memory data structure for convenience, putting `memcpy`s in a tight loop; coupled with (1) that means each iteration of the loop takes longer than the last.

On my machine, this makes an explicitly linear version of the example code to go from >2 hours runtime (I just killed it after it had been running that long) to ~1 minute. However, transpiling to Javascript and running it takes ~4 seconds, so there's still a ways to go.

Breaking this up into multiple PRs to keep it reviewable. Future work includes:

* Array methods that use a user-provided function to automatically detect if the function is 100% CPU bound and perform the loop in-thread instead of scheduling in Tokio.
* Try to "uninfect" such io opcodes to avoid unnecessary threading when possible
* Actual parallel opcodes (eg `map` vs `mapl`) to only schedule up to `n` threads where `n` is the number of CPU cores, rather than creating a Tokio task per array element, and each Tokio thread consuming `m/n` elements where `m` is the total number of elements in the array being operated on.
* Rethink the AVM memory model itself to make deletions as cheap as insertions

It's expected that just the first one should get us within margin-of-error of the JS transpiled form, while the second one *should* get us slightly faster than JS, the third makes the AVM demonstrably better than normal dynamic languages and competitive with JVM, and the fourth to avoid a whole class of issues that probably exist but we don't have example code for, yet.

This PR only tackles half of what's described in #343