### PR TITLE
Add `toSubtree` method, and make fixes to the `addChild` functions to properly handle Trees and Nodes attached to other Trees

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,10 +92,6 @@ jobs:
     # The type of runner that the job will run on
     runs-on: macos-latest
 
-    strategy:
-      matrix:
-        node-version: [10.20.1, 12.x, 14.x]
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -104,10 +100,10 @@ jobs:
     # Rust is automatically set up and included by default according to: https://github.com/actions/starter-workflows/blob/master/ci/rust.yml
 
     # Set up Node.js
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 14.x
 
     # Run the BDD tests
     - name: Run BDD tests
@@ -133,10 +129,6 @@ jobs:
     # The type of runner that the job will run on
     runs-on: windows-latest
 
-    strategy:
-      matrix:
-        node-version: [10.20.1, 12.x, 14.x]
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -145,10 +137,10 @@ jobs:
     # Rust is automatically set up and included by default according to: https://github.com/actions/starter-workflows/blob/master/ci/rust.yml
 
     # Set up Node.js
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 14.x
 
     # Run the BDD tests
     - name: Run BDD tests

--- a/bdd/spec/028_tree_spec.sh
+++ b/bdd/spec/028_tree_spec.sh
@@ -144,4 +144,50 @@ baz
       The output should eq "$BASICOUTPUT"
     End
   End
+
+  Describe "subtree and deeply nested tree construction"
+    before() {
+      sourceToAll "
+        from @std/app import start, print, exit
+
+        on start {
+          const bigNestedTree = newTree('foo')
+            .addChild('bar')
+            .addChild(newTree('baz')
+              .addChild('quux')
+            ).getTree();
+
+          const mySubtree = bigNestedTree
+            .getRootNode()
+            .getChildren()[1]
+            .getOr(newTree('what').getRootNode())
+            .toSubtree();
+
+          print(bigNestedTree.getRootNode() || 'wrong');
+          print(mySubtree.getRootNode() || 'wrong');
+
+          emit exit 0;
+        }
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanTemp
+    }
+    AfterAll after
+
+    SUBTREEOUTPUT="foo
+baz"
+
+    It "runs js"
+      When run test_js
+      The output should eq "$SUBTREEOUTPUT"
+    End
+
+    It "runs agc"
+      When run test_agc
+      The output should eq "$SUBTREEOUTPUT"
+    End
+  End
 End

