### PR TITLE
Fan out parallel array operations across cores

### DIFF
--- a/avm/src/vm/opcode.rs
+++ b/avm/src/vm/opcode.rs
@@ -2312,7 +2312,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       for i in 0..fractal.len() {
         hand_mem.register_out(args[0], i, CLOSURE_ARG_MEM_START + 1);
         hand_mem.write_fixed(CLOSURE_ARG_MEM_START + 2, i as i64);
-        hand_mem = subhandler.clone().run_local(hand_mem).await;
+        hand_mem = subhandler.clone().run(hand_mem).await;
         hand_mem.push_register(args[2], CLOSURE_ARG_MEM_START);
       }
       hand_mem
@@ -2362,7 +2362,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
         hm.register_out(args[0], i, CLOSURE_ARG_MEM_START + 1);
         hm.write_fixed(CLOSURE_ARG_MEM_START + 2, i as i64);
         let j = i / s;
-        runners[j].push(Box::pin(subhandler.clone().run_local(hm)));
+        runners[j].push(Box::pin(subhandler.clone().run(hm)));
       }
       let mut hms: Vec<HandlerMemory> = Vec::with_capacity(l);
       for runner in runners {
@@ -2429,7 +2429,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       let subhandler = HandlerFragment::new(args[1], 0);
       for i in 0..fractal.len() {
         hand_mem.register_out(args[0], i, CLOSURE_ARG_MEM_START + 1);
-        hand_mem = subhandler.clone().run_local(hand_mem).await;
+        hand_mem = subhandler.clone().run(hand_mem).await;
         let val = hand_mem.read_fixed(CLOSURE_ARG_MEM_START);
         if val == 1 {
           hand_mem.init_fractal(args[2]);
@@ -2475,7 +2475,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       let subhandler = HandlerFragment::new(args[1], 0);
       for i in 0..fractal.len() {
         hand_mem.register_out(args[0], i, CLOSURE_ARG_MEM_START + 1);
-        hand_mem = subhandler.clone().run_local(hand_mem).await;
+        hand_mem = subhandler.clone().run(hand_mem).await;
         let val = hand_mem.read_fixed(CLOSURE_ARG_MEM_START);
         if val == 1 {
           hand_mem.write_fixed(args[2], 1);
@@ -2517,7 +2517,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       let subhandler = HandlerFragment::new(args[1], 0);
       for i in 0..fractal.len() {
         hand_mem.register_out(args[0], i, CLOSURE_ARG_MEM_START + 1);
-        hand_mem = subhandler.clone().run_local(hand_mem).await;
+        hand_mem = subhandler.clone().run(hand_mem).await;
         let val = hand_mem.read_fixed(CLOSURE_ARG_MEM_START);
         if val == 0 {
           hand_mem.write_fixed(args[2], 0);
@@ -2598,7 +2598,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
         let current = &vals[i];
         HandlerMemory::transfer(&cumulative, 0, &mut hand_mem, CLOSURE_ARG_MEM_START + 1);
         HandlerMemory::transfer(&current, 0, &mut hand_mem, CLOSURE_ARG_MEM_START + 2);
-        hand_mem = subhandler.clone().run_local(hand_mem).await;
+        hand_mem = subhandler.clone().run(hand_mem).await;
         HandlerMemory::transfer(&hand_mem, CLOSURE_ARG_MEM_START, &mut cumulative, 0);
       }
       HandlerMemory::transfer(&cumulative, 0, &mut hand_mem, args[2]);
@@ -2676,7 +2676,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
         let current = &vals[i];
         HandlerMemory::transfer(&cumulative, 0, &mut hand_mem, CLOSURE_ARG_MEM_START + 1);
         HandlerMemory::transfer(current, 0, &mut hand_mem, CLOSURE_ARG_MEM_START + 2);
-        hand_mem = subhandler.clone().run_local(hand_mem).await;
+        hand_mem = subhandler.clone().run(hand_mem).await;
         HandlerMemory::transfer(&hand_mem, CLOSURE_ARG_MEM_START, &mut cumulative, 0);
       }
       hand_mem.register(args[2], CLOSURE_ARG_MEM_START, false);
@@ -2721,7 +2721,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       hand_mem.init_fractal(args[2]);
       for i in 0..len {
         hand_mem.register_out(args[0], i, CLOSURE_ARG_MEM_START + 1);
-        hand_mem = subhandler.clone().run_local(hand_mem).await;
+        hand_mem = subhandler.clone().run(hand_mem).await;
         let val = hand_mem.read_fixed(CLOSURE_ARG_MEM_START);
         if val == 1 {
           hand_mem.push_register_out(args[2], &fractal, i);
@@ -2737,7 +2737,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       let cond = hand_mem.read_fixed(args[0]);
       let subhandler = HandlerFragment::new(args[1], 0);
       if cond == 1 {
-        hand_mem = subhandler.run_local(hand_mem).await;
+        hand_mem = subhandler.run(hand_mem).await;
       }
       hand_mem
     })
@@ -3085,7 +3085,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       for i in current..limit {
         // array element is $1 argument of the closure memory space
         hand_mem.write_fixed(CLOSURE_ARG_MEM_START + 1, i);
-        hand_mem = subhandler.clone().run_local(hand_mem).await;
+        hand_mem = subhandler.clone().run(hand_mem).await;
       }
       hand_mem
     })
@@ -3101,11 +3101,11 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       if current >= limit {
         return hand_mem;
       }
-      hand_mem = cond_handler.clone().run_local(hand_mem).await;
+      hand_mem = cond_handler.clone().run(hand_mem).await;
       while current < limit && hand_mem.read_fixed(CLOSURE_ARG_MEM_START) > 0 {
-        hand_mem = body_handler.clone().run_local(hand_mem).await;
+        hand_mem = body_handler.clone().run(hand_mem).await;
         current = current + 1;
-        hand_mem = cond_handler.clone().run_local(hand_mem).await;
+        hand_mem = cond_handler.clone().run(hand_mem).await;
       }
       let mut seq = hand_mem.read_fractal(args[0]);
       hand_mem.write_fixed_in_fractal(&mut seq, 0, current);
@@ -3120,7 +3120,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       drop(seq);
       let subhandler = HandlerFragment::new(args[1], 0);
       loop {
-        hand_mem = subhandler.clone().run_local(hand_mem).await;
+        hand_mem = subhandler.clone().run(hand_mem).await;
         current = current + 1;
         if current >= limit || hand_mem.read_fixed(CLOSURE_ARG_MEM_START) == 0 {
           break;
@@ -3146,7 +3146,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       let mut hand_mem;
       if curr < seq.read_fixed(1) {
         hm.write_fixed_in_fractal(&mut seq, 0, curr + 1);
-        hm = recurse_fn.run_local(hm).await;
+        hm = recurse_fn.run(hm).await;
         hm.drop_parent();
         hand_mem = Arc::try_unwrap(hand_mem_ref).unwrap();
         hand_mem.join(&mut hm);

--- a/bdd/spec/011_array_spec.sh
+++ b/bdd/spec/011_array_spec.sh
@@ -260,15 +260,16 @@ Hello, World!"
     End
   End
 
-  Describe "repeat and mapLin"
+  Describe "repeat, mapLin and eachLin"
     before() {
       sourceToAll "
         from @std/app import start, print, exit
 
         on start {
           const arr = [1, 2, 3] * 3;
-          const out = arr.mapLin(fn (x: int64): string = x.toString()).join(', ');
-          print(out);
+          const out = arr.mapLin(fn (x: int64): string = x.toString());
+          print(out.join(', '));
+          out.eachLin(fn (x: string): void = print(x));
           emit exit 0;
         }
       "
@@ -280,7 +281,16 @@ Hello, World!"
     }
     AfterAll after
 
-    MAPLOUTPUT="1, 2, 3, 1, 2, 3, 1, 2, 3"
+    MAPLOUTPUT="1, 2, 3, 1, 2, 3, 1, 2, 3
+1
+2
+3
+1
+2
+3
+1
+2
+3"
 
     It "runs js"
       When run test_js


### PR DESCRIPTION
`eachl` is already doing the right thing here, but the rest of the linear opcodes are spinning up multiple tokio tasks when there is no explicit parallelism necessary beyond the IO parallelism provided by tokio.