### PR TITLE
Merge function and operator from imports with existing functions and operators with the same name within the module

### DIFF
--- a/bdd/spec/023_http_spec.sh
+++ b/bdd/spec/023_http_spec.sh
@@ -111,4 +111,44 @@ Describe "@std/http"
       The output should eq "Hello, World!"
     End
   End
+
+  Describe "importing http get doesn't break hashmap get"
+    before() {
+      sourceToAll "
+        from @std/app import start, print, exit
+        from @std/http import get
+
+        on start {
+          const str = get('https://raw.githubusercontent.com/alantech/hellodep/aea1ce817a423d00107577a430a046993e4e6cad/index.ln').getOr('');
+          const kv = str.split(' = ');
+          const key = kv[0] || 'bad';
+          const val = kv[1] || 'bad';
+          const hm = newHashMap(key, val);
+          hm.get(key).getOr('failed').print();
+          hm.get('something else').getOr('correct').print();
+          emit exit 0;
+        }
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanTemp
+    }
+    AfterAll after
+
+    GETGETOUTPUT="\"You got me!\"
+
+correct"
+
+    It "runs js"
+      When run test_js
+      The output should eq "${GETGETOUTPUT}"
+    End
+
+    It "runs agc"
+      When run test_agc
+      The output should eq "${GETGETOUTPUT}"
+    End
+  End
 End

--- a/compiler/src/lntoamm/Module.ts
+++ b/compiler/src/lntoamm/Module.ts
@@ -82,7 +82,27 @@ class Module {
             importName = moduleVar.varop(0).getText()
           }
           const thing = importedModule.exportScope.shallowGet(exportName)
-          module.moduleScope.put(importName, thing)
+          if (thing instanceof Array && thing[0].microstatementInlining instanceof Function) {
+            const otherthing = module.moduleScope.deepGet(importName)
+            if (
+              !!otherthing &&
+              otherthing instanceof Array &&
+              (otherthing[0] as Fn).microstatementInlining instanceof Function
+            ) {
+              module.moduleScope.put(importName, [...thing, ...otherthing])
+            } else {
+              module.moduleScope.put(importName, thing)
+            }
+          } else if (thing instanceof Array && thing[0] instanceof Operator) {
+            const otherthing = module.moduleScope.deepGet(importName)
+            if (!!otherthing && otherthing instanceof Array && otherthing instanceof Operator) {
+              module.moduleScope.put(importName, [...thing, ...otherthing])
+            } else {
+              module.moduleScope.put(importName, thing)
+            }
+          } else {
+            module.moduleScope.put(importName, thing)
+          }
           // Special behavior for interfaces. If there are any functions or operators that match
           // the interface, pull them in. Similarly any types that match the entire interface. This
           // allows concise importing of a related suite of tools without having to explicitly call

--- a/compiler/src/lntoamm/UserFunction.ts
+++ b/compiler/src/lntoamm/UserFunction.ts
@@ -669,7 +669,18 @@ ${statements[i].statementAst.getText().trim()} on line ${statements[i].statement
       for (let i = 0; i < argumentTypeList.length; i++) {
         argTypes.push("<" + argumentTypeList[i].typename + ">")
       }
-      errMsg += '\n' + fns[0].getName() + "(" + argTypes.join(", ") + ")"
+      errMsg += '\n' + fns[0].getName() + "(" + argTypes.join(", ") + ")\n"
+      errMsg += 'Candidate functions considered:\n'
+      for (let i = 0; i < fns.length; i++) {
+        const fn = fns[i]
+        if (fn instanceof UserFunction) {
+          const fnStr = fn.toFnStr().split('{')[0]
+          errMsg += `${fnStr}\n`
+        } else {
+          // TODO: Add this to the opcode definition, too?
+          errMsg += `fn ${fn.getName()}(${Object.entries(fn.getArguments()).map(kv => `${kv[0]}: ${kv[1].typename}`)}): ${fn.getReturnType().typename}\n`
+        }
+      }
       throw new Error(errMsg)
     }
     return fn


### PR DESCRIPTION
Thanks to @ledwards for finding this with this example file: https://gist.github.com/ledwards/1b1497d0e53875a59054c4e36879bab0

`from` imports were obliterating any functions and operators with the same name within the scope before. This merges it (with the imported functions getting precedence on checking) similar to how defining new functions and operators within the scope merges them in the scope.

Will update this PR shortly with an even simpler test case. This might break a test on error reporting because I made the reporting better for not-found functions.