### PR TITLE
AVM string equality fix for global strings

### DIFF
--- a/avm/src/vm/opcode.rs
+++ b/avm/src/vm/opcode.rs
@@ -1092,7 +1092,15 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
   cpu!("eqstr", |args, hand_mem| {
     let a_pascal_string = hand_mem.read_fractal(args[0]);
     let b_pascal_string = hand_mem.read_fractal(args[1]);
-    let out = if a_pascal_string == b_pascal_string { 1i64 } else { 0i64 };
+    let out;
+    if args[0] < 0 || args[1] < 0 {
+      // Special path for global memory stored strings, they aren't represented the same way
+      let a_str = HandlerMemory::fractal_to_string(&a_pascal_string);
+      let b_str = HandlerMemory::fractal_to_string(&b_pascal_string);
+      out = if a_str == b_str { 1i64 } else { 0i64 };
+    } else {
+      out = if a_pascal_string == b_pascal_string { 1i64 } else { 0i64 };
+    }
     hand_mem.write_fixed(args[2], out);
     None
   });

--- a/bdd/spec/006_string_spec.sh
+++ b/bdd/spec/006_string_spec.sh
@@ -73,6 +73,36 @@ World!"
     End
   End
 
+  Describe "equality between global constant and 'live' string works"
+    before() {
+      sourceToAll "
+        from @std/app import start, print, exit
+
+        on start {
+          const foo = 'foo';
+          print(foo.trim() == foo);
+          emit exit 0;
+        }
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanTemp
+    }
+    AfterAll after
+
+    It "runs js"
+      When run test_js
+      The output should eq "true"
+    End
+
+    It "runs agc"
+      When run test_agc
+      The output should eq "true"
+    End
+  End
+
   Describe "templating"
     before() {
       # TODO: sourceToAll


### PR DESCRIPTION
Thanks to @ledwards for spotting this!

Proof that this test fails on current main:

```
Running: /bin/bash [bash 5.0.17(1)-release]
...Fpp

Examples:
  1) Strings equality between global constant and 'live' string works runs agc
     When run test_agc

     1.1) The output should eq true

            expected: "true"
                 got: "false"

          \# /usr/local/alancorp/alan/bdd/spec/006_string_spec.sh:102
```