### PR TITLE
Remove the http listen opcode (from users) and auto-listen on 80 or 8000 depending on context

### DIFF
--- a/avm/src/vm/event.rs
+++ b/avm/src/vm/event.rs
@@ -50,7 +50,7 @@ pub struct EventHandler {
   movable_capstones: Vec<usize>,
   /// topological order of the instructions split into fragments
   /// by unpredictable or partially predictable opcodes
-  fragments: Vec<Vec<Instruction>>,
+  pub fragments: Vec<Vec<Instruction>>,
   /// total count of instructions within fragments
   ins_count: usize,
 }

--- a/avm/src/vm/opcode.rs
+++ b/avm/src/vm/opcode.rs
@@ -20,8 +20,8 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{client::{Client, ResponseFuture}, server::Server, Body, Request, Response, StatusCode};
 use hyper_rustls::HttpsConnector;
 use once_cell::sync::Lazy;
-use rand::rngs::OsRng;
 use rand::RngCore;
+use rand::rngs::OsRng;
 use regex::Regex;
 use tokio::process::Command;
 use tokio::time::sleep;
@@ -29,6 +29,7 @@ use twox_hash::XxHash64;
 
 use crate::vm::event::{BuiltInEvents, EventEmit, HandlerFragment};
 use crate::vm::memory::{FractalMemory, HandlerMemory, CLOSURE_ARG_MEM_START};
+use crate::vm::program::Program;
 use crate::vm::run::EVENT_TX;
 
 static HTTP_RESPONSES: Lazy<Arc<Mutex<HashMap<i64, Arc<HandlerMemory>>>>> =
