### PR TITLE
Opcode refactor

### DIFF
--- a/avm/src/vm/event.rs
+++ b/avm/src/vm/event.rs
@@ -213,8 +213,12 @@ impl HandlerFragment {
           */
           for i in 0..instructions.len() {
             let ins = &instructions[i];
+            if let OpcodeFn::Io(async_func) = ins.opcode.fun {
+                hand_mem = async_func(ins.args.clone(), hand_mem).await;
+            } else {
+                eprintln!("expected another IO instruction, found a CPU instruction");
+            };
             //eprintln!("{} {} {} {}", ins.opcode._name, ins.args[0], ins.args[1], ins.args[2]);
-            hand_mem = async_func(ins.args.clone(), hand_mem).await;
           }
         } else {
           //eprintln!("{} {} {} {}", instructions[0].opcode._name, instructions[0].args[0], instructions[0].args[1], instructions[0].args[2]);

--- a/avm/src/vm/event.rs
+++ b/avm/src/vm/event.rs
@@ -3,7 +3,7 @@ use tokio::task;
 
 use crate::vm::instruction::Instruction;
 use crate::vm::memory::HandlerMemory;
-use crate::vm::opcode::HMFuture;
+use crate::vm::opcode::{HMFuture, OpcodeFn};
 use crate::vm::program::Program;
 use crate::vm::run::{EVENT_TX};
 
@@ -65,9 +65,9 @@ impl EventHandler {
 
   pub fn add_instruction(self: &mut EventHandler, ins: Instruction) {
     self.ins_count += 1;
-    if ins.opcode.pred_exec {
+    if ins.opcode.pred_exec() {
       let mut frag = self.fragments.pop().unwrap_or(Vec::new());
-      if frag.len() > 0 && !frag.get(frag.len() - 1).unwrap().opcode.pred_exec {
+      if frag.len() > 0 && !frag.get(frag.len() - 1).unwrap().opcode.pred_exec() {
         // if last instruction in the last fragment is a (io or cpu) capstone start a new fragment
         self.fragments.push(frag);
         self.fragments.push(vec![ins]);
@@ -190,7 +190,8 @@ impl HandlerFragment {
     let mut instructions = self.get_instruction_fragment();
     loop {
       // io-bound fragment
-      if !instructions[0].opcode.pred_exec {
+      match &instructions[0].opcode.fun {
+        OpcodeFn::Io(async_func) => {
         if instructions.len() > 1 {
           // TODO: Revive IO parallelization, again, once AGA dependency graph *actually* works
           /*let futures: Vec<HMFuture> = instructions.iter().map(|ins| {
@@ -212,24 +213,23 @@ impl HandlerFragment {
           */
           for i in 0..instructions.len() {
             let ins = &instructions[i];
-            let async_func = ins.opcode.async_func.unwrap();
             //eprintln!("{} {} {} {}", ins.opcode._name, ins.args[0], ins.args[1], ins.args[2]);
             hand_mem = async_func(ins.args.clone(), hand_mem).await;
           }
         } else {
           //eprintln!("{} {} {} {}", instructions[0].opcode._name, instructions[0].args[0], instructions[0].args[1], instructions[0].args[2]);
-          let future = instructions[0].opcode.async_func.unwrap()(
+          let future = async_func(
             instructions[0].args.clone(),
             hand_mem
           );
           hand_mem = future.await;
         }
-      } else {
+      },
+      OpcodeFn::Cpu(func) => {
         // cpu-bound fragment
         let self_and_hand_mem = task::block_in_place(move || {
           instructions.iter().for_each( |i| {
             //eprintln!("{} {} {} {}", i.opcode._name, i.args[0], i.args[1], i.args[2]);
-            let func = i.opcode.func.unwrap();
             let event = func(i.args.as_slice(), &mut hand_mem);
             if event.is_some() {
               let event_tx = EVENT_TX.get().unwrap();
@@ -244,6 +244,7 @@ impl HandlerFragment {
         });
         self = self_and_hand_mem.0;
         hand_mem = self_and_hand_mem.1;
+      },
       }
       let next_frag = self.get_next_fragment();
       if next_frag.is_some() {

--- a/avm/src/vm/instruction.rs
+++ b/avm/src/vm/instruction.rs
@@ -1,5 +1,6 @@
 use crate::vm::opcode::ByteOpcode;
 
+#[derive(Debug)]
 pub struct Instruction {
   // only unique per fn/handler
   pub(crate) id: i64,

--- a/avm/src/vm/opcode.rs
+++ b/avm/src/vm/opcode.rs
@@ -84,9 +84,9 @@ impl ByteOpcode {
 }
 
 pub fn opcode_id(name: &str) -> i64 {
-  let mut ascii_name = [0u8; 8];
+  let mut ascii_name = [b' '; 8];
   // Now insert the new name characters
-  for (i, c) in name.chars().enumerate() {
+  for (i, c) in name.chars().take(8).enumerate() {
     std::mem::replace(&mut ascii_name[i], c as u8);
   }
   let id = LittleEndian::read_i64(&ascii_name);

--- a/avm/src/vm/opcode.rs
+++ b/avm/src/vm/opcode.rs
@@ -16,28 +16,26 @@ use byteorder::{ByteOrder, LittleEndian};
 use dashmap::DashMap;
 use hyper::header::{HeaderName, HeaderValue};
 use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, client::Client, Request, Response, server::Server, StatusCode, Uri};
+use hyper::{client::Client, server::Server, Body, Request, Response, StatusCode, Uri};
 use hyper_tls::HttpsConnector;
 use num_cpus;
 use once_cell::sync::Lazy;
-use rand::RngCore;
 use rand::rngs::OsRng;
+use rand::RngCore;
 use regex::Regex;
 use tokio::task;
 use tokio::time::sleep;
 use twox_hash::XxHash64;
 
 use crate::vm::event::{BuiltInEvents, EventEmit, HandlerFragment};
-use crate::vm::memory::{CLOSURE_ARG_MEM_START, HandlerMemory, FractalMemory};
-use crate::vm::run::{EVENT_TX};
+use crate::vm::memory::{FractalMemory, HandlerMemory, CLOSURE_ARG_MEM_START};
+use crate::vm::run::EVENT_TX;
 
-static HTTP_RESPONSES: Lazy<Arc<Mutex<HashMap<i64, HandlerMemory>>>> = Lazy::new(|| {
-  Arc::new(Mutex::new(HashMap::<i64, HandlerMemory>::new()))
-});
+static HTTP_RESPONSES: Lazy<Arc<Mutex<HashMap<i64, HandlerMemory>>>> =
+  Lazy::new(|| Arc::new(Mutex::new(HashMap::<i64, HandlerMemory>::new())));
 
-static DS: Lazy<Arc<DashMap<String, HandlerMemory>>> = Lazy::new(|| {
-  Arc::new(DashMap::<String, HandlerMemory>::new())
-});
+static DS: Lazy<Arc<DashMap<String, HandlerMemory>>> =
+  Lazy::new(|| Arc::new(DashMap::<String, HandlerMemory>::new()));
 
 // type aliases
 /// Futures implement an Unpin marker that guarantees to the compiler that the future will not move while it is running
@@ -47,16 +45,12 @@ static DS: Lazy<Arc<DashMap<String, HandlerMemory>>> = Lazy::new(|| {
 /// https://stackoverflow.com/questions/58354633/cannot-use-impl-future-to-store-async-function-in-a-vector
 /// https://stackoverflow.com/questions/51485410/unable-to-tokiorun-a-boxed-future-because-the-trait-bound-send-is-not-satisfie
 pub type HMFuture = Pin<Box<dyn Future<Output = HandlerMemory> + Send>>;
-/// Function pointer for io bound opcodes
-type AsyncFnPtr = fn(
-  Vec<i64>,
-  HandlerMemory,
-) -> HMFuture;
-/// Function pointer for cpu bound opcodes
-type FnPtr = fn(
-  &[i64],
-  &mut HandlerMemory,
-) -> Option<EventEmit>;
+
+/// A function to be run for an opcode.
+pub(crate) enum OpcodeFn {
+  Cpu(fn(&[i64], &mut HandlerMemory) -> Option<EventEmit>),
+  Io(fn(Vec<i64>, HandlerMemory) -> HMFuture),
+}
 
 /// To allow concise definition of opcodes we have a struct that stores all the information
 /// about an opcode and how to run it.
@@ -72,368 +66,402 @@ pub struct ByteOpcode {
   pub(crate) _id: i64,
   /// Human readable name for id
   pub(crate) _name: String,
-  /// Boolean that is true if this opcode has predictable execution
-  pub(crate) pred_exec: bool,
-  /// void function pointer that describes the side-effect of cpu bound opcode
-  pub(crate) func: Option<FnPtr>,
-  /// void async function pointer that describes the side-effect of io bound opcode
-  pub(crate) async_func: Option<AsyncFnPtr>,
+  /// The native code to execute for this opcode
+  pub(crate) fun: OpcodeFn,
 }
 
 pub fn opcode_id(name: &str) -> i64 {
-  let mut name_vec = vec!(b' ', b' ', b' ', b' ', b' ', b' ', b' ', b' ');
+  let mut ascii_name = [0u8; 8];
   // Now insert the new name characters
-  for (i, c) in name.chars().enumerate() {
-    std::mem::replace(&mut name_vec[i], c as u8);
+  for (i, c) in name.chars().take(8).enumerate() {
+    std::mem::replace(&mut ascii_name[i], c as u8);
   }
-  let id = LittleEndian::read_i64(&name_vec);
+  let id = LittleEndian::read_i64(&ascii_name);
   return id;
 }
 
+#[allow(unused)]
 pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
   let mut o = HashMap::new();
 
-  macro_rules! io {
-    ($name:expr, $async_func:expr) => {
-      let id = opcode_id($name);
+  macro_rules! cpu {
+    ($name:ident => fn ($args:ident , $hand_mem:ident) $body:block) => {
+      fn $name($args: &[i64], $hand_mem: &mut HandlerMemory) -> Option<EventEmit> {
+        $body
+      }
+      let id = opcode_id(stringify!($name));
       let opcode = ByteOpcode {
         _id: id,
-        _name: $name.to_string(),
-        pred_exec: false,
-        func: None,
-        async_func: Some($async_func),
+        _name: stringify!($name).to_string(),
+        fun: OpcodeFn::Cpu($name),
       };
       o.insert(id, opcode);
     };
   }
-
-  macro_rules! cpu {
-    ($name:expr, $func:expr) => {
-      let id = opcode_id($name);
+  macro_rules! io {
+    ($name:ident => fn ($args:ident , $hand_mem:ident) $body:block) => {
+      fn $name($args: Vec<i64>, $hand_mem: HandlerMemory) -> HMFuture {
+        $body
+      }
+      let id = opcode_id(stringify!($name));
       let opcode = ByteOpcode {
         _id: id,
-        _name: $name.to_string(),
-        pred_exec: true,
-        func: Some($func),
-        async_func: None,
+        _name: stringify!($name).to_string(),
+        fun: OpcodeFn::Io($name),
+      };
+      o.insert(id, opcode);
+    };
+    ($name:ident => fn (mut $args:ident , $hand_mem:ident) $body:block) => {
+      fn $name(mut $args: Vec<i64>, $hand_mem: HandlerMemory) -> HMFuture {
+        $body
+      }
+      let id = opcode_id(stringify!($name));
+      let opcode = ByteOpcode {
+        _id: id,
+        _name: stringify!($name).to_string(),
+        fun: OpcodeFn::Io($name),
+      };
+      o.insert(id, opcode);
+    };
+    ($name:ident => fn ($args:ident , mut $hand_mem:ident) $body:block) => {
+      fn $name($args: Vec<i64>, mut $hand_mem: HandlerMemory) -> HMFuture {
+        $body
+      }
+      let id = opcode_id(stringify!($name));
+      let opcode = ByteOpcode {
+        _id: id,
+        _name: stringify!($name).to_string(),
+        fun: OpcodeFn::Io($name),
+      };
+      o.insert(id, opcode);
+    };
+    ($name:ident => fn (mut $args:ident , mut $hand_mem:ident) $body:block) => {
+      fn $name(mut $args: Vec<i64>, mut $hand_mem: HandlerMemory) -> HMFuture {
+        $body
+      }
+      let id = opcode_id(stringify!($name));
+      let opcode = ByteOpcode {
+        _id: id,
+        _name: stringify!($name).to_string(),
+        fun: OpcodeFn::Io($name),
       };
       o.insert(id, opcode);
     };
   }
 
   // Type conversion opcodes
-  cpu!("i8f64", |args, hand_mem| {
+  cpu!(i8f64 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]) as f64;
     hand_mem.write_fixed(args[2], i64::from_ne_bytes(out.to_ne_bytes()));
     None
   });
-  cpu!("i16f64", |args, hand_mem| {
+  cpu!(i16f64 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]) as f64;
     hand_mem.write_fixed(args[2], i64::from_ne_bytes(out.to_ne_bytes()));
     None
   });
-  cpu!("i32f64", |args, hand_mem| {
+  cpu!(i32f64 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]) as f64;
     hand_mem.write_fixed(args[2], i64::from_ne_bytes(out.to_ne_bytes()));
     None
   });
-  cpu!("i64f64", |args, hand_mem| {
+  cpu!(i64f64 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]) as f64;
     hand_mem.write_fixed(args[2], i64::from_ne_bytes(out.to_ne_bytes()));
     None
   });
-  cpu!("f32f64", |args, hand_mem| {
+  cpu!(f32f64 => fn(args, hand_mem) {
     let out = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes());
     hand_mem.write_fixed(args[2], i32::from_ne_bytes(out.to_ne_bytes()) as i64);
     None
   });
-  cpu!("strf64", |args, hand_mem| {
+  cpu!(strf64 => fn(args, hand_mem) {
     let s = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let out: f64 = s.parse().unwrap();
     hand_mem.write_fixed(args[2], i64::from_ne_bytes(out.to_ne_bytes()));
     None
   });
-  cpu!("boolf64", |args, hand_mem| {
+  cpu!(boolf64 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]) as f64;
     hand_mem.write_fixed(args[2], i64::from_ne_bytes(out.to_ne_bytes()));
     None
   });
 
-  cpu!("i8f32", |args, hand_mem| {
+  cpu!(i8f32 => fn(args, hand_mem) {
     let num = hand_mem.read_fixed(args[0]) as f32;
     let out = i32::from_ne_bytes(num.to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i16f32", |args, hand_mem| {
+  cpu!(i16f32 => fn(args, hand_mem) {
     let num = hand_mem.read_fixed(args[0]) as f32;
     let out = i32::from_ne_bytes(num.to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i32f32", |args, hand_mem| {
+  cpu!(i32f32 => fn(args, hand_mem) {
     let num = hand_mem.read_fixed(args[0]) as f32;
     let out = i32::from_ne_bytes(num.to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i64f32", |args, hand_mem| {
+  cpu!(i64f32 => fn(args, hand_mem) {
     let num = hand_mem.read_fixed(args[0]) as f32;
     let out = i32::from_ne_bytes(num.to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("f64f32", |args, hand_mem| {
+  cpu!(f64f32 => fn(args, hand_mem) {
     let num = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes()) as f32;
     let out = i32::from_ne_bytes(num.to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("strf32", |args, hand_mem| {
+  cpu!(strf32 => fn(args, hand_mem) {
     let s = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let num: f32 = s.parse().unwrap();
     let out = i32::from_ne_bytes(num.to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("boolf32", |args, hand_mem| {
+  cpu!(boolf32 => fn(args, hand_mem) {
     let num = hand_mem.read_fixed(args[0]) as f32;
     let out = i32::from_ne_bytes(num.to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
 
-  cpu!("i8i64", |args, hand_mem| {
+  cpu!(i8i64 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i16i64", |args, hand_mem| {
+  cpu!(i16i64 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i32i64", |args, hand_mem| {
+  cpu!(i32i64 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("f64i64", |args, hand_mem| {
+  cpu!(f64i64 => fn(args, hand_mem) {
     let out = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("f32i64", |args, hand_mem| {
+  cpu!(f32i64 => fn(args, hand_mem) {
     let out = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("stri64", |args, hand_mem| {
+  cpu!(stri64 => fn(args, hand_mem) {
     let s = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let out: i64 = s.parse().unwrap();
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("booli64", |args, hand_mem| {
+  cpu!(booli64 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], out);
     None
   });
 
-  cpu!("i8i32", |args, hand_mem| {
+  cpu!(i8i32 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i16i32", |args, hand_mem| {
+  cpu!(i16i32 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i64i32", |args, hand_mem| {
+  cpu!(i64i32 => fn(args, hand_mem) {
     let out = (hand_mem.read_fixed(args[0]) as i32) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("f64i32", |args, hand_mem| {
+  cpu!(f64i32 => fn(args, hand_mem) {
     let out = (f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes()) as i32) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("f32i32", |args, hand_mem| {
+  cpu!(f32i32 => fn(args, hand_mem) {
     let out = (f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes()) as i32) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("stri32", |args, hand_mem| {
+  cpu!(stri32 => fn(args, hand_mem) {
     let s = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let num: i32 = s.parse().unwrap();
     let out = num as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("booli32", |args, hand_mem| {
+  cpu!(booli32 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], out);
     None
   });
 
-  cpu!("i8i16", |args, hand_mem| {
+  cpu!(i8i16 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i32i16", |args, hand_mem| {
+  cpu!(i32i16 => fn(args, hand_mem) {
     let out = (hand_mem.read_fixed(args[0]) as i16) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i64i16", |args, hand_mem| {
+  cpu!(i64i16 => fn(args, hand_mem) {
     let out = (hand_mem.read_fixed(args[0]) as i16) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("f64i16", |args, hand_mem| {
+  cpu!(f64i16 => fn(args, hand_mem) {
     let out = (f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes()) as i16) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("f32i16", |args, hand_mem| {
+  cpu!(f32i16 => fn(args, hand_mem) {
     let out = (f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes()) as i16) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("stri16", |args, hand_mem| {
+  cpu!(stri16 => fn(args, hand_mem) {
     let s = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let num: i16 = s.parse().unwrap();
     let out = num as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("booli16", |args, hand_mem| {
+  cpu!(booli16 => fn(args, hand_mem) {
     let out = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], out);
     None
   });
 
-  cpu!("i16i8", |args, hand_mem| {
+  cpu!(i16i8 => fn(args, hand_mem) {
     let out = (hand_mem.read_fixed(args[0]) as i8) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i32i8", |args, hand_mem| {
+  cpu!(i32i8 => fn(args, hand_mem) {
     let out = (hand_mem.read_fixed(args[0]) as i8) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i64i8", |args, hand_mem| {
+  cpu!(i64i8 => fn(args, hand_mem) {
     let out = (hand_mem.read_fixed(args[0]) as i8) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("f64i8", |args, hand_mem| {
+  cpu!(f64i8 => fn(args, hand_mem) {
     let out = (f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes()) as i8) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("f32i8", |args, hand_mem| {
+  cpu!(f32i8 => fn(args, hand_mem) {
     let out = (f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes()) as i8) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("stri8", |args, hand_mem| {
+  cpu!(stri8 => fn(args, hand_mem) {
     let s = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let num: i8 = s.parse().unwrap();
     let out = num as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("booli8", |args, hand_mem| {
+  cpu!(booli8 => fn(args, hand_mem) {
     let out = (hand_mem.read_fixed(args[0]) as i8) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
 
-  cpu!("i8bool", |args, hand_mem| {
+  cpu!(i8bool => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let out = if a != 0 { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i16bool", |args, hand_mem| {
+  cpu!(i16bool => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let out = if a != 0 { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i32bool", |args, hand_mem| {
+  cpu!(i32bool => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let out = if a != 0 { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("i64bool", |args, hand_mem| {
+  cpu!(i64bool => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let out = if a != 0 { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("f64bool", |args, hand_mem| {
+  cpu!(f64bool => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = if a != 0.0 { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("f32bool", |args, hand_mem| {
+  cpu!(f32bool => fn(args, hand_mem) {
     let a = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes());
     let out = if a != 0.0 { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("strbool", |args, hand_mem| {
+  cpu!(strbool => fn(args, hand_mem) {
     let s = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let out = if s == "true" { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
 
-  cpu!("i8str", |args, hand_mem| {
+  cpu!(i8str => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let a_str = a.to_string();
     hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&a_str));
     None
   });
-  cpu!("i16str", |args, hand_mem| {
+  cpu!(i16str => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let a_str = a.to_string();
     hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&a_str));
     None
   });
-  cpu!("i32str", |args, hand_mem| {
+  cpu!(i32str => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let a_str = a.to_string();
     hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&a_str));
     None
   });
-  cpu!("i64str", |args, hand_mem| {
+  cpu!(i64str => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let a_str = a.to_string();
     hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&a_str));
     None
   });
-  cpu!("f64str", |args, hand_mem| {
+  cpu!(f64str => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let a_str = a.to_string();
     hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&a_str));
     None
   });
-  cpu!("f32str", |args, hand_mem| {
+  cpu!(f32str => fn(args, hand_mem) {
     let a = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes());
     let a_str = a.to_string();
     hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&a_str));
     None
   });
-  cpu!("boolstr", |args, hand_mem| {
+  cpu!(boolstr => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let a_str = if a == 1 { "true" } else { "false" };
     hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&a_str));
@@ -441,16 +469,16 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
   });
 
   // Arithmetic opcodes
-  cpu!("addi8", |args, hand_mem| {
+  cpu!(addi8 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i8;
     let b = rb.read_fixed(1) as i8;
@@ -458,27 +486,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b > 0 && a > std::i8::MAX - b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b < 0 && a < std::i8::MIN - b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a + b) as i64);
     None
   });
-  cpu!("addi16", |args, hand_mem| {
+  cpu!(addi16 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i16;
     let b = rb.read_fixed(1) as i16;
@@ -486,27 +514,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b > 0 && a > std::i16::MAX - b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b < 0 && a < std::i16::MIN - b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a + b) as i64);
     None
   });
-  cpu!("addi32", |args, hand_mem| {
+  cpu!(addi32 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i32;
     let b = rb.read_fixed(1) as i32;
@@ -514,27 +542,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b > 0 && a > std::i32::MAX - b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b < 0 && a < std::i32::MIN - b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a + b) as i64);
     None
   });
-  cpu!("addi64", |args, hand_mem| {
+  cpu!(addi64 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i64;
     let b = rb.read_fixed(1) as i64;
@@ -542,27 +570,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b > 0 && a > std::i64::MAX - b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b < 0 && a < std::i64::MIN - b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a + b) as i64);
     None
   });
-  cpu!("addf32", |args, hand_mem| {
+  cpu!(addf32 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = f32::from_ne_bytes((ra.read_fixed(1) as i32).to_ne_bytes());
     let b = f32::from_ne_bytes((rb.read_fixed(1) as i32).to_ne_bytes());
@@ -571,28 +599,28 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if out == std::f32::INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if out == std::f32::NEG_INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     let num = i32::from_ne_bytes(out.to_ne_bytes()) as i64;
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], num);
     None
   });
-  cpu!("addf64", |args, hand_mem| {
+  cpu!(addf64 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = f64::from_ne_bytes(ra.read_fixed(1).to_ne_bytes());
     let b = f64::from_ne_bytes(rb.read_fixed(1).to_ne_bytes());
@@ -601,12 +629,12 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if out == std::f64::INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if out == std::f64::NEG_INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     let num = i64::from_ne_bytes(out.to_ne_bytes());
     hand_mem.push_fixed(args[2], 1);
@@ -614,16 +642,16 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("subi8", |args, hand_mem| {
+  cpu!(subi8 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i8;
     let b = rb.read_fixed(1) as i8;
@@ -631,27 +659,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b < 0 && a > std::i8::MAX + b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b > 0 && a < std::i8::MIN + b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a - b) as i64);
     None
   });
-  cpu!("subi16", |args, hand_mem| {
+  cpu!(subi16 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i16;
     let b = rb.read_fixed(1) as i16;
@@ -659,27 +687,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b < 0 && a > std::i16::MAX + b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b > 0 && a < std::i16::MIN + b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a - b) as i64);
     None
   });
-  cpu!("subi32", |args, hand_mem| {
+  cpu!(subi32 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i32;
     let b = rb.read_fixed(1) as i32;
@@ -687,27 +715,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b < 0 && a > std::i32::MAX + b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b > 0 && a < std::i32::MIN + b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a - b) as i64);
     None
   });
-  cpu!("subi64", |args, hand_mem| {
+  cpu!(subi64 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i64;
     let b = rb.read_fixed(1) as i64;
@@ -715,27 +743,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b < 0 && a > std::i64::MAX + b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b > 0 && a < std::i64::MIN + b {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], a - b);
     None
   });
-  cpu!("subf32", |args, hand_mem| {
+  cpu!(subf32 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = f32::from_ne_bytes((ra.read_fixed(1) as i32).to_ne_bytes());
     let b = f32::from_ne_bytes((rb.read_fixed(1) as i32).to_ne_bytes());
@@ -744,28 +772,28 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if out == std::f32::INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if out == std::f32::NEG_INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     let num = i32::from_ne_bytes(out.to_ne_bytes()) as i64;
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], num);
     None
   });
-  cpu!("subf64", |args, hand_mem| {
+  cpu!(subf64 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = f64::from_ne_bytes(ra.read_fixed(1).to_ne_bytes());
     let b = f64::from_ne_bytes(rb.read_fixed(1).to_ne_bytes());
@@ -774,12 +802,12 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if out == std::f64::INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if out == std::f64::NEG_INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     let num = i64::from_ne_bytes(out.to_ne_bytes());
     hand_mem.push_fixed(args[2], 1);
@@ -787,90 +815,90 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("negi8", |args, hand_mem| {
+  cpu!(negi8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let out = (0 - a) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("negi16", |args, hand_mem| {
+  cpu!(negi16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let out = (0 - a) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("negi32", |args, hand_mem| {
+  cpu!(negi32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let out = (0 - a) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("negi64", |args, hand_mem| {
+  cpu!(negi64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let out = 0 - a;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("negf32", |args, hand_mem| {
+  cpu!(negf32 => fn(args, hand_mem) {
     let a = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes());
     let out = i32::from_ne_bytes((0.0 - a).to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("negf64", |args, hand_mem| {
+  cpu!(negf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes((0.0 - a).to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
 
-  cpu!("absi8", |args, hand_mem| {
+  cpu!(absi8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let out = a.abs() as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("absi16", |args, hand_mem| {
+  cpu!(absi16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let out = a.abs() as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("absi32", |args, hand_mem| {
+  cpu!(absi32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let out = a.abs() as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("absi64", |args, hand_mem| {
+  cpu!(absi64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let out = a.abs();
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("absf32", |args, hand_mem| {
+  cpu!(absf32 => fn(args, hand_mem) {
     let a = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes());
     let out = i32::from_ne_bytes(a.abs().to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("absf64", |args, hand_mem| {
+  cpu!(absf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(a.abs().to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
 
-  cpu!("muli8", |args, hand_mem| {
+  cpu!(muli8 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i8;
     let b = rb.read_fixed(1) as i8;
@@ -878,27 +906,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b > 0 && (a as f64) > (std::i8::MAX as f64) / (b as f64) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b < 0 && (a as f64) < (std::i8::MIN as f64) / (b as f64) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a * b) as i64);
     None
   });
-  cpu!("muli16", |args, hand_mem| {
+  cpu!(muli16 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i16;
     let b = rb.read_fixed(1) as i16;
@@ -906,27 +934,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b > 0 && (a as f64) > (std::i16::MAX as f64) / (b as f64) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b < 0 && (a as f64) < (std::i16::MIN as f64) / (b as f64) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a * b) as i64);
     None
   });
-  cpu!("muli32", |args, hand_mem| {
+  cpu!(muli32 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i32;
     let b = rb.read_fixed(1) as i32;
@@ -934,27 +962,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b > 0 && (a as f64) > (std::i32::MAX as f64) / (b as f64) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b < 0 && (a as f64) < (std::i32::MIN as f64) / (b as f64) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a * b) as i64);
     None
   });
-  cpu!("muli64", |args, hand_mem| {
+  cpu!(muli64 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i64;
     let b = rb.read_fixed(1) as i64;
@@ -962,27 +990,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b > 0 && (a as f64) > (std::i64::MAX as f64) / (b as f64) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b < 0 && (a as f64) < (std::i64::MIN as f64) / (b as f64) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], a * b);
     None
   });
-  cpu!("mulf32", |args, hand_mem| {
+  cpu!(mulf32 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = f32::from_ne_bytes((ra.read_fixed(1) as i32).to_ne_bytes());
     let b = f32::from_ne_bytes((rb.read_fixed(1) as i32).to_ne_bytes());
@@ -991,28 +1019,28 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if out == std::f32::INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if out == std::f32::NEG_INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     let num = i32::from_ne_bytes(out.to_ne_bytes()) as i64;
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], num);
     None
   });
-  cpu!("mulf64", |args, hand_mem| {
+  cpu!(mulf64 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = f64::from_ne_bytes(ra.read_fixed(1).to_ne_bytes());
     let b = f64::from_ne_bytes(rb.read_fixed(1).to_ne_bytes());
@@ -1021,12 +1049,12 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if out == std::f64::INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if out == std::f64::NEG_INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     let num = i64::from_ne_bytes(out.to_ne_bytes());
     hand_mem.push_fixed(args[2], 1);
@@ -1034,16 +1062,16 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("divi8", |args, hand_mem| {
+  cpu!(divi8 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i8;
     let b = rb.read_fixed(1) as i8;
@@ -1051,22 +1079,22 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if b == 0 {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("divide-by-zero"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a / b) as i64);
     None
   });
-  cpu!("divi16", |args, hand_mem| {
+  cpu!(divi16 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i16;
     let b = rb.read_fixed(1) as i16;
@@ -1074,22 +1102,22 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if b == 0 {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("divide-by-zero"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a / b) as i64);
     None
   });
-  cpu!("divi32", |args, hand_mem| {
+  cpu!(divi32 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i32;
     let b = rb.read_fixed(1) as i32;
@@ -1097,22 +1125,22 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if b == 0 {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("divide-by-zero"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], (a / b) as i64);
     None
   });
-  cpu!("divi64", |args, hand_mem| {
+  cpu!(divi64 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i64;
     let b = rb.read_fixed(1) as i64;
@@ -1120,22 +1148,22 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if b == 0 {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("divide-by-zero"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], a / b);
     None
   });
-  cpu!("divf32", |args, hand_mem| {
+  cpu!(divf32 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = f32::from_ne_bytes((ra.read_fixed(1) as i32).to_ne_bytes());
     let b = f32::from_ne_bytes((rb.read_fixed(1) as i32).to_ne_bytes());
@@ -1143,34 +1171,34 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if b == 0.0 {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("divide-by-zero"));
-      return None
+      return None;
     }
     let out = a / b;
     if out == std::f32::INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if out == std::f32::NEG_INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     let num = i32::from_ne_bytes(out.to_ne_bytes()) as i64;
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], num);
     None
   });
-  cpu!("divf64", |args, hand_mem| {
+  cpu!(divf64 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = f64::from_ne_bytes(ra.read_fixed(1).to_ne_bytes());
     let b = f64::from_ne_bytes(rb.read_fixed(1).to_ne_bytes());
@@ -1178,18 +1206,18 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if b == 0.0 {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("divide-by-zero"));
-      return None
+      return None;
     }
     let out = a / b;
     if out == std::f64::INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if out == std::f64::NEG_INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     let num = i64::from_ne_bytes(out.to_ne_bytes());
     hand_mem.push_fixed(args[2], 1);
@@ -1197,28 +1225,28 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("modi8", |args, hand_mem| {
+  cpu!(modi8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = (a % b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("modi16", |args, hand_mem| {
+  cpu!(modi16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = (a % b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("modi32", |args, hand_mem| {
+  cpu!(modi32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = (a % b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("modi64", |args, hand_mem| {
+  cpu!(modi64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = a % b;
@@ -1226,16 +1254,16 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("powi8", |args, hand_mem| {
+  cpu!(powi8 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i8;
     let b = rb.read_fixed(1) as i8;
@@ -1243,28 +1271,28 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b > 1 && (a as f64) > f64::powf(std::i8::MAX as f64, 1.0 / (b as f64)) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b > 1 && (a as f64) < f64::powf(std::i8::MIN as f64, 1.0 / (b as f64)) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     let out = if b < 0 { 0i64 } else { i8::pow(a, b as u32) as i64 };
     hand_mem.push_fixed(args[2], out);
     None
   });
-  cpu!("powi16", |args, hand_mem| {
+  cpu!(powi16 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i16;
     let b = rb.read_fixed(1) as i16;
@@ -1272,28 +1300,28 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b > 1 && (a as f64) > f64::powf(std::i16::MAX as f64, 1.0 / (b as f64)) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b > 1 && (a as f64) < f64::powf(std::i16::MIN as f64, 1.0 / (b as f64)) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     let out = if b < 0 { 0i64 } else { i16::pow(a, b as u32) as i64 };
     hand_mem.push_fixed(args[2], out);
     None
   });
-  cpu!("powi32", |args, hand_mem| {
+  cpu!(powi32 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i32;
     let b = rb.read_fixed(1) as i32;
@@ -1301,28 +1329,28 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b > 1 && (a as f64) > f64::powf(std::i32::MAX as f64, 1.0 / (b as f64)) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b > 1 && (a as f64) < f64::powf(std::i32::MIN as f64, 1.0 / (b as f64)) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     let out = if b < 0 { 0i64 } else { i32::pow(a, b as u32) as i64 };
     hand_mem.push_fixed(args[2], out);
     None
   });
-  cpu!("powi64", |args, hand_mem| {
+  cpu!(powi64 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = ra.read_fixed(1) as i64;
     let b = rb.read_fixed(1) as i64;
@@ -1330,28 +1358,28 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if a > 0 && b > 1 && (a as f64) > f64::powf(std::i64::MAX as f64, 1.0 / (b as f64)) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if a < 0 && b > 1 && (a as f64) < f64::powf(std::i64::MIN as f64, 1.0 / (b as f64)) {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     hand_mem.push_fixed(args[2], 1);
     let out = if b < 0 { 0i64 } else { i64::pow(a, b as u32) as i64 };
     hand_mem.push_fixed(args[2], out);
     None
   });
-  cpu!("powf32", |args, hand_mem| {
+  cpu!(powf32 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = f32::from_ne_bytes((ra.read_fixed(1) as i32).to_ne_bytes());
     let b = f32::from_ne_bytes((rb.read_fixed(1) as i32).to_ne_bytes());
@@ -1360,28 +1388,28 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if out == std::f32::INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if out == std::f32::NEG_INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     let num = i32::from_ne_bytes(out.to_ne_bytes()) as i64;
     hand_mem.push_fixed(args[2], 1);
     hand_mem.push_fixed(args[2], num);
     None
   });
-  cpu!("powf64", |args, hand_mem| {
+  cpu!(powf64 => fn(args, hand_mem) {
     let ra = hand_mem.read_fractal(args[0]);
     let rb = hand_mem.read_fractal(args[1]);
     if ra.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &ra);
-      return None
+      return None;
     }
     if rb.read_fixed(0) == 0 {
       hand_mem.write_fractal(args[2], &rb);
-      return None
+      return None;
     }
     let a = f64::from_ne_bytes(ra.read_fixed(1).to_ne_bytes());
     let b = f64::from_ne_bytes(rb.read_fixed(1).to_ne_bytes());
@@ -1390,12 +1418,12 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     if out == std::f64::INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("overflow"));
-      return None
+      return None;
     }
     if out == std::f64::NEG_INFINITY {
       hand_mem.push_fixed(args[2], 0);
       hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("underflow"));
-      return None
+      return None;
     }
     let num = i64::from_ne_bytes(out.to_ne_bytes());
     hand_mem.push_fixed(args[2], 1);
@@ -1403,13 +1431,13 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("sqrtf32", |args, hand_mem| {
+  cpu!(sqrtf32 => fn(args, hand_mem) {
     let a = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes());
     let out = i32::from_ne_bytes(f32::sqrt(a).to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("sqrtf64", |args, hand_mem| {
+  cpu!(sqrtf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(f64::sqrt(a).to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
@@ -1417,35 +1445,35 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
   });
 
   // Boolean and bitwise opcodes
-  cpu!("andi8", |args, hand_mem| {
+  cpu!(andi8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = (a & b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("andi16", |args, hand_mem| {
+  cpu!(andi16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = (a & b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("andi32", |args, hand_mem| {
+  cpu!(andi32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = (a & b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("andi64", |args, hand_mem| {
+  cpu!(andi64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = a & b;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("andbool", |args, hand_mem| {
+  cpu!(andbool => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let a_bool = if a == 1 { true } else { false };
@@ -1455,35 +1483,35 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("ori8", |args, hand_mem| {
+  cpu!(ori8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = (a | b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("ori16", |args, hand_mem| {
+  cpu!(ori16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = (a | b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("ori32", |args, hand_mem| {
+  cpu!(ori32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = (a | b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("ori64", |args, hand_mem| {
+  cpu!(ori64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = a | b;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("orbool", |args, hand_mem| {
+  cpu!(orbool => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let a_bool = if a == 1 { true } else { false };
@@ -1493,35 +1521,35 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("xori8", |args, hand_mem| {
+  cpu!(xori8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = (a ^ b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("xori16", |args, hand_mem| {
+  cpu!(xori16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = (a ^ b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("xori32", |args, hand_mem| {
+  cpu!(xori32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = (a ^ b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("xori64", |args, hand_mem| {
+  cpu!(xori64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = a ^ b;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("xorbool", |args, hand_mem| {
+  cpu!(xorbool => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let a_bool = if a == 1 { true } else { false };
@@ -1531,31 +1559,31 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("noti8", |args, hand_mem| {
+  cpu!(noti8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let out = !a as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("noti16", |args, hand_mem| {
+  cpu!(noti16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let out = !a as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("noti32", |args, hand_mem| {
+  cpu!(noti32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let out = !a as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("noti64", |args, hand_mem| {
+  cpu!(noti64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let out = !a;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("notbool", |args, hand_mem| {
+  cpu!(notbool => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let a_bool = if a == 1 { true } else { false };
     let out = if !a_bool { 1i64 } else { 0i64 };
@@ -1563,35 +1591,35 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("nandi8", |args, hand_mem| {
+  cpu!(nandi8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = !(a & b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("nandi16", |args, hand_mem| {
+  cpu!(nandi16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = !(a & b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("nandi32", |args, hand_mem| {
+  cpu!(nandi32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = !(a & b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("nandi64", |args, hand_mem| {
+  cpu!(nandi64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = !(a & b);
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("nandboo", |args, hand_mem| {
+  cpu!(nandboo => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let a_bool = if a == 1 { true } else { false };
@@ -1601,35 +1629,35 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("nori8", |args, hand_mem| {
+  cpu!(nori8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = !(a | b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("nori16", |args, hand_mem| {
+  cpu!(nori16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = !(a | b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("nori32", |args, hand_mem| {
+  cpu!(nori32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = !(a | b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("nori64", |args, hand_mem| {
+  cpu!(nori64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = !(a | b);
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("norbool", |args, hand_mem| {
+  cpu!(norbool => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let a_bool = if a == 1 { true } else { false };
@@ -1639,35 +1667,35 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("xnori8", |args, hand_mem| {
+  cpu!(xnori8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = !(a ^ b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("xnori16", |args, hand_mem| {
+  cpu!(xnori16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = !(a ^ b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("xnori32", |args, hand_mem| {
+  cpu!(xnori32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = !(a ^ b) as i64;
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("xnori64", |args, hand_mem| {
+  cpu!(xnori64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = !(a ^ b);
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("xnorboo", |args, hand_mem| {
+  cpu!(xnorboo => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let a_bool = if a == 1 { true } else { false };
@@ -1678,64 +1706,65 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
   });
 
   // Equality and order opcodes
-  cpu!("eqi8", |args, hand_mem| {
+  cpu!(eqi8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = if a == b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("eqi16", |args, hand_mem| {
+  cpu!(eqi16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = if a == b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("eqi32", |args, hand_mem| {
+  cpu!(eqi32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = if a == b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("eqi64", |args, hand_mem| {
+  cpu!(eqi64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = if a == b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("eqf32", |args, hand_mem| {
+  cpu!(eqf32 => fn(args, hand_mem) {
     let a = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes());
     let b = f32::from_ne_bytes((hand_mem.read_fixed(args[1]) as i32).to_ne_bytes());
     let out = if a == b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("eqf64", |args, hand_mem| {
+  cpu!(eqf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let b = f64::from_ne_bytes(hand_mem.read_fixed(args[1]).to_ne_bytes());
     let out = if a == b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("eqstr", |args, hand_mem| {
+  cpu!(eqstr => fn(args, hand_mem) {
     let a_pascal_string = hand_mem.read_fractal(args[0]);
     let b_pascal_string = hand_mem.read_fractal(args[1]);
-    let out;
-    if args[0] < 0 || args[1] < 0 {
+    let out = if args[0] < 0 || args[1] < 0 {
       // Special path for global memory stored strings, they aren't represented the same way
       let a_str = HandlerMemory::fractal_to_string(a_pascal_string);
       let b_str = HandlerMemory::fractal_to_string(b_pascal_string);
-      out = if a_str == b_str { 1i64 } else { 0i64 };
+      if a_str == b_str { 1i64 } else { 0i64 }
+    } else if a_pascal_string == b_pascal_string {
+      1i64
     } else {
-      out = if a_pascal_string == b_pascal_string { 1i64 } else { 0i64 };
-    }
+      0i64
+    };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("eqbool", |args, hand_mem| {
+  cpu!(eqbool => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = if a == b { 1i64 } else { 0i64 };
@@ -1743,56 +1772,60 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("neqi8", |args, hand_mem| {
+  cpu!(neqi8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = if a != b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("neqi16", |args, hand_mem| {
+  cpu!(neqi16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = if a != b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("neqi32", |args, hand_mem| {
+  cpu!(neqi32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = if a != b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("neqi64", |args, hand_mem| {
+  cpu!(neqi64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = if a != b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("neqf32", |args, hand_mem| {
+  cpu!(neqf32 => fn(args, hand_mem) {
     let a = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes());
     let b = f32::from_ne_bytes((hand_mem.read_fixed(args[1]) as i32).to_ne_bytes());
     let out = if a != b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("neqf64", |args, hand_mem| {
+  cpu!(neqf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let b = f64::from_ne_bytes(hand_mem.read_fixed(args[1]).to_ne_bytes());
     let out = if a != b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("neqstr", |args, hand_mem| {
+  cpu!(neqstr => fn(args, hand_mem) {
     let a_pascal_string = hand_mem.read_fractal(args[0]);
     let b_pascal_string = hand_mem.read_fractal(args[1]);
-    let out = if a_pascal_string != b_pascal_string { 1i64 } else { 0i64 };
+    let out = if a_pascal_string != b_pascal_string {
+      1i64
+    } else {
+      0i64
+    };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("neqbool", |args, hand_mem| {
+  cpu!(neqbool => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = if a != b { 1i64 } else { 0i64 };
@@ -1800,49 +1833,49 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("lti8", |args, hand_mem| {
+  cpu!(lti8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = if a < b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("lti16", |args, hand_mem| {
+  cpu!(lti16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = if a < b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("lti32", |args, hand_mem| {
+  cpu!(lti32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = if a < b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("lti64", |args, hand_mem| {
+  cpu!(lti64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = if a < b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("ltf32", |args, hand_mem| {
+  cpu!(ltf32 => fn(args, hand_mem) {
     let a = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes());
     let b = f32::from_ne_bytes((hand_mem.read_fixed(args[1]) as i32).to_ne_bytes());
     let out = if a < b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("ltf64", |args, hand_mem| {
+  cpu!(ltf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let b = f64::from_ne_bytes(hand_mem.read_fixed(args[1]).to_ne_bytes());
     let out = if a < b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("ltstr", |args, hand_mem| {
+  cpu!(ltstr => fn(args, hand_mem) {
     let a_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let b_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
     let out = if a_str < b_str { 1i64 } else { 0i64 };
@@ -1850,49 +1883,49 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("ltei8", |args, hand_mem| {
+  cpu!(ltei8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = if a <= b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("ltei16", |args, hand_mem| {
+  cpu!(ltei16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = if a <= b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("ltei32", |args, hand_mem| {
+  cpu!(ltei32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = if a <= b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("ltei64", |args, hand_mem| {
+  cpu!(ltei64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = if a <= b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("ltef32", |args, hand_mem| {
+  cpu!(ltef32 => fn(args, hand_mem) {
     let a = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes());
     let b = f32::from_ne_bytes((hand_mem.read_fixed(args[1]) as i32).to_ne_bytes());
     let out = if a <= b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("ltef64", |args, hand_mem| {
+  cpu!(ltef64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let b = f64::from_ne_bytes(hand_mem.read_fixed(args[1]).to_ne_bytes());
     let out = if a <= b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("ltestr", |args, hand_mem| {
+  cpu!(ltestr => fn(args, hand_mem) {
     let a_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let b_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
     let out = if a_str <= b_str { 1i64 } else { 0i64 };
@@ -1900,49 +1933,49 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("gti8", |args, hand_mem| {
+  cpu!(gti8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = if a > b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("gti16", |args, hand_mem| {
+  cpu!(gti16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = if a > b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("gti32", |args, hand_mem| {
+  cpu!(gti32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = if a > b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("gti64", |args, hand_mem| {
+  cpu!(gti64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = if a > b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("gtf32", |args, hand_mem| {
+  cpu!(gtf32 => fn(args, hand_mem) {
     let a = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes());
     let b = f32::from_ne_bytes((hand_mem.read_fixed(args[1]) as i32).to_ne_bytes());
     let out = if a > b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("gtf64", |args, hand_mem| {
+  cpu!(gtf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let b = f64::from_ne_bytes(hand_mem.read_fixed(args[1]).to_ne_bytes());
     let out = if a > b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("gtstr", |args, hand_mem| {
+  cpu!(gtstr => fn(args, hand_mem) {
     let a_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let b_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
     let out = if a_str > b_str { 1i64 } else { 0i64 };
@@ -1950,49 +1983,49 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("gtei8", |args, hand_mem| {
+  cpu!(gtei8 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i8;
     let b = hand_mem.read_fixed(args[1]) as i8;
     let out = if a >= b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("gtei16", |args, hand_mem| {
+  cpu!(gtei16 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i16;
     let b = hand_mem.read_fixed(args[1]) as i16;
     let out = if a >= b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("gtei32", |args, hand_mem| {
+  cpu!(gtei32 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]) as i32;
     let b = hand_mem.read_fixed(args[1]) as i32;
     let out = if a >= b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("gtei64", |args, hand_mem| {
+  cpu!(gtei64 => fn(args, hand_mem) {
     let a = hand_mem.read_fixed(args[0]);
     let b = hand_mem.read_fixed(args[1]);
     let out = if a >= b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("gtef32", |args, hand_mem| {
+  cpu!(gtef32 => fn(args, hand_mem) {
     let a = f32::from_ne_bytes((hand_mem.read_fixed(args[0]) as i32).to_ne_bytes());
     let b = f32::from_ne_bytes((hand_mem.read_fixed(args[1]) as i32).to_ne_bytes());
     let out = if a >= b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("gtef64", |args, hand_mem| {
+  cpu!(gtef64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let b = f64::from_ne_bytes(hand_mem.read_fixed(args[1]).to_ne_bytes());
     let out = if a >= b { 1i64 } else { 0i64 };
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("gtestr", |args, hand_mem| {
+  cpu!(gtestr => fn(args, hand_mem) {
     let a_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let b_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
     let out = if a_str >= b_str { 1i64 } else { 0i64 };
@@ -2001,14 +2034,14 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
   });
 
   // String opcodes
-  cpu!("catstr", |args, hand_mem| {
+  cpu!(catstr => fn(args, hand_mem) {
     let a_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let b_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
     let out_str = format!("{}{}", a_str, b_str);
     hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&out_str));
     None
   });
-  cpu!("split", |args, hand_mem| {
+  cpu!(split => fn(args, hand_mem) {
     let a_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let b_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
     let out_hms = a_str.split(&b_str).map(|out_str| HandlerMemory::str_to_fractal(&out_str));
@@ -2018,14 +2051,14 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("repstr", |args, hand_mem| {
+  cpu!(repstr => fn(args, hand_mem) {
     let a_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let n = hand_mem.read_fixed(args[1]);
     let out_str = a_str.repeat(n as usize);
     hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&out_str));
     None
   });
-  cpu!("matches", |args, hand_mem| {
+  cpu!(matches => fn(args, hand_mem) {
     let a_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let b_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
     let b_regex = Regex::new(&b_str).unwrap();
@@ -2033,7 +2066,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     hand_mem.write_fixed(args[2], out);
     None
   });
-  cpu!("indstr", |args, hand_mem| {
+  cpu!(indstr => fn(args, hand_mem) {
     let a_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let b_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
     let out_option = a_str.find(&b_str);
@@ -2048,13 +2081,13 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("lenstr", |args, hand_mem| {
+  cpu!(lenstr => fn(args, hand_mem) {
     let pascal_string = hand_mem.read_fractal(args[0]);
     let val = pascal_string.read_fixed(0);
     hand_mem.write_fixed(args[2], val);
     None
   });
-  cpu!("trim", |args, hand_mem| {
+  cpu!(trim => fn(args, hand_mem) {
     let in_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     let out_str = in_str.trim();
     hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&out_str));
@@ -2062,7 +2095,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
   });
 
   // Array opcodes
-  cpu!("register", |args, hand_mem| {
+  cpu!(register => fn(args, hand_mem) {
     // args[2] is the register address
     // args[0] point to an array in memory
     // args[1] is the address within the array to register
@@ -2070,7 +2103,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     hand_mem.register_out(args[0], inner_addr as usize, args[2]);
     None
   });
-  cpu!("copyfrom", |args, hand_mem| {
+  cpu!(copyfrom => fn(args, hand_mem) {
     // args = [arr_addr, arr_idx_addr, outer_addr]
     // copy data from outer_addr to inner_addr of the array in reg_addr
     // The array index instead of inner address is provided to keep interaction with the js-runtime
@@ -2079,27 +2112,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     hand_mem.register_out(args[0], inner_addr as usize, args[2]);
     None
   });
-  cpu!("copytof", |args, hand_mem| {
+  cpu!(copytof => fn(args, hand_mem) {
     // args = [arr_addr, inner_addr, outer_addr]
     // copy data from outer_addr to inner_addr in arr_addr
     let inner = hand_mem.read_fixed(args[1]);
     hand_mem.register_in(args[2], args[0], inner);
     None
   });
-  cpu!("copytov", |args, hand_mem| {
+  cpu!(copytov => fn(args, hand_mem) {
     // args = [arr_addr, inner_addr, outer_addr]
     // copy data from outer_addr to inner_addr in arr_addr
     let inner = hand_mem.read_fixed(args[1]);
     hand_mem.register_in(args[2], args[0], inner);
     None
   });
-  cpu!("lenarr", |args, hand_mem| {
+  cpu!(lenarr => fn(args, hand_mem) {
     let arr = hand_mem.read_fractal(args[0]);
     let len = arr.len() as i64;
     hand_mem.write_fixed(args[2], len);
     None
   });
-  cpu!("indarrf", |args, hand_mem| {
+  cpu!(indarrf => fn(args, hand_mem) {
     let val = hand_mem.read_fixed(args[1]);
     let mem = hand_mem.read_fractal(args[0]);
     let len = mem.len();
@@ -2108,7 +2141,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       let check = mem.read_fixed(i);
       if val == check {
         idx = i as i64;
-        break
+        break;
       }
     }
     hand_mem.init_fractal(args[2]);
@@ -2121,60 +2154,58 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("indarrv", |args, hand_mem| {
+  cpu!(indarrv => fn(args, hand_mem) {
     let val = hand_mem.read_fractal(args[1]);
     let fractal = hand_mem.read_fractal(args[0]);
-    let mut idx = -1i64;
+    let mut idx: Option<i64> = None;
     for i in 0..fractal.len() {
-      let (check, is_fractal) = hand_mem.read_from_fractal(&fractal, i);
-      if is_fractal {
+      if let (check, true) = hand_mem.read_from_fractal(&fractal, i) {
         // TODO: equality comparisons for nested arrays, for now, assume it's string-like
         if val.len() != check.len() {
-          continue
+          continue;
         }
         let mut matches = true;
         for j in 0..val.len() {
           if !val.compare_at(j, &check) {
             matches = false;
-            break
+            break;
           }
         }
         if matches {
-          idx = i as i64;
-          break
+          idx = Some(i as i64);
+          break;
         }
-      } else {
-        continue
       }
+      // the else branch originally just had `continue`
     }
     hand_mem.init_fractal(args[2]);
-    if idx == -1i64 {
-      hand_mem.push_fixed(args[2], 0i64);
-      hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal("element not found"));
-    } else {
+    if let Some(idx) = idx {
       hand_mem.push_fixed(args[2], 1i64);
       hand_mem.push_fixed(args[2], idx);
+    } else {
+      hand_mem.push_fixed(args[2], 0i64);
+      hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal("element not found"));
     }
     None
   });
-  cpu!("join", |args, hand_mem| {
+  cpu!(join => fn(args, hand_mem) {
     let sep_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
     let fractal = hand_mem.read_fractal(args[0]);
-    let mut strs: Vec<String> = Vec::new();
+    let mut strs = Vec::with_capacity(fractal.len());
     for i in 0..fractal.len() {
-      let (data, is_fractal) = hand_mem.read_from_fractal(&fractal, i);
-      if is_fractal {
-        let v_str = HandlerMemory::fractal_to_string(data);
-        strs.push(v_str);
-      } else {
-        // TODO: Skip for now
+      match hand_mem.read_from_fractal(&fractal, i) {
+        (data, true) => {
+          let v_str = HandlerMemory::fractal_to_string(data);
+          strs.push(v_str);
+        },
+        (_, false) => todo!("handle joining non-fractal strings I think?"),
       }
     }
     let out_str = strs.join(&sep_str);
     hand_mem.write_fractal(args[2], &HandlerMemory::str_to_fractal(&out_str));
     None
   });
-  cpu!("pusharr", |args, hand_mem| {
+  cpu!(pusharr => fn(args, hand_mem) {
     let val_size = hand_mem.read_fixed(args[2]);
     if val_size == 0 {
       hand_mem.push_register(args[0], args[1]);
@@ -2184,45 +2215,47 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("poparr", |args, hand_mem| {
+  cpu!(poparr => fn(args, hand_mem) {
     let last = hand_mem.pop(args[0]);
     hand_mem.init_fractal(args[2]);
-    if last.is_ok() {
-      hand_mem.push_fixed(args[2], 1i64);
-      let record = last.ok().unwrap();
-      hand_mem.push_register_out(args[2], &record, 0);
-    } else {
-      hand_mem.push_fixed(args[2], 0i64);
-      let error_string = last.err().unwrap();
-      hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(&error_string));
+    match last {
+      Ok(record) => {
+        hand_mem.push_fixed(args[2], 1i64);
+        hand_mem.push_register_out(args[2], &record, 0);
+      },
+      Err(error_string) => {
+        hand_mem.push_fixed(args[2], 0i64);
+        hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(&error_string));
+      },
     }
     None
   });
-  cpu!("delindx", |args, hand_mem| {
+  cpu!(delindx => fn(args, hand_mem) {
     let idx = hand_mem.read_fixed(args[1]) as usize;
     let el = hand_mem.delete(args[0], idx);
     hand_mem.init_fractal(args[2]);
-    if el.is_ok() {
-      hand_mem.push_fixed(args[2], 1i64);
-      let record = el.ok().unwrap();
-      hand_mem.push_register_out(args[2], &record, 0);
-    } else {
-      hand_mem.push_fixed(args[2], 0i64);
-      let error_string = el.err().unwrap();
-      hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(&error_string));
+    match el {
+      Ok(record) => {
+        hand_mem.push_fixed(args[2], 1i64);
+        hand_mem.push_register_out(args[2], &record, 0);
+      },
+      Err(error_string) => {
+        hand_mem.push_fixed(args[2], 0i64);
+        hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(&error_string));
+      },
     }
     None
   });
-  cpu!("newarr", |args, hand_mem| {
+  cpu!(newarr => fn(args, hand_mem) {
     hand_mem.init_fractal(args[2]);
     None
   });
-  io!("map", |args, hand_mem| {
+  io!(map => fn(args, mut hand_mem) {
     Box::pin(async move {
       let hand_mem_ref = Arc::new(hand_mem);
       let fractal = hand_mem_ref.read_fractal(args[0]);
       let subhandler = HandlerFragment::new(args[1], 0);
-      let mut mappers = Vec::new();
+      let mut mappers = Vec::with_capacity(fractal.len());
       for i in 0..fractal.len() {
         let mut hm = HandlerMemory::fork(Arc::clone(&hand_mem_ref));
         hm.register_out(args[0], i, CLOSURE_ARG_MEM_START + 1);
@@ -2242,7 +2275,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("mapl", |args, mut hand_mem| {
+  io!(mapl => fn(args, mut hand_mem) {
     Box::pin(async move {
       let fractal = hand_mem.read_fractal(args[0]);
       let subhandler = HandlerFragment::new(args[1], 0);
@@ -2256,36 +2289,39 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  cpu!("reparr", |args, hand_mem| {
+  cpu!(reparr => fn(args, hand_mem) {
     hand_mem.init_fractal(args[2]);
     let n = hand_mem.read_fixed(args[1]);
+    if n == 0 {
+      return None;
+    }
     let fractal = hand_mem.read_fractal(args[0]);
     let mut is_fixed = true;
-    let mut output: Vec<FractalMemory> = vec![];
-    for i in 0..n {
-      for j in 0..fractal.len() {
-        let (val, is_fractal) = hand_mem.read_from_fractal(&fractal, j);
-        output.push(val);
-        if i == 0 && is_fractal {
-          is_fixed = false;
-        }
+    let mut arr = Vec::with_capacity(fractal.len());
+    for i in 0..fractal.len() {
+      let (val, is_fractal) = hand_mem.read_from_fractal(&fractal, i);
+      arr.push(val);
+      if is_fractal {
+        is_fixed = false;
       }
     }
-    for val in output {
-      if is_fixed {
-        hand_mem.push_fixed(args[2], val.read_fixed(0));
-      } else {
-        hand_mem.push_fractal(args[2], val);
+    for _ in 0..n {
+      for val in arr.iter() {
+        if is_fixed {
+          hand_mem.push_fixed(args[2], val.read_fixed(0));
+        } else {
+          hand_mem.push_fractal(args[2], val.clone());
+        }
       }
     }
     None
   });
-  io!("each", |args, hand_mem| {
+  io!(each => fn(args, hand_mem) {
     Box::pin(async move {
       let hand_mem_ref = Arc::new(hand_mem);
       let fractal = hand_mem_ref.read_fractal(args[0]);
       let subhandler = HandlerFragment::new(args[1], 0);
-      let mut runners = Vec::new();
+      let mut runners = Vec::with_capacity(fractal.len());
       for i in 0..fractal.len() {
         let mut hm = HandlerMemory::fork(Arc::clone(&hand_mem_ref));
         hm.register_out(args[0], i, CLOSURE_ARG_MEM_START + 1);
@@ -2299,7 +2335,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       Arc::try_unwrap(hand_mem_ref).expect("Dangling reference to parent HM in parallel opcode")
     })
   });
-  io!("eachl", |args, mut hand_mem| {
+  io!(eachl => fn(args, mut hand_mem) {
     Box::pin(async move {
       let fractal = hand_mem.read_fractal(args[0]);
       let subhandler = HandlerFragment::new(args[1], 0);
@@ -2311,22 +2347,22 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("find", |args, hand_mem| {
+  io!(find => fn(args, mut hand_mem) {
     Box::pin(async move {
       let hand_mem_ref = Arc::new(hand_mem);
-      let fractal = hand_mem_ref.read_fractal(args[0]);
+      let fractal = hand_mem.read_fractal(args[0]);
       let len = fractal.len();
       let subhandler = HandlerFragment::new(args[1], 0);
-      let mut finders = Vec::new();
+      let mut finders = Vec::with_capacity(fractal.len());
       for i in 0..len {
         let mut hm = HandlerMemory::fork(Arc::clone(&hand_mem_ref));
         hm.register_out(args[0], i, CLOSURE_ARG_MEM_START + 1);
         finders.push(subhandler.clone().run(hm));
       }
-      let mut hms = join_all(finders).await;
+      let hms = join_all(finders).await;
       let mut idx = None;
-      for i in 0..len {
-        let hm = &mut hms[i];
+      for i in 0..len() {
+        let hm = &hms[i];
         let val = hm.read_fixed(CLOSURE_ARG_MEM_START);
         hm.drop_parent();
         if idx.is_none() && val == 1 {
@@ -2345,7 +2381,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("findl", |args, mut hand_mem| {
+  io!(findl => fn(args, mut hand_mem) {
     Box::pin(async move {
       let fractal = hand_mem.read_fractal(args[0]);
       let subhandler = HandlerFragment::new(args[1], 0);
@@ -2366,12 +2402,12 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("some", |args, hand_mem| {
+  io!(some => fn(args, mut hand_mem) {
     Box::pin(async move {
       let hand_mem_ref = Arc::new(hand_mem);
       let fractal = hand_mem_ref.read_fractal(args[0]);
       let subhandler = HandlerFragment::new(args[1], 0);
-      let mut somers = Vec::new();
+      let mut somers = Vec::with_capacity(fractal.len());
       for i in 0..fractal.len() {
         let mut hm = HandlerMemory::fork(Arc::clone(&hand_mem_ref));
         hm.register_out(args[0], i, CLOSURE_ARG_MEM_START + 1);
@@ -2391,7 +2427,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("somel", |args, mut hand_mem| {
+  io!(somel => fn(args, mut hand_mem) {
     Box::pin(async move {
       let fractal = hand_mem.read_fractal(args[0]);
       let subhandler = HandlerFragment::new(args[1], 0);
@@ -2408,12 +2444,12 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("every", |args, hand_mem| {
+  io!(every => fn(args, mut hand_mem) {
     Box::pin(async move {
       let hand_mem_ref = Arc::new(hand_mem);
       let fractal = hand_mem_ref.read_fractal(args[0]);
       let subhandler = HandlerFragment::new(args[1], 0);
-      let mut somers = Vec::new();
+      let mut somers = Vec::with_capacity(fractal.len());
       for i in 0..fractal.len() {
         let mut hm = HandlerMemory::fork(Arc::clone(&hand_mem_ref));
         hm.register_out(args[0], i, CLOSURE_ARG_MEM_START + 1);
@@ -2433,7 +2469,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("everyl", |args, mut hand_mem| {
+  io!(everyl => fn(args, mut hand_mem) {
     Box::pin(async move {
       let fractal = hand_mem.read_fractal(args[0]);
       let subhandler = HandlerFragment::new(args[1], 0);
@@ -2450,7 +2486,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  cpu!("catarr", |args, hand_mem| {
+  cpu!(catarr => fn(args, hand_mem) {
     let fractal1 = hand_mem.read_fractal(args[0]);
     let fractal2 = hand_mem.read_fractal(args[1]);
     hand_mem.init_fractal(args[2]);
@@ -2462,10 +2498,10 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  io!("reducep", |args, mut hand_mem| {
+  io!(reducep => fn(args, mut hand_mem) {
     Box::pin(async move {
       let fractal = hand_mem.read_fractal(args[0]);
-      let mut vals: Vec<HandlerMemory> = vec![];
+      let mut vals = Vec::with_capacity(fractal.len());
       for i in 0..fractal.len() {
         let mut hm = HandlerMemory::new(None, 1);
         hand_mem.register_out(args[0], i, CLOSURE_ARG_MEM_START);
@@ -2475,7 +2511,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       let subhandler = HandlerFragment::new(args[1], 0);
       // Log-n parallelism. First n/2 in parallel, then n/4, then n/8, etc
       while vals.len() > 1 {
-        let mut reducers = Vec::new();
+        let mut reducers = Vec::with_capacity((vals.len() / 2) + 1);
         while vals.len() > 1 {
           let mut hm = hand_mem.clone();
           let a = vals.remove(0);
@@ -2492,8 +2528,8 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
           hm.register(0, CLOSURE_ARG_MEM_START, false);
           vals.push(hm);
         }
-        if maybe_hm.is_some() {
-          vals.push(maybe_hm.unwrap());
+        if let Some(hm) = maybe_hm {
+          vals.push(hm);
         }
       }
       // There can be only one
@@ -2501,13 +2537,13 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("reducel", |args, mut hand_mem| {
+  io!(reducel => fn(args, mut hand_mem) {
     Box::pin(async move {
       let fractal = hand_mem.read_fractal(args[0]);
       if fractal.len() == 0 {
         return hand_mem;
       }
-      let mut vals: Vec<HandlerMemory> = vec![];
+      let mut vals = Vec::with_capacity(fractal.len());
       for i in 0..fractal.len() {
         let mut hm = HandlerMemory::new(None, 1);
         hand_mem.register_out(args[0], i, CLOSURE_ARG_MEM_START);
@@ -2527,11 +2563,11 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("foldp", |args, mut hand_mem| {
+  io!(foldp => fn(args, mut hand_mem) {
     Box::pin(async move {
       let obj = hand_mem.read_fractal(args[0]);
       let (arr, _) = hand_mem.read_from_fractal(&obj, 0);
-      let mut vals: Vec<HandlerMemory> = vec![];
+      let mut vals = Vec::with_capacity(arr.len());
       for i in 0..arr.len() {
         let mut hm = HandlerMemory::new(None, 1);
         hand_mem.register_from_fractal(CLOSURE_ARG_MEM_START, &arr, i);
@@ -2546,12 +2582,12 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       let n = num_cpus::get();
       let l = vals.len();
       let s = l / n;
-      let mut reducers = Vec::new();
+      let mut reducers = Vec::with_capacity(n);
       for i in 0..n {
         let subvals = if i == n - 1 {
-          vals[i*s..].to_vec()
+          vals[i * s..].to_vec()
         } else {
-          vals[i*s..(i+1)*s].to_vec()
+          vals[i * s..(i + 1) * s].to_vec()
         };
         let mem = hand_mem.clone();
         let init2 = init.clone();
@@ -2579,11 +2615,11 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("foldl", |args, mut hand_mem| {
+  io!(foldl => fn(args, mut hand_mem) {
     Box::pin(async move {
       let obj = hand_mem.read_fractal(args[0]);
       let (arr, _) = hand_mem.read_from_fractal(&obj, 0);
-      let mut vals: Vec<HandlerMemory> = vec![];
+      let mut vals = Vec::with_capacity(arr.len());
       for i in 0..arr.len() {
         let mut hm = HandlerMemory::new(None, 1);
         hand_mem.register_from_fractal(CLOSURE_ARG_MEM_START, &arr, i);
@@ -2605,13 +2641,13 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("filter", |args, hand_mem| {
+  io!(filter => fn(args, mut hand_mem) {
     Box::pin(async move {
       let hand_mem_ref = Arc::new(hand_mem);
       let fractal = hand_mem_ref.read_fractal(args[0]);
       let len = fractal.len();
       let subhandler = HandlerFragment::new(args[1], 0);
-      let mut filters = Vec::new();
+      let mut filters = Vec::with_capacity(len);
       for i in 0..len {
         let mut hm = HandlerMemory::fork(Arc::clone(&hand_mem_ref));
         hm.register_out(args[0], i, CLOSURE_ARG_MEM_START + 1);
@@ -2635,7 +2671,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("filterl", |args, mut hand_mem| {
+  io!(filterl => fn(args, mut hand_mem) {
     Box::pin(async move {
       let fractal = hand_mem.read_fractal(args[0]);
       let len = fractal.len();
@@ -2652,8 +2688,9 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
+
   // Conditional opcode
-  io!("condfn", |args, mut hand_mem| {
+  io!(condfn => fn(args, mut hand_mem) {
     Box::pin(async move {
       let cond = hand_mem.read_fixed(args[0]);
       let subhandler = HandlerFragment::new(args[1], 0);
@@ -2663,8 +2700,9 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
+
   // Std opcodes
-  io!("execop", |args, mut hand_mem| {
+  io!(execop => fn(args, mut hand_mem) {
     Box::pin(async move {
       let full_cmd = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
       let split_cmd: Vec<&str> = full_cmd.split(" ").collect();
@@ -2689,64 +2727,59 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
+
   // IO opcodes
-  io!("waitop", |args, hand_mem| {
+  io!(waitop => fn(args, hand_mem) {
     Box::pin(async move {
       let ms = hand_mem.read_fixed(args[0]) as u64;
       sleep(Duration::from_millis(ms)).await;
       hand_mem
     })
   });
-  io!("httpget", |args, mut hand_mem| {
+
+  async fn __httpget(uri: String) -> std::result::Result<String, Box<dyn std::error::Error>> {
+    let url = TryInto::<Uri>::try_into(uri)?;
+    let mut response = Client::builder()
+      .build::<_, Body>(HttpsConnector::new())
+      .get(url)
+      .await?;
+    let body = hyper::body::to_bytes(response.body_mut()).await?;
+    let res = String::from_utf8(body.to_vec())?;
+    Ok(res)
+  }
+  io!(httpget => fn(args, mut hand_mem) {
     Box::pin(async move {
-      let (res, ok) = match TryInto::<Uri>::try_into(HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]))) {
-        Err(ee) => (format!("{}", ee), false),
-        Ok(url) => match Client::builder().build::<_, Body>(HttpsConnector::new()).get(url.clone()).await {
-          Err(ee) => (format!("{}", ee), false),
-          Ok(mut response) => match hyper::body::to_bytes(response.body_mut()).await {
-            Err(ee) => (format!("{}", ee), false),
-            Ok(body) => if let Ok(res) = String::from_utf8(body.to_vec()) {
-              (res, true)
-            } else {
-              (format!("could not parse"), false)
-            },
-          },
-        },
-      };
+      let res = __httpget(HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]))).await;
       hand_mem.init_fractal(args[2]);
-      hand_mem.push_fixed(args[2], if ok { 1i64 } else { 0i64 });
-      hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(&res));
+      hand_mem.push_fixed(args[2], if res.is_ok() { 1i64 } else { 0i64 });
+      match res {
+        Ok(res) => hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(&res)),
+        Err(ee) => hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(format!("{}", ee).as_str())),
+      }
       hand_mem
     })
   });
-  io!("httppost", |args, mut hand_mem| {
+
+  async fn __httppost(uri: String, payload: String) -> Result<String, Box<dyn std::error::Error>> {
+    let url = TryInto::<Uri>::try_into(uri)?;
+    let request = Request::post(url).body(Body::from(payload))?;
+    let client = Client::builder().build::<_, Body>(HttpsConnector::new());
+    let mut response = client.request(request).await?;
+    let body = hyper::body::to_bytes(response.body_mut()).await?;
+    let res = String::from_utf8(body.to_vec())?;
+    Ok(res)
+  }
+  io!(httppost => fn(args, mut hand_mem) {
     Box::pin(async move {
+      let uri = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
       let payload = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
-      let (res, ok) = match TryInto::<Uri>::try_into(HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]))) {
-        Err(ee) => (format!("{}", ee), false),
-        Ok(url) => {
-          match Request::post(&url).body(Body::from(payload.clone())) {
-            Err(ee) => (format!("{}", ee), false),
-            Ok(request) => {
-              let client = Client::builder().build::<_, Body>(HttpsConnector::new());
-              match client.request(request).await {
-                Err(ee) => (format!("{}", ee), false),
-                Ok(mut response) => match hyper::body::to_bytes(response.body_mut()).await {
-                  Err(ee) => (format!("{}", ee), false),
-                  Ok(body) => if let Ok(res) = String::from_utf8(body.to_vec()) {
-                    (res, true)
-                  } else {
-                    ("could not parse".to_string(), false)
-                  },
-                },
-              }
-            }
-          }
-        }
-      };
+      let res = __httppost(uri, payload).await;
       hand_mem.init_fractal(args[2]);
-      hand_mem.push_fixed(args[2], if ok { 1i64 } else { 0i64 });
-      hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(&res));
+      hand_mem.push_fixed(args[2], if res.is_ok() { 1i64 } else { 0i64 });
+      match res {
+        Ok(res) => hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(&res)),
+        Err(ee) => hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(format!("{}", ee).as_str())),
+      }
       hand_mem
     })
   });
@@ -2770,12 +2803,14 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       i = i + 1;
     }
     // Grab the body, if any
-    let body_req = hyper::body::to_bytes(req.into_body()).await;
-    // If we error out while getting the body, just close this listener out immediately
-    if body_req.is_err() {
-      return Ok(Response::new("Conection terminated".into()));
-    }
-    let body_str = str::from_utf8(&body_req.unwrap()).unwrap().to_string();
+    let body_req = match hyper::body::to_bytes(req.into_body()).await {
+      Ok(bytes) => bytes,
+      // If we error out while getting the body, just close this listener out immediately
+      Err(ee) => {
+        return Ok(Response::new(format!("Connection terminated: {}", ee).into()));
+      }
+    };
+    let body_str = str::from_utf8(&body_req).unwrap().to_string();
     let body = HandlerMemory::str_to_fractal(&body_str);
     // Generate a connection ID
     let conn_id = OsRng.next_u64() as i64;
@@ -2802,19 +2837,22 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     let response_hm = poll_fn(|cx: &mut Context<'_>| -> Poll<HandlerMemory> {
       let responses_hm = responses.lock().unwrap();
       let hm = responses_hm.get(&conn_id);
-      if hm.is_some() {
-        Poll::Ready(hm.unwrap().clone())
+      if let Some(hm) = hm {
+        Poll::Ready(hm.clone())
       } else {
         drop(hm);
         drop(responses_hm);
         let waker = cx.waker().clone();
+        // TODO: os threads are quite expensive and could cause our runtime to
+        // stop executing, this might be a point of optimization:
         thread::spawn(|| {
           thread::sleep(Duration::from_millis(10));
           waker.wake();
         });
         Poll::Pending
       }
-    }).await;
+    })
+    .await;
     // Get the status from the user response and begin building the response object
     let status = response_hm.read_fixed(0) as u16;
     let mut res = Response::builder().status(StatusCode::from_u16(status).unwrap());
@@ -2835,34 +2873,27 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     let body = HandlerMemory::fractal_to_string(response_hm.read_fractal(2));
     Ok(res.body(body.into()).unwrap())
   }
-
-  io!("httplsn", |args, mut hand_mem| {
+  io!(httplsn => fn(args, mut hand_mem) {
     Box::pin(async move {
       let port_num = hand_mem.read_fixed(args[0]) as u16;
       let addr = SocketAddr::from(([127, 0, 0, 1], port_num));
-      let make_svc = make_service_fn(|_conn| async {
-        Ok::<_, Infallible>(service_fn(http_listener))
-      });
+      let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(http_listener)) });
 
       let bind = Server::try_bind(&addr);
       hand_mem.init_fractal(args[2]);
-      if bind.is_err() {
-        hand_mem.push_fixed(args[2], 0i64);
-        let result_str = format!("{}", bind.err().unwrap());
-        hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(&result_str));
-        return hand_mem;
-      } else {
-        hand_mem.push_fixed(args[2], 1i64);
-        hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("ok"));
+      hand_mem.push_fixed(args[2], if bind.is_ok() { 1i64 } else { 0i64 });
+      match bind {
+        Ok(server) => {
+          hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("ok"));
+          let server = server.serve(make_svc);
+          tokio::spawn(async move { server.await });
+        },
+        Err(ee) => hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(format!("{}", ee).as_str())),
       }
-      let server = bind.unwrap().serve(make_svc);
-      tokio::spawn(async move {
-        server.await
-      });
-      hand_mem
+      return hand_mem;
     })
   });
-  io!("httpsend", |args, mut hand_mem| {
+  io!(httpsend => fn(args, mut hand_mem) {
     Box::pin(async move {
       hand_mem.dupe(args[0], args[0]); // Make sure there's no pointers involved
       let fractal = hand_mem.read_fractal(args[0]);
@@ -2885,10 +2916,12 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("dssetf", |args, hand_mem| {
+
+  // Datastore opcodes
+  io!(dssetf => fn(args, hand_mem) {
     Box::pin(async move {
       let val = hand_mem.read_fixed(args[2]);
-      let mut hm = HandlerMemory::new(None, 1); 
+      let mut hm = HandlerMemory::new(None, 1);
       hm.write_fixed(0, val);
       let ns = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
       let key = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
@@ -2898,7 +2931,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("dssetv", |args, hand_mem| {
+  io!(dssetv => fn(args, hand_mem) {
     Box::pin(async move {
       let mut hm = HandlerMemory::new(None, 1);
       HandlerMemory::transfer(&hand_mem, args[2], &mut hm, 0);
@@ -2910,7 +2943,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("dshas", |args, mut hand_mem| {
+  io!(dshas => fn(args, mut hand_mem) {
     Box::pin(async move {
       let ns = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
       let key = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
@@ -2921,7 +2954,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("dsdel", |args, mut hand_mem| {
+  io!(dsdel => fn(args, mut hand_mem) {
     Box::pin(async move {
       let ns = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
       let key = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
@@ -2932,7 +2965,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("dsgetf", |args, mut hand_mem| {
+  io!(dsgetf => fn(args, mut hand_mem) {
     Box::pin(async move {
       let ns = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
       let key = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
@@ -2940,18 +2973,15 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       let ds = Arc::clone(&DS);
       let maybe_hm = ds.get(&nskey);
       hand_mem.init_fractal(args[2]);
-      if maybe_hm.is_some() {
-        hand_mem.push_fixed(args[2], 1i64);
-        hand_mem.push_fixed(args[2], maybe_hm.unwrap().read_fixed(0));
-      } else {
-        hand_mem.push_fixed(args[2], 0i64);
-        let err_msg = "namespace-key pair not found";
-        hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(&err_msg));
+      hand_mem.push_fixed(args[2], if maybe_hm.is_some() { 1i64 } else { 0i64 });
+      match maybe_hm {
+        Some(hm) => hand_mem.push_fixed(args[2], hm.read_fixed(0)),
+        None => hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("namespace-key pair not found")),
       }
       hand_mem
     })
   });
-  io!("dsgetv", |args, mut hand_mem| {
+  io!(dsgetv => fn(args, mut hand_mem) {
     Box::pin(async move {
       let ns = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
       let key = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[1]));
@@ -2959,26 +2989,26 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       let ds = Arc::clone(&DS);
       let maybe_hm = ds.get(&nskey);
       hand_mem.init_fractal(args[2]);
-      if maybe_hm.is_some() {
-        hand_mem.push_fixed(args[2], 1i64);
-        let hm = maybe_hm.unwrap();
-        HandlerMemory::transfer(&hm, 0, &mut hand_mem, CLOSURE_ARG_MEM_START);
-        hand_mem.push_register(args[2], CLOSURE_ARG_MEM_START);
-      } else {
-        hand_mem.push_fixed(args[2], 0i64);
-        let err_msg = "namespace-key pair not found";
-        hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal(&err_msg));
+      match maybe_hm {
+        Some(hm) => {
+          hand_mem.push_fixed(args[2], 1i64);
+          HandlerMemory::transfer(&hm, 0, &mut hand_mem, CLOSURE_ARG_MEM_START);
+          hand_mem.push_register(args[2], CLOSURE_ARG_MEM_START);
+        },
+        None => hand_mem.push_fractal(args[2], HandlerMemory::str_to_fractal("namespace-key pair not found")),
       }
       hand_mem
     })
   });
-  cpu!("newseq", |args, hand_mem| {
+
+  // seq opcodes
+  cpu!(newseq => fn(args, hand_mem) {
     hand_mem.init_fractal(args[2]);
     hand_mem.push_fixed(args[2], 0i64);
     hand_mem.push_fixed(args[2], hand_mem.read_fixed(args[0]));
     None
   });
-  cpu!("seqnext", |args, hand_mem| {
+  cpu!(seqnext => fn(args, hand_mem) {
     hand_mem.init_fractal(args[2]);
     let mut seq = hand_mem.read_fractal(args[0]);
     let current = seq.read_fixed(0);
@@ -2994,7 +3024,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  io!("seqeach", |args, mut hand_mem| {
+  io!(seqeach => fn(args, mut hand_mem) {
     Box::pin(async move {
       let mut seq = hand_mem.read_fractal(args[0]);
       let current = seq.read_fixed(0);
@@ -3013,7 +3043,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("seqwhile", |args, mut hand_mem| {
+  io!(seqwhile => fn(args, mut hand_mem) {
     Box::pin(async move {
       let seq = hand_mem.read_fractal(args[0]);
       let mut current = seq.read_fixed(0);
@@ -3035,7 +3065,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("seqdo", |args, mut hand_mem| {
+  io!(seqdo => fn(args, mut hand_mem) {
     Box::pin(async move {
       let seq = hand_mem.read_fractal(args[0]);
       let mut current = seq.read_fixed(0);
@@ -3054,7 +3084,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!("selfrec", |args, hand_mem| {
+  io!(selfrec => fn(args, mut hand_mem) {
     Box::pin(async move {
       let hand_mem_ref = Arc::new(hand_mem);
       let mut hm = HandlerMemory::fork(Arc::clone(&hand_mem_ref));
@@ -3083,225 +3113,218 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  cpu!("seqrec", |args, hand_mem| {
+  cpu!(seqrec => fn(args, hand_mem) {
     hand_mem.init_fractal(args[2]);
     hand_mem.push_register(args[2], args[0]);
     hand_mem.push_fixed(args[2], args[1]);
     None
   });
+
   // "Special" opcodes
-  cpu!("exitop", |args, hand_mem| {
+  cpu!(exitop => fn(args, hand_mem) {
     std::process::exit(hand_mem.read_fixed(args[0]) as i32);
   });
-  cpu!("stdoutp", |args, hand_mem| {
+  cpu!(stdoutp => fn(args, hand_mem) {
     let out_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     print!("{}", out_str);
     None
   });
-  cpu!("stderrp", |args, hand_mem| {
+  cpu!(stderrp => fn(args, hand_mem) {
     let err_str = HandlerMemory::fractal_to_string(hand_mem.read_fractal(args[0]));
     eprint!("{}", err_str);
     None
   });
+
   // set opcodes use args[0] directly, since the relevant value directly
   // fits in i64, and write it to args[2]
-  cpu!("seti64", |args, hand_mem| {
+  cpu!(seti64 => fn(args, hand_mem) {
     let data = args[0];
     hand_mem.write_fixed(args[2], data);
     None
   });
-  cpu!("seti32", |args, hand_mem| {
+  cpu!(seti32 => fn(args, hand_mem) {
     let data = (args[0] as i32) as i64;
     hand_mem.write_fixed(args[2], data);
     None
   });
-  cpu!("seti16", |args, hand_mem| {
+  cpu!(seti16 => fn(args, hand_mem) {
     let data = (args[0] as i16) as i64;
     hand_mem.write_fixed(args[2], data);
     None
   });
-  cpu!("seti8", |args, hand_mem| {
+  cpu!(seti8 => fn(args, hand_mem) {
     let data = (args[0] as i8) as i64;
     hand_mem.write_fixed(args[2], data);
     None
   });
-  cpu!("setf64", |args, hand_mem| {
+  cpu!(setf64 => fn(args, hand_mem) {
     let data = i64::from_ne_bytes((args[0] as f64).to_ne_bytes());
     hand_mem.write_fixed(args[2], data);
     None
   });
-  cpu!("setf32", |args, hand_mem| {
+  cpu!(setf32 => fn(args, hand_mem) {
     let data = i32::from_ne_bytes((args[0] as f32).to_ne_bytes()) as i64;
     hand_mem.write_fixed(args[2], data);
     None
   });
-  cpu!("setbool", |args, hand_mem| {
+  cpu!(setbool => fn(args, hand_mem) {
     let data = if args[0] == 0 { 0i64 } else { 1i64 };
     hand_mem.write_fixed(args[2], data);
     None
   });
-  cpu!("setestr", |args, hand_mem| {
+  cpu!(setestr => fn(args, hand_mem) {
     let empty_str = FractalMemory::new(vec![(0, 0)]);
     hand_mem.write_fractal(args[2], &empty_str);
     None
   });
 
   // copy opcodes used for let variable reassignments
-  cpu!("copyi8", |args, hand_mem| {
+  cpu!(copyi8 => fn(args, hand_mem) {
     let val = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], val);
     None
   });
-  cpu!("copyi16", |args, hand_mem| {
+  cpu!(copyi16 => fn(args, hand_mem) {
     let val = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], val);
     None
   });
-  cpu!("copyi32", |args, hand_mem| {
+  cpu!(copyi32 => fn(args, hand_mem) {
     let val = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], val);
     None
   });
-  cpu!("copyi64", |args, hand_mem| {
+  cpu!(copyi64 => fn(args, hand_mem) {
     let val = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], val);
     None
   });
-  cpu!("copyvoid", |args, hand_mem| {
+  cpu!(copyvoid => fn(args, hand_mem) {
     let val = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], val);
     None
   });
-  cpu!("copyf32", |args, hand_mem| {
+  cpu!(copyf32 => fn(args, hand_mem) {
     let val = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], val);
     None
   });
-  cpu!("copyf64", |args, hand_mem| {
+  cpu!(copyf64 => fn(args, hand_mem) {
     let val = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], val);
     None
   });
-  cpu!("copybool", |args, hand_mem| {
+  cpu!(copybool => fn(args, hand_mem) {
     let val = hand_mem.read_fixed(args[0]);
     hand_mem.write_fixed(args[2], val);
     None
   });
-  cpu!("copystr", |args, hand_mem| {
+  cpu!(copystr => fn(args, hand_mem) {
     let pascal_string = hand_mem.read_fractal(args[0]);
     hand_mem.write_fractal(args[2], &pascal_string);
     None
   });
-  cpu!("copyarr", |args, hand_mem| {
+  cpu!(copyarr => fn(args, hand_mem) {
     // args = [in_addr, unused, out_addr]
     hand_mem.dupe(args[0], args[2]);
     None
   });
-  cpu!("zeroed", |args, hand_mem| {
+  cpu!(zeroed => fn(args, hand_mem) {
     hand_mem.write_fixed(args[2], 0);
     None
   });
 
   // Trig opcodes
-  cpu!("lnf64", |args, hand_mem| {
+  cpu!(lnf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(a.ln().to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
-
-  cpu!("logf64", |args, hand_mem| {
+  cpu!(logf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(a.log10().to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
-
-  cpu!("sinf64", |args, hand_mem| {
+  cpu!(sinf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(a.sin().to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
-
-  cpu!("cosf64", |args, hand_mem| {
+  cpu!(cosf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(a.cos().to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
-
-  cpu!("tanf64", |args, hand_mem| {
+  cpu!(tanf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(a.tan().to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
-
-  cpu!("asinf64", |args, hand_mem| {
+  cpu!(asinf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(a.asin().to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
-
-  cpu!("acosf64", |args, hand_mem| {
+  cpu!(acosf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(a.acos().to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
-
-  cpu!("atanf64", |args, hand_mem| {
+  cpu!(atanf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(a.atan().to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
-
-  cpu!("sinhf64", |args, hand_mem| {
+  cpu!(sinhf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(a.sinh().to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
-
-  cpu!("coshf64", |args, hand_mem| {
+  cpu!(coshf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(a.cosh().to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
-
-  cpu!("tanhf64", |args, hand_mem| {
+  cpu!(tanhf64 => fn(args, hand_mem) {
     let a = f64::from_ne_bytes(hand_mem.read_fixed(args[0]).to_ne_bytes());
     let out = i64::from_ne_bytes(a.tanh().to_ne_bytes());
     hand_mem.write_fixed(args[2], out);
     None
   });
+
   // Error, Maybe, Result, Either opcodes
-  cpu!("error", |args, hand_mem| {
+  cpu!(error => fn(args, hand_mem) {
     hand_mem.register(args[2], args[0], true);
     None
   });
-  cpu!("refv", |args, hand_mem| {
+  cpu!(refv => fn(args, hand_mem) {
     hand_mem.register(args[2], args[0], true);
     None
   });
-  cpu!("reff", |args, hand_mem| {
+  cpu!(reff => fn(args, hand_mem) {
     hand_mem.register(args[2], args[0], false);
     None
   });
-  cpu!("noerr", |args, hand_mem| {
+  cpu!(noerr => fn(args, hand_mem) {
     let empty_string = FractalMemory::new(vec![(0, 0)]);
     hand_mem.write_fractal(args[2], &empty_string);
     None
   });
-  cpu!("errorstr", |args, hand_mem| {
+  cpu!(errorstr => fn(args, hand_mem) {
     hand_mem.register(args[2], args[0], true);
     None
   });
-  cpu!("someM", |args, hand_mem| {
+  cpu!(someM => fn(args, hand_mem) {
     hand_mem.init_fractal(args[2]);
     hand_mem.push_fixed(args[2], 1i64);
     let val_size = hand_mem.read_fixed(args[1]);
@@ -3313,22 +3336,22 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("noneM", |args, hand_mem| {
+  cpu!(noneM => fn(args, hand_mem) {
     hand_mem.init_fractal(args[2]);
     hand_mem.push_fixed(args[2], 0i64);
     None
   });
-  cpu!("isSome", |args, hand_mem| {
+  cpu!(isSome => fn(args, hand_mem) {
     hand_mem.register_out(args[0], 0, args[2]);
     None
   });
-  cpu!("isNone", |args, hand_mem| {
+  cpu!(isNone => fn(args, hand_mem) {
     let fractal = hand_mem.read_fractal(args[0]);
     let val = fractal.read_fixed(0);
     hand_mem.write_fixed(args[2], if val == 0i64 { 1i64 } else { 0i64 });
     None
   });
-  cpu!("getOrM", |args, hand_mem| {
+  cpu!(getOrM => fn(args, hand_mem) {
     let fractal = hand_mem.read_fractal(args[0]);
     let val = fractal.read_fixed(0);
     if val == 1i64 {
@@ -3348,7 +3371,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("okR", |args, hand_mem| {
+  cpu!(okR => fn(args, hand_mem) {
     hand_mem.init_fractal(args[2]);
     hand_mem.push_fixed(args[2], 1i64);
     let val_size = hand_mem.read_fixed(args[1]);
@@ -3360,23 +3383,23 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("err", |args, hand_mem| {
+  cpu!(err => fn(args, hand_mem) {
     hand_mem.init_fractal(args[2]);
     hand_mem.push_fixed(args[2], 0i64);
     hand_mem.push_register(args[2], args[0]);
     None
   });
-  cpu!("isOk", |args, hand_mem| {
+  cpu!(isOk => fn(args, hand_mem) {
     hand_mem.register_out(args[0], 0, args[2]);
     None
   });
-  cpu!("isErr", |args, hand_mem| {
+  cpu!(isErr => fn(args, hand_mem) {
     let fractal = hand_mem.read_fractal(args[0]);
     let val = fractal.read_fixed(0);
     hand_mem.write_fixed(args[2], if val == 0i64 { 1i64 } else { 0i64 });
     None
   });
-  cpu!("getOrR", |args, hand_mem| {
+  cpu!(getOrR => fn(args, hand_mem) {
     let fractal = hand_mem.read_fractal(args[0]);
     let val = fractal.read_fixed(0);
     if val == 1i64 {
@@ -3391,7 +3414,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("getOrRS", |args, hand_mem| {
+  cpu!(getOrRS => fn(args, hand_mem) {
     let fractal = hand_mem.read_fractal(args[0]);
     let val = fractal.read_fixed(0);
     if val == 1i64 {
@@ -3402,7 +3425,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("getR", |args, hand_mem| {
+  cpu!(getR => fn(args, hand_mem) {
     let fractal = hand_mem.read_fractal(args[0]);
     let val = fractal.read_fixed(0);
     if val == 1i64 {
@@ -3412,7 +3435,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("getErr", |args, hand_mem| {
+  cpu!(getErr => fn(args, hand_mem) {
     let fractal = hand_mem.read_fractal(args[0]);
     let val = fractal.read_fixed(0);
     if val == 0i64 {
@@ -3427,7 +3450,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("resfrom", |args, hand_mem| {
+  cpu!(resfrom => fn(args, hand_mem) {
     // args = [arr_addr, arr_idx_addr, outer_addr]
     // a guarded copy of data from an array to a result object
     hand_mem.init_fractal(args[2]);
@@ -3435,7 +3458,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     let val = fractal.read_fixed(0);
     if val == 0 {
       hand_mem.write_fractal(args[2], &fractal);
-      return None
+      return None;
     }
     let inner_addr = fractal.read_fixed(1) as usize;
     let arr = hand_mem.read_fractal(args[0]);
@@ -3448,7 +3471,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("mainE", |args, hand_mem| {
+  cpu!(mainE => fn(args, hand_mem) {
     hand_mem.init_fractal(args[2]);
     hand_mem.push_fixed(args[2], 1i64);
     let val_size = hand_mem.read_fixed(args[1]);
@@ -3460,7 +3483,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("altE", |args, hand_mem| {
+  cpu!(altE => fn(args, hand_mem) {
     hand_mem.init_fractal(args[2]);
     hand_mem.push_fixed(args[2], 0i64);
     let val_size = hand_mem.read_fixed(args[1]);
@@ -3472,17 +3495,17 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("isMain", |args, hand_mem| {
+  cpu!(isMain => fn(args, hand_mem) {
     hand_mem.register_out(args[0], 0, args[2]);
     None
   });
-  cpu!("isAlt", |args, hand_mem| {
+  cpu!(isAlt => fn(args, hand_mem) {
     let fractal = hand_mem.read_fractal(args[0]);
     let val = fractal.read_fixed(0);
     hand_mem.write_fixed(args[2], if val == 0i64 { 1i64 } else { 0i64 });
     None
   });
-  cpu!("mainOr", |args, hand_mem| {
+  cpu!(mainOr => fn(args, hand_mem) {
     let fractal = hand_mem.read_fractal(args[0]);
     let val = fractal.read_fixed(0);
     if val == 1i64 {
@@ -3497,7 +3520,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     }
     None
   });
-  cpu!("altOr", |args, hand_mem| {
+  cpu!(altOr => fn(args, hand_mem) {
     let fractal = hand_mem.read_fractal(args[0]);
     let val = fractal.read_fixed(0);
     if val == 0i64 {
@@ -3513,7 +3536,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("hashf", |args, hand_mem| {
+  cpu!(hashf => fn(args, hand_mem) {
     let val = hand_mem.read_fixed(args[0]);
     let mut hasher = XxHash64::with_seed(0xfa57);
     hasher.write_i64(val);
@@ -3522,10 +3545,11 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-  cpu!("hashv", |args, hand_mem| {
+  cpu!(hashv => fn(args, hand_mem) {
     let mut hasher = XxHash64::with_seed(0xfa57);
     let addr = args[0];
-    if addr < 0 { // It's a string!
+    if addr < 0 {
+      // It's a string!
       let pascal_string = hand_mem.read_fractal(args[0]);
       let strlen = pascal_string.read_fixed(0) as f64;
       let intlen = 1 + (strlen / 8.0).ceil() as usize;
@@ -3551,14 +3575,15 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     None
   });
 
-
-  cpu!("emit", |args, hand_mem| {
+  // king opcode
+  cpu!(emit => fn(args, hand_mem) {
     let event = EventEmit {
       id: args[0],
       payload: HandlerMemory::alloc_payload(args[0], args[1], &hand_mem),
     };
     Some(event)
   });
+
   o
 });
 
@@ -3566,7 +3591,7 @@ impl From<i64> for &ByteOpcode {
   fn from(v: i64) -> Self {
     let opc = OPCODES.get(&v);
     if opc.is_none() {
-        panic!(format!("Illegal byte opcode {} ({})", v, str::from_utf8(&v.to_ne_bytes()).unwrap()));
+      panic!(format!("Illegal byte opcode {} ({})", v, str::from_utf8(&v.to_ne_bytes()).unwrap()));
     }
     return &opc.unwrap();
   }

--- a/avm/src/vm/opcode.rs
+++ b/avm/src/vm/opcode.rs
@@ -86,7 +86,7 @@ impl ByteOpcode {
 pub fn opcode_id(name: &str) -> i64 {
   let mut ascii_name = [0u8; 8];
   // Now insert the new name characters
-  for (i, c) in name.chars().take(8).enumerate() {
+  for (i, c) in name.chars().enumerate() {
     std::mem::replace(&mut ascii_name[i], c as u8);
   }
   let id = LittleEndian::read_i64(&ascii_name);

--- a/avm/src/vm/opcode.rs
+++ b/avm/src/vm/opcode.rs
@@ -98,18 +98,18 @@ pub fn opcode_id(name: &str) -> i64 {
   let mut ascii_name = [b' '; 8];
   // Now insert the new name characters
   for (i, c) in name.chars().take(8).enumerate() {
-    std::mem::replace(&mut ascii_name[i], c as u8);
+    ascii_name[i] = c as u8;
   }
   let id = LittleEndian::read_i64(&ascii_name);
   return id;
 }
 
-#[allow(unused)]
 pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
   let mut o = HashMap::new();
 
   macro_rules! cpu {
     ($name:ident => fn ($args:ident , $hand_mem:ident) $body:block) => {
+      #[allow(non_snake_case)]
       fn $name($args: &[i64], $hand_mem: &mut HandlerMemory) -> Option<EventEmit> {
         $body
       }
@@ -124,6 +124,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
   }
   macro_rules! io {
     ($name:ident => fn ($args:ident , $hand_mem:ident) $body:block) => {
+      #[allow(non_snake_case)]
       fn $name($args: Vec<i64>, $hand_mem: HandlerMemory) -> HMFuture {
         $body
       }
@@ -136,6 +137,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       o.insert(id, opcode);
     };
     ($name:ident => fn (mut $args:ident , $hand_mem:ident) $body:block) => {
+      #[allow(non_snake_case)]
       fn $name(mut $args: Vec<i64>, $hand_mem: HandlerMemory) -> HMFuture {
         $body
       }
@@ -148,6 +150,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       o.insert(id, opcode);
     };
     ($name:ident => fn ($args:ident , mut $hand_mem:ident) $body:block) => {
+      #[allow(non_snake_case)]
       fn $name($args: Vec<i64>, mut $hand_mem: HandlerMemory) -> HMFuture {
         $body
       }
@@ -160,6 +163,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       o.insert(id, opcode);
     };
     ($name:ident => fn (mut $args:ident , mut $hand_mem:ident) $body:block) => {
+      #[allow(non_snake_case)]
       fn $name(mut $args: Vec<i64>, mut $hand_mem: HandlerMemory) -> HMFuture {
         $body
       }
@@ -2274,7 +2278,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
     hand_mem.init_fractal(args[2]);
     None
   });
-  io!(map => fn(args, mut hand_mem) {
+  io!(map => fn(args, hand_mem) {
     Box::pin(async move {
       let hand_mem_ref = Arc::new(hand_mem);
       let fractal = hand_mem_ref.read_fractal(args[0]);
@@ -2371,7 +2375,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!(find => fn(args, mut hand_mem) {
+  io!(find => fn(args, hand_mem) {
     Box::pin(async move {
       let hand_mem = Arc::new(hand_mem);
       let fractal = hand_mem.read_fractal(args[0]);
@@ -2426,7 +2430,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!(some => fn(args, mut hand_mem) {
+  io!(some => fn(args, hand_mem) {
     Box::pin(async move {
       let hand_mem_ref = Arc::new(hand_mem);
       let fractal = hand_mem_ref.read_fractal(args[0]);
@@ -2468,7 +2472,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!(every => fn(args, mut hand_mem) {
+  io!(every => fn(args, hand_mem) {
     Box::pin(async move {
       let hand_mem_ref = Arc::new(hand_mem);
       let fractal = hand_mem_ref.read_fractal(args[0]);
@@ -2665,7 +2669,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!(filter => fn(args, mut hand_mem) {
+  io!(filter => fn(args, hand_mem) {
     Box::pin(async move {
       let hand_mem_ref = Arc::new(hand_mem);
       let fractal = hand_mem_ref.read_fractal(args[0]);
@@ -3111,7 +3115,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem
     })
   });
-  io!(selfrec => fn(args, mut hand_mem) {
+  io!(selfrec => fn(args, hand_mem) {
     Box::pin(async move {
       let hand_mem_ref = Arc::new(hand_mem);
       let mut hm = HandlerMemory::fork(Arc::clone(&hand_mem_ref));


### PR DESCRIPTION
Changes all of the opcode native functions to be static functions instead of closures, also changes the implementation of the opcode macros.