### PR TITLE
Use pkg instead of nexe

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -58,8 +58,8 @@ Still thinking about the best approach to take on the GPGPU front: do it "right"
 
 We are still scoping out [FFI support](https://github.com/alantech/alan/pull/60/files) for bindings that plays nice with the auto parallelization that happens in the VM. Alan [transpiles to Javascript](https://docs.alan-lang.org/transpile_js.html) which still offers IO concurrency but without the parallelization.
 
-### The "source installation" necessary to contribute to Alan requires Python, Node.js and Rust. Why are there so many dependencies?
+### The "source installation" necessary to contribute to Alan requires Node.js and Rust. Why are there so many dependencies?
 
 We went with tools we were familiar with or believed would accelerate our ability to prove to ourselves that this could work, and that is reflected in the language implementation as it exists today, but we have always intended to rewrite the Alan compiler in Alan. Then only the runtime(s) would be in different languages.
 
-Currently, the compiler is written in Typescript, the main runtime in Rust and the secondary runtime in Javascript. Python is required due to a limitation of a dependency to [nexe](https://github.com/nexe/nexe) and not something we are using within the project. The upcoming nexe 4.0 release will hopefully resolve this. That said our dependency on nexe is intended to be temporary.
+Currently, the compiler is written in Typescript, the main runtime in Rust and the secondary runtime in Javascript.

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ compiler-browser-check:
 
 ./compiler/alan-compile:
 	cd compiler && yarn
-	yarn add nexe
-	cd compiler && ../node_modules/.bin/nexe -t 10.20.1 -r std -o alan-compile || ../node_modules/.bin/nexe -t 12.18.2 -r std -o alan-compile || ../node_modules/.bin/nexe -b -p python2 -t 10.20.1 -r std -o alan-compile
+	yarn add pkg
+	cd compiler && ../node_modules/.bin/pkg --targets host .
 
 ./avm/target/release/alan: compiler/alan-compile
 	cd avm && cargo build --release

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -15,6 +15,9 @@
   "bin": {
     "alan-compile": "./dist/index.js"
   },
+  "pkg": {
+    "assets": "std/*"
+  },
   "browser": {
     "./dist/index.js": "./browser.js",
     "./dist/lntoamm/Std.js": "./browser/Std.js"


### PR DESCRIPTION
Resolves \#347 and eliminates Python 2 from our build process!