@@ -3021,7 +3022,7 @@ pub static OPCODES: Lazy<HashMap<i64, ByteOpcode>> = Lazy::new(|| {
   }
   io!(httplsn => fn(args, mut hand_mem) {
     Box::pin(async move {
-      let port_num = hand_mem.read_fixed(args[0]) as u16;
+      let port_num = Program::global().http_port;
       let addr = SocketAddr::from(([0, 0, 0, 0], port_num));
       let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(http_listener)) });
 

--- a/avm/src/vm/run.rs
+++ b/avm/src/vm/run.rs
@@ -88,7 +88,7 @@ pub async fn run_file(fp: &str, delete_after_load: bool) {
   if delete_after_load {
     std::fs::remove_file(Path::new(fp)).unwrap();
   }
-  run(bytecode).await;
+  run(bytecode, 8000).await;
 }
 
 pub async fn run_agz_b64(agz_b64: &str) {
@@ -98,11 +98,11 @@ pub async fn run_agz_b64(agz_b64: &str) {
   let mut bytecode = vec![0; count / 8];
   let mut gz = GzDecoder::new(bytes.as_slice());
   gz.read_i64_into::<LittleEndian>(&mut bytecode).unwrap();
-  run(bytecode).await;
+  run(bytecode, 80).await;
 }
 
-pub async fn run(bytecode: Vec<i64>) {
-  let program = Program::load(bytecode);
+pub async fn run(bytecode: Vec<i64>, http_port: u16) {
+  let program = Program::load(bytecode, http_port);
   let set_global = PROGRAM.set(program);
   if set_global.is_err() {
     eprintln!("Failed to load bytecode");

--- a/bdd/spec/023_http_spec.sh
+++ b/bdd/spec/023_http_spec.sh
@@ -117,7 +117,7 @@ export const comeGetMe = \"You got me!\""
     before() {
       sourceToAll "
         from @std/app import start, exit
-        from @std/http import connection, body, send, Connection
+        from @std/httpserver import connection, body, send, Connection
 
         on connection fn (conn: Connection) {
           const req = conn.req;
@@ -146,7 +146,6 @@ export const comeGetMe = \"You got me!\""
     After afterEach
 
     It "runs js"
-      Pending how-do-we-detect-this-in-amm-to-js
       node test_$$/temp.js 1>/dev/null 2>/dev/null &
       PID=$!
       sleep 1

--- a/bdd/spec/023_http_spec.sh
+++ b/bdd/spec/023_http_spec.sh
@@ -117,7 +117,7 @@ export const comeGetMe = \"You got me!\""
     before() {
       sourceToAll "
         from @std/app import start, exit
-        from @std/http import connection, listen, body, send, Connection
+        from @std/http import connection, body, send, Connection
 
         on connection fn (conn: Connection) {
           const req = conn.req;
@@ -127,13 +127,6 @@ export const comeGetMe = \"You got me!\""
             res.body('Hello, World!').send();
           } else {
             res.body('Hello, Failure!').send();
-          }
-        }
-
-        on start {
-          const serverStatus = listen(8080);
-          if serverStatus.isErr() {
-            emit exit 1;
           }
         }
       "
@@ -153,10 +146,11 @@ export const comeGetMe = \"You got me!\""
     After afterEach
 
     It "runs js"
+      Pending how-do-we-detect-this-in-amm-to-js
       node test_$$/temp.js 1>/dev/null 2>/dev/null &
       PID=$!
       sleep 1
-      When run curl -s localhost:8080
+      When run curl -s localhost:8000
       The output should eq "Hello, World!"
     End
 
@@ -164,7 +158,7 @@ export const comeGetMe = \"You got me!\""
       alan run test_$$/temp.agc 1>/dev/null 2>/dev/null &
       PID=$!
       sleep 1
-      When run curl -s localhost:8080
+      When run curl -s localhost:8000
       The output should eq "Hello, World!"
     End
   End

--- a/compiler/src/ammtojs.ts
+++ b/compiler/src/ammtojs.ts
@@ -89,6 +89,7 @@ const ammToJsText = (amm: LPNode) => {
   }
   // We can also skip the event declarations because they are lazily bound by EventEmitter
   // Now we convert the handlers to Javascript. This is the vast majority of the work
+  let hasConn = false
   for (const handler of amm.get('handlers').getAll()) {
     const rec = handler.get()
     if (!(rec instanceof NamedAnd)) continue
@@ -98,10 +99,12 @@ const ammToJsText = (amm: LPNode) => {
     }
     const eventVarName = !(arg instanceof NulLP) ?
       arg.get('variable').t : ""
+    if (rec.get('variable').t === '__conn') hasConn = true
     outFile += `r.on('${rec.get('variable').t}', async (${eventVarName}) => {\n`
     outFile += functionbodyToJsText(rec.get('functions').get('functionbody'), '')
     outFile += '})\n' // End this handler
   }
+  if (hasConn) outFile += "r.on('_start', () => r.httplsn())\n" // Make sure a web server starts up
   outFile += "r.emit('_start', undefined)\n" // Let's get it started in here
   return outFile
 }

--- a/compiler/src/lntoamm/opcodes.ts
+++ b/compiler/src/lntoamm/opcodes.ts
@@ -732,7 +732,6 @@ addopcodes({
   gtef64: [{ a: t('float64'), b: t('float64'), }, t('bool')],
   gtestr: [{ a: t('string'), b: t('string'), }, t('bool')],
   httpreq: [{ a: t('InternalRequest')}, t('Result<InternalResponse>')],
-  httplsn: [{ a: t('int64'), }, t('Result<string>')],
   httpsend: [{ a: t('InternalResponse'), }, t('Result<string>')],
   execop: [{ a: t('string')}, t('ExecRes')],
   waitop: [{ a: t('int64')}, t('void')],

--- a/js-runtime/index.js
+++ b/js-runtime/index.js
@@ -940,7 +940,7 @@ module.exports = {
       return [ false, e.toString() ]
     }
   },
-  httplsn:  async (port) => {
+  httplsn:  async () => {
     const server = http.createServer((req, res) => {
       const connId = Number(hashf(Math.random().toString()))
       httpConns[connId] = {
@@ -961,12 +961,17 @@ module.exports = {
         ])
       })
     })
-    return await new Promise(resolve => {
-      server.on('error', e => resolve([ false, e.code, ]))
+    const listenResult = await new Promise(resolve => {
+      server.on('error', e => resolve(e))
       server.listen({
-        port: parseInt(port.toString()),
-      }, () => resolve([ true, 'ok', ]))
+        port: 8000,
+      }, () => resolve(true))
     })
+    if (listenResult === true) {
+      console.log("HTTP server listening on port 8000")
+    } else {
+      console.error(`HTTP server failed to listen to port 8000: ${e}`)
+    }
   },
   httpsend: ires => {
     const [ status, headers, body, connId, ] = ires

--- a/std/http.ln
+++ b/std/http.ln
@@ -1,5 +1,5 @@
 /**
- * @std/http - Built-in client and server for http
+ * @std/http - Built-in client for http(s)
  */
 
 // The InternalRequest type for http requests
@@ -132,64 +132,4 @@ export fn del(url: string): Result<string> {
   } else {
     return res;
   }
-}
-
-/**
- * HTTP Server
- */
-
-// The roll-up Connection type with both
-export type Connection {
-  req: Request,
-  res: Response,
-}
-
-// The connection event
-export event connection: Connection
-
-// The special connection event with a signature like `event __conn: InternalConnection`
-// This wrapper function takes the internal connection object, converts it to the user-friendly
-// connection object, and then emits it on a new event for user code to pick up
-on __conn fn (conn: InternalRequest) {
-  emit connection new Connection {
-    req: new Request {
-      method: conn.method,
-      url: conn.url,
-      headers: toHashMap(conn.headers),
-      body: conn.body,
-    },
-    res: new Response {
-      status: 200, // If not set by the user, assume they meant it to be good
-      headers: newHashMap('Content-Length', '0'), // If not set by the user, assume no data
-      body: '', // If not set by the user, assume no data
-      connId: conn.connId,
-    },
-  };
-}
-
-// The body function sets the body for a Response, sets the Content-Length header, and retuns the
-// Response for chaining needs
-export fn body(res: Response, body: string) {
-  res.body = body;
-  const len = body.length();
-  set(res.headers, 'Content-Length', len.toString());
-  return res;
-}
-
-// The status function sets the status of the response
-export fn status(res: Response, status: int64) {
-  res.status = status;
-  return res;
-}
-
-// The send function converts the response object into an internal response object and passed that
-// back to the HTTP server. A Result type with either an 'ok' string or an error is returned
-export fn send(res: Response): Result<string> {
-  const ires = new InternalResponse {
-    status: res.status,
-    headers: res.headers.keyVal,
-    body: res.body,
-    connId: res.connId,
-  };
-  return httpsend(ires);
 }

--- a/std/http.ln
+++ b/std/http.ln
@@ -167,11 +167,6 @@ on __conn fn (conn: InternalRequest) {
   };
 }
 
-// The listen function tells the http server to start up and listen on the given port
-// For now only one http server per application, a macro system is necessary to improve this
-// Returns a Result with either an 'ok' string or an error
-export fn listen(port: int64) = httplsn(port);
-
 // The body function sets the body for a Response, sets the Content-Length header, and retuns the
 // Response for chaining needs
 export fn body(res: Response, body: string) {

--- a/std/httpserver.ln
+++ b/std/httpserver.ln
@@ -1,0 +1,85 @@
+/**
+ * @std/httpserver - Built-in server for http
+ *
+ * Split from the client because of the automatic inclusion of event handlers when importing
+ */
+
+// Make sure we're using the same Request, Response definitions between the two
+from @std/http import Request, Response
+
+// The InternalRequest type for http requests
+type InternalRequest {
+  method: string,
+  url: string,
+  headers: Array<KeyVal<string, string>>,
+  body: string,
+  connId: int64,
+}
+
+// The InternalResponse type for http responses
+type InternalResponse {
+  status: int64,
+  headers: Array<KeyVal<string, string>>,
+  body: string,
+  connId: int64,
+}
+
+/**
+ * HTTP Server
+ */
+
+// The roll-up Connection type with both
+export type Connection {
+  req: Request,
+  res: Response,
+}
+
+// The connection event
+export event connection: Connection
+
+// The special connection event with a signature like `event __conn: InternalConnection`
+// This wrapper function takes the internal connection object, converts it to the user-friendly
+// connection object, and then emits it on a new event for user code to pick up
+on __conn fn (conn: InternalRequest) {
+  emit connection new Connection {
+    req: new Request {
+      method: conn.method,
+      url: conn.url,
+      headers: toHashMap(conn.headers),
+      body: conn.body,
+    },
+    res: new Response {
+      status: 200, // If not set by the user, assume they meant it to be good
+      headers: newHashMap('Content-Length', '0'), // If not set by the user, assume no data
+      body: '', // If not set by the user, assume no data
+      connId: conn.connId,
+    },
+  };
+}
+
+// The body function sets the body for a Response, sets the Content-Length header, and retuns the
+// Response for chaining needs
+export fn body(res: Response, body: string) {
+  res.body = body;
+  const len = body.length();
+  set(res.headers, 'Content-Length', len.toString());
+  return res;
+}
+
+// The status function sets the status of the response
+export fn status(res: Response, status: int64) {
+  res.status = status;
+  return res;
+}
+
+// The send function converts the response object into an internal response object and passed that
+// back to the HTTP server. A Result type with either an 'ok' string or an error is returned
+export fn send(res: Response): Result<string> {
+  const ires = new InternalResponse {
+    status: res.status,
+    headers: res.headers.keyVal,
+    body: res.body,
+    connId: res.connId,
+  };
+  return httpsend(ires);
+}


### PR DESCRIPTION
Had to split the http client from the server because the `__conn` event handler is auto-attached when importing and that handler was being used to determine whether or not the http server should be started or not, but it now works as intended, and we can make it switch to HTTPS in the daemon with the appropriate PEM file being handed to it in a follow-up PR. :)