### PR TITLE
Add daemon domain argument

### DIFF
--- a/avm/src/daemon/linux.rs
+++ b/avm/src/daemon/linux.rs
@@ -46,8 +46,6 @@ struct VMStatsV1 {
   freeSwapKb: u64,
 }
 
-const DOMAIN: &'static str = "anycloudapp.com";
-
 async fn get_private_ip() -> String {
   let res = Command::new("hostname")
     .arg("-I")
@@ -136,14 +134,15 @@ async fn post_v1_stats(cluster_id: &str, deploy_token: &str) -> String {
   post_v1("stats", stats_body).await
 }
 
-pub async fn start(cluster_id: &str, agz_b64: &str, deploy_token: &str) {
+pub async fn start(cluster_id: &str, agz_b64: &str, deploy_token: &str, domain: &str) {
   let cluster_id = cluster_id.to_string();
   let deploy_token = deploy_token.to_string();
   let agzb64 = agz_b64.to_string();
+  let domain = domain.to_string();
   task::spawn(async move {
     // TODO better period determination
     let period = Duration::from_secs(180);
-    let dns = DNS::new(DOMAIN);
+    let dns = DNS::new(domain);
     let self_ip = get_private_ip().await;
     let mut cluster_size = 0;
     let mut leader_ip = "".to_string();

--- a/avm/src/daemon/linux.rs
+++ b/avm/src/daemon/linux.rs
@@ -142,7 +142,7 @@ pub async fn start(cluster_id: &str, agz_b64: &str, deploy_token: &str, domain: 
   task::spawn(async move {
     // TODO better period determination
     let period = Duration::from_secs(180);
-    let dns = DNS::new(domain);
+    let dns = DNS::new(&domain);
     let self_ip = get_private_ip().await;
     let mut cluster_size = 0;
     let mut leader_ip = "".to_string();

--- a/avm/src/daemon/nonlinux.rs
+++ b/avm/src/daemon/nonlinux.rs
@@ -1,3 +1,3 @@
-pub async fn start(_app_id: &str, _agz_b64: &str, _deploy_token: &str) {
+pub async fn start(_app_id: &str, _agz_b64: &str, _deploy_token: &str, _domain: &str) {
   panic!("Daemon only works on Linux");
 }

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -77,6 +77,7 @@ fn main() {
       .arg_from_usage("<APP_ID> 'Specifies the alan app to upgrade'")
       .arg_from_usage("<AGZ_B64> 'Specifies the .agz program as a base64 encoded string'")
       .arg_from_usage("<DEPLOY_TOKEN> 'Specifies the deploy token'")
+      .arg_from_usage("<DOMAIN> 'Specifies the application domain'")
     )
     .arg_from_usage("[SOURCE] 'Specifies a source ln file to compile and run'");
 
@@ -158,7 +159,8 @@ fn main() {
         let app_id = matches.value_of("APP_ID").unwrap();
         let agz_b64 = matches.value_of("AGZ_B64").unwrap();
         let deploy_token = matches.value_of("DEPLOY_TOKEN").unwrap();
-        start(app_id, agz_b64, deploy_token).await;
+        let domain = matches.value_of("DOMAIN").unwrap();
+        start(app_id, agz_b64, deploy_token, domain).await;
       },
       _ => {
         // AppSettings::SubcommandRequiredElseHelp does not cut it here


### PR DESCRIPTION
The `alan daemon` stop using the hardcoded `anycloudapp.com` value and use the provided domain with its dns client.