--- a/bdd/spec/028_tree_spec.sh
+++ b/bdd/spec/028_tree_spec.sh
@@ -153,8 +153,10 @@ baz
         on start {
           const bigNestedTree = newTree('foo')
             .addChild('bar')
+            .getTree()
             .addChild(newTree('baz')
               .addChild('quux')
+              .getTree()
             ).getTree();
 
           const mySubtree = bigNestedTree

--- a/js-runtime/index.js
+++ b/js-runtime/index.js
@@ -598,11 +598,11 @@ module.exports = {
   poparr:   arr => arr.length > 0 ? [ true, arr.pop(), ] : [ false, 'cannot pop empty array', ],
   lenarr:   arr => BigInt(arr.length),
   indarrf: (arr, val) => {
-    const ind = arr.indexOf(val)
+    const ind = BigInt(arr.indexOf(val))
     return ind > -1 ? [ true, ind, ] : [ false, 'element not found', ]
   },
   indarrv: (arr, val) => {
-    const ind = arr.indexOf(val)
+    const ind = BigInt(arr.indexOf(val))
     return ind > -1 ? [ true, ind, ] : [ false, 'element not found', ]
   },
   delindx: (arr, idx) => {

--- a/std/root.ln
+++ b/std/root.ln
@@ -2590,7 +2590,8 @@ export fn toSubtree(n: Node<any>): Tree<any> {
   let outTree = newTree(val);
   let children = n.tree.children[n.id].getOr(new Array<int64> []);
   let parentIds = [0].repeat(children.length().sub(1).getOr(0));
-  seqdo(newseq(pow(2, 64).getOr(0)), fn (): bool {
+  //seqdo(newseq(pow(2, 64).getOr(0)), fn (): bool {
+  seqdo(newseq(100), fn (): bool {
     const childId = children.pop();
     const parentId = parentIds.pop();
     const childVal = n.tree.vals[childId].getR();

--- a/std/root.ln
+++ b/std/root.ln
@@ -2591,8 +2591,7 @@ export fn toSubtree(n: Node<any>): Tree<any> {
   let children = n.tree.children[n.id].getOr(new Array<int64> []);
   if children.length().gt(0) {
     let parentIds = [0].repeat(children.length());
-    //seqdo(newseq(pow(2, 64).getOr(0)), fn (): bool {
-    seqdo(newseq(100), fn (): bool {
+    seqdo(newseq(pow(2, 64).getOr(0)), fn (): bool {
       const childId = children.pop();
       const parentId = parentIds.pop();
       const childVal = n.tree.vals[childId].getR();

--- a/std/root.ln
+++ b/std/root.ln
@@ -2602,7 +2602,7 @@ export fn toSubtree(n: Node<any>): Tree<any> {
       outTree.parents.push(parentId);
       outTree.children.push(new Array<int64> []);
       children = grandchildIds.concat(children);
-      parentIds = [newParentId].concat(parentIds);
+      parentIds = [newParentId].repeat(grandchildIds.length()).concat(parentIds);
       return parentIds.length().gt(0);
     });
   }

--- a/std/root.ln
+++ b/std/root.ln
@@ -2590,7 +2590,7 @@ export fn toSubtree(n: Node<any>): Tree<any> {
   let outTree = newTree(val);
   let children = n.tree.children[n.id].getOr(new Array<int64> []);
   if children.length().gt(0) {
-    let parentIds = [0].repeat(children.length().sub(1).getOr(0));
+    let parentIds = [0].repeat(children.length());
     //seqdo(newseq(pow(2, 64).getOr(0)), fn (): bool {
     seqdo(newseq(100), fn (): bool {
       const childId = children.pop();

--- a/std/root.ln
+++ b/std/root.ln
@@ -2633,11 +2633,11 @@ export fn addChild(n: Node<any>, val: Tree<any>): Node<any> {
     if p == -1 {
       return n.id;
     } else {
-      return p + childIdOffset;
+      return p.add(childIdOffset).getOr(0);
     }
   });
   const newChildren = n.tree.children.map(fn (ca: Array<int64>): Array<int64> {
-    return ca.map(fn (c: int64): int64 = c + childIdOffset);
+    return ca.map(fn (c: int64): int64 = c.add(childIdOffset).getOr(0));
   });
   n.tree.children[n.id].getOr(new Array<int64> []).push(childIdOffset);
   n.tree.vals = n.tree.vals.concat(val.vals);

--- a/std/root.ln
+++ b/std/root.ln
@@ -2614,10 +2614,11 @@ export fn getChildren(t: Tree<any>): Array<Node<any>> = t.getRootNode().getChild
 // Attaches the value as a child of the specified node. Returns the new child node added for easier
 // method chaining
 export fn addChild(n: Node<any>, val: any): Node<any> {
-  const childId = length(n.tree.vals);
-  push(n.tree.vals, val);
-  push(n.tree.parents, n.id);
-  push(n.tree.children, [ childId, ]);
+  const childId = n.tree.vals.length();
+  n.tree.vals.push(val);
+  n.tree.parents.push(n.id);
+  n.tree.children.push(new Array<int64> []);
+  n.tree.children[n.id].getOr(new Array<int64> []).push(childId);
   return new Node<any> {
     id: childId,
     tree: n.tree,

--- a/std/root.ln
+++ b/std/root.ln
@@ -2583,9 +2583,33 @@ export fn prune(n: Node<any>): Tree<any> {
   return n.tree;
 }
 
+// Takes the given node and copies that node and all of its children into a new tree with the
+// current node as the root. Unfortunately a sequential algorithm right now.
+export fn toSubtree(n: Node<any>): Tree<any> {
+  const val = n.tree.vals[n.id].getR();
+  let outTree = newTree(val);
+  let children = n.tree.children[n.id].getOr(new Array<int64> []);
+  let parentIds = [0].repeat(children.length().sub(1));
+  seqdo(newseq(pow(2, 64).getOr(0)), fn (): bool {
+    const childId = children.pop();
+    const parentId = parentIds.pop();
+    const childVal = n.tree.vals[childId].getR();
+    const grandchildIds = n.tree.children[childId].getOr(new Array<int64> []);
+    const newParentId = outTree.vals.length();
+    outTree.vals.push(childVal);
+    outTree.parents.push(parentId);
+    outTree.children.push(new Array<int64> []);
+    children = grandchildIds.concat(children);
+    parentIds = [newParentId].concat(parentIds);
+    return parentIds.length().gt(0);
+  });
+  return outTree;
+}
+
 export fn getChildren(t: Tree<any>): Array<Node<any>> = t.getRootNode().getChildren();
 
-// returns the new child node added
+// Attaches the value as a child of the specified node. Returns the new child node added for easier
+// method chaining
 export fn addChild(n: Node<any>, val: any): Node<any> {
   const childId = length(n.tree.vals);
   push(n.tree.vals, val);
@@ -2598,11 +2622,42 @@ export fn addChild(n: Node<any>, val: any): Node<any> {
   };
 }
 
+// Attaches the specified Tree to the specified Node. Can be done with simple maps and concats. This
+// returns the new child node corresponding to the root node of the tree.
+export fn addChild(n: Node<any>, val: Tree<any>): Node<any> {
+  const childIdOffset = n.tree.vals.length();
+  const newParents = n.tree.parents.map(fn (p: int64): int64 {
+    if p == -1 {
+      return n.id;
+    } else {
+      return p + childIdOffset;
+    }
+  });
+  const newChildren = n.tree.children.map(fn (ca: Array<int64>): Array<int64> {
+    return ca.map(fn (c: int64): int64 = c + childIdOffset);
+  });
+  n.tree.children[n.id].getOr(new Array<int64> []).push(childIdOffset);
+  n.tree.vals = n.tree.vals.concat(val.vals);
+  n.tree.parents = n.tree.parents.concat(newParents);
+  return new Node<any> {
+    id: childIdOffset,
+    tree: n.tree,
+  };
+}
+
+// Attaches the specified Node and its children to the specified Node. This returns the new child
+// node corresponding to the attached node
+export fn addChild(n: Node<any>, val: Node<any>): Node<any> = n.addChild(val.toSubtree());
+
+// Attaches the specified value to the specified Tree, by referencing a Tree directly, attaches to
+// the root node, and returns the new child node
 export fn addChild(t: Tree<any>, val: any): Node<any> = t.getRootNode().addChild(val);
 
-export fn addChild(t: Tree<any>, val: Node<any>): Node<any> = t.getRootNode().addChild(val);
+// Attaches the specified Node and its children to the specified Tree's root node
+export fn addChild(t: Tree<any>, val: Node<any>): Node<any> = t.getRootNode().addChild(val.toSubtree());
 
-export fn addChild(n: Node<any>, val: Tree<any>): Node<any> = n.addChild(val.getRootNode());
+// Attahces one tree to the root node of another tree. Returns the node of the attached tree's root
+export fn addChild(t: Tree<any>, val: Tree<any>): Node<any> = t.getRootNode().addChild(val);
 
 export fn getOr(n: Node<any>, default: any): any = getOr(n.tree.vals[n.id], default);
 

--- a/std/root.ln
+++ b/std/root.ln
@@ -2617,8 +2617,7 @@ export fn addChild(n: Node<any>, val: any): Node<any> {
   const childId = length(n.tree.vals);
   push(n.tree.vals, val);
   push(n.tree.parents, n.id);
-  push(n.tree.children, new Array<int64> [ ]);
-  push(getOr(n.tree.children[n.id], new Array<int64> []), childId);
+  push(n.tree.children, [ childId, ]);
   return new Node<any> {
     id: childId,
     tree: n.tree,

--- a/std/root.ln
+++ b/std/root.ln
@@ -2589,21 +2589,23 @@ export fn toSubtree(n: Node<any>): Tree<any> {
   const val = n.tree.vals[n.id].getR();
   let outTree = newTree(val);
   let children = n.tree.children[n.id].getOr(new Array<int64> []);
-  let parentIds = [0].repeat(children.length().sub(1).getOr(0));
-  //seqdo(newseq(pow(2, 64).getOr(0)), fn (): bool {
-  seqdo(newseq(100), fn (): bool {
-    const childId = children.pop();
-    const parentId = parentIds.pop();
-    const childVal = n.tree.vals[childId].getR();
-    const grandchildIds = n.tree.children[childId].getOr(new Array<int64> []);
-    const newParentId = outTree.vals.length();
-    outTree.vals.push(childVal);
-    outTree.parents.push(parentId);
-    outTree.children.push(new Array<int64> []);
-    children = grandchildIds.concat(children);
-    parentIds = [newParentId].concat(parentIds);
-    return parentIds.length().gt(0);
-  });
+  if children.length().gt(0) {
+    let parentIds = [0].repeat(children.length().sub(1).getOr(0));
+    //seqdo(newseq(pow(2, 64).getOr(0)), fn (): bool {
+    seqdo(newseq(100), fn (): bool {
+      const childId = children.pop();
+      const parentId = parentIds.pop();
+      const childVal = n.tree.vals[childId].getR();
+      const grandchildIds = n.tree.children[childId].getOr(new Array<int64> []);
+      const newParentId = outTree.vals.length();
+      outTree.vals.push(childVal);
+      outTree.parents.push(parentId);
+      outTree.children.push(new Array<int64> []);
+      children = grandchildIds.concat(children);
+      parentIds = [newParentId].concat(parentIds);
+      return parentIds.length().gt(0);
+    });
+  }
   return outTree;
 }
 

--- a/std/root.ln
+++ b/std/root.ln
@@ -2589,7 +2589,7 @@ export fn toSubtree(n: Node<any>): Tree<any> {
   const val = n.tree.vals[n.id].getR();
   let outTree = newTree(val);
   let children = n.tree.children[n.id].getOr(new Array<int64> []);
-  let parentIds = [0].repeat(children.length().sub(1));
+  let parentIds = [0].repeat(children.length().sub(1).getOr(0));
   seqdo(newseq(pow(2, 64).getOr(0)), fn (): bool {
     const childId = children.pop();
     const parentId = parentIds.pop();

--- a/std/root.ln
+++ b/std/root.ln
@@ -2625,7 +2625,17 @@ export fn addChild(n: Node<any>, val: any): Node<any> {
 }
 
 // Attaches the specified Tree to the specified Node. Can be done with simple maps and concats. This
-// returns the new child node corresponding to the root node of the tree.
+// returns the new child node corresponding to the root node of the tree. When adding a tree, we
+// duplicate that tree and attach it to the specified node on the new tree with the parent-child
+// relationships "re-stitched" on the node's own tree. This means it is even possible to attach a
+// tree to itself without producing loops in the tree structure:
+//    A          A
+//   / \   =>   / \
+//  B   C      B   C
+//                 |
+//                 A'
+//                / \
+//               B'  C'
 export fn addChild(n: Node<any>, val: Tree<any>): Node<any> {
   const childIdOffset = n.tree.vals.length();
   const newParents = n.tree.parents.map(fn (p: int64): int64 {


### PR DESCRIPTION
This was broken out from the JSON work because it became beefy enough as it is, and it could be useful now. It also fixes a bug in the js-runtime that wasn't caught until now.