### PR TITLE
Switch to rustls for hyper in the AVM

### DIFF
--- a/avm/Cargo.lock
+++ b/avm/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
  "futures",
  "heim",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "num_cpus",
  "once_cell",
  "rand 0.7.3",
@@ -285,6 +285,15 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct",
+]
 
 [[package]]
 name = "darwin-libproc"
@@ -803,6 +812,23 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
 ]
 
 [[package]]
@@ -1439,6 +1465,18 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]

--- a/avm/Cargo.lock
+++ b/avm/Cargo.lock
@@ -66,8 +66,8 @@ dependencies = [
 
 [[package]]
 name = "anycloud"
-version = "0.1.1"
-source = "git+https://github.com/alantech/anycloud?branch=main#56a8964f0df7e5fa277e12b5e16f6916da6f4fd5"
+version = "0.1.2"
+source = "git+https://github.com/alantech/anycloud?branch=main#3a90f10b44d724ec84efe504ffac224a60d55235"
 dependencies = [
  "ascii_table",
  "base64",
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
 dependencies = [
  "bytes",
  "fnv",
@@ -539,7 +539,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -915,9 +914,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
 
 [[package]]
 name = "linked-hash-map"
@@ -1100,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "openssl"
@@ -1199,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -1571,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43535db9747a4ba938c0ce0a98cc631a46ebf943c9e1d604e091df6007620bf6"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1835,16 +1834,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -22,7 +22,7 @@ clap = "2.33.1"
 dashmap = "3.11.10"
 futures = "0.3.8"
 hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server"] }
-hyper-tls = "0.5" # needed for HTTPS w/ hyper
+hyper-rustls = "0.22.1" # needed for HTTPS w/ hyper
 num_cpus = "1.0"
 once_cell = "1.5.2"
 rand = "0.7.3"

--- a/avm/src/vm/opcode.rs
+++ b/avm/src/vm/opcode.rs
@@ -18,7 +18,7 @@ use dashmap::DashMap;
 use hyper::header::{HeaderName, HeaderValue};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{client::{Client, ResponseFuture}, server::Server, Body, Request, Response, StatusCode};
-use hyper_tls::HttpsConnector;
+use hyper_rustls::HttpsConnector;
 use once_cell::sync::Lazy;
 use rand::rngs::OsRng;
 use rand::RngCore;
@@ -2825,7 +2825,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
       return Err("Failed to construct request, invalid body provided".to_string());
     } else {
       return Ok(Client::builder()
-        .build::<_, Body>(HttpsConnector::new())
+        .build::<_, Body>(HttpsConnector::with_native_roots())
         .request(req_obj.unwrap()));
     }
   }

--- a/avm/src/vm/telemetry.rs
+++ b/avm/src/vm/telemetry.rs
@@ -25,7 +25,7 @@ pub async fn log(event: &str) {
       }
     ]
   });
-  let client = Client::builder().build::<_, Body>(hyper_tls::HttpsConnector::new());
+  let client = Client::builder().build::<_, Body>(hyper_rustls::HttpsConnector::with_native_roots());
   if client
     .request(
       Request::post(AMPLITUDE_URL)

--- a/bdd/spec/023_http_spec.sh
+++ b/bdd/spec/023_http_spec.sh
@@ -99,7 +99,7 @@ export const comeGetMe = \"You got me!\""
 
     FETCHAGCOUTPUT="true
 200
-23
+22
 export const comeGetMe = \"You got me!\""
 
     It "runs js"


### PR DESCRIPTION
This doesn't add HTTPS support, but sets us up for it, since [hyper-rustls](https://github.com/ctz/hyper-rustls/blob/master/examples/server.rs) has server support, but [hyper-tls](https://github.com/hyperium/hyper-tls/tree/master/examples) apparently does not.