### PR TITLE
HTTPS Server support in alan daemon

### DIFF
--- a/avm/Cargo.lock
+++ b/avm/Cargo.lock
@@ -29,12 +29,14 @@ name = "alan"
 version = "0.1.32"
 dependencies = [
  "anycloud",
+ "async-stream",
  "base64",
  "byteorder",
  "clap",
  "dashmap",
  "flate2",
  "futures",
+ "futures-util",
  "heim",
  "hyper",
  "hyper-rustls",
@@ -42,9 +44,11 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "regex",
+ "rustls",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-rustls",
  "trust-dns-resolver",
  "twox-hash",
 ]
@@ -97,6 +101,27 @@ name = "ascii_table"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f0a58f3b1453981b910b603a4a7346be14fccd50f8edd7c954725a9210c24f"
+
+[[package]]
+name = "async-stream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-trait"

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -16,21 +16,25 @@ edition = "2018"
 anycloud = { git = "https://github.com/alantech/anycloud", branch = "main" }
 # For local development, it is possible to specify a relative path location instead of a git repository
 # anycloud = { path = "../../anycloud/cli" }
+async-stream = "0.3.0"
 base64 = "0.13"
 byteorder = "1.3.4"
 clap = "2.33.1"
 dashmap = "3.11.10"
+flate2 = "1.0"
 futures = "0.3.8"
+futures-util = "0.3.13"
+heim = "0.0.11"
 hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server"] }
 hyper-rustls = "0.22.1" # needed for HTTPS w/ hyper
 num_cpus = "1.0"
 once_cell = "1.5.2"
 rand = "0.7.3"
 regex = "1"
+rustls = "0.19.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-heim = "0.0.11"
-trust-dns-resolver = { version = "0.20.0", features = ["dns-over-rustls"] }
 tokio = { version = "1.2", features = ["rt-multi-thread", "macros", "process", "sync", "time"] }
+tokio-rustls = "0.22.0"
+trust-dns-resolver = { version = "0.20.0", features = ["dns-over-rustls"] }
 twox-hash = "1.5.0"
-flate2 = "1.0"

--- a/avm/src/daemon/linux.rs
+++ b/avm/src/daemon/linux.rs
@@ -134,7 +134,14 @@ async fn post_v1_stats(cluster_id: &str, deploy_token: &str) -> String {
   post_v1("stats", stats_body).await
 }
 
-pub async fn start(cluster_id: &str, agz_b64: &str, deploy_token: &str, domain: &str) {
+pub async fn start(
+  cluster_id: &str,
+  agz_b64: &str,
+  deploy_token: &str,
+  domain: &str,
+  priv_key_b64: Option<&str>,
+  cert_b64: Option<&str>,
+) {
   let cluster_id = cluster_id.to_string();
   let deploy_token = deploy_token.to_string();
   let agzb64 = agz_b64.to_string();
@@ -166,5 +173,5 @@ pub async fn start(cluster_id: &str, agz_b64: &str, deploy_token: &str, domain: 
       sleep(period).await
     }
   });
-  run_agz_b64(agz_b64).await;
+  run_agz_b64(agz_b64, priv_key_b64, cert_b64).await;
 }

--- a/avm/src/daemon/nonlinux.rs
+++ b/avm/src/daemon/nonlinux.rs
@@ -1,3 +1,10 @@
-pub async fn start(_app_id: &str, _agz_b64: &str, _deploy_token: &str, _domain: &str) {
+pub async fn start(
+  _app_id: &str,
+  _agz_b64: &str,
+  _deploy_token: &str,
+  _domain: &str,
+  _priv_key_b64: Option<&str>,
+  _cert_b64: Option<&str>,
+) {
   panic!("Daemon only works on Linux");
 }

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -78,6 +78,8 @@ fn main() {
       .arg_from_usage("<AGZ_B64> 'Specifies the .agz program as a base64 encoded string'")
       .arg_from_usage("<DEPLOY_TOKEN> 'Specifies the deploy token'")
       .arg_from_usage("<DOMAIN> 'Specifies the application domain'")
+      .arg_from_usage("-k, --private-key=[PRIV_KEY_B64] 'An optional base64 encoded private key for HTTPS mode'")
+      .arg_from_usage("-c, --certificate=[CERT_B64] 'An optional base64 encoded certificate for HTTPS mode'")
     )
     .arg_from_usage("[SOURCE] 'Specifies a source ln file to compile and run'");
 
@@ -161,6 +163,9 @@ fn main() {
         let deploy_token = matches.value_of("DEPLOY_TOKEN").unwrap();
         let domain = matches.value_of("DOMAIN").unwrap();
         start(app_id, agz_b64, deploy_token, domain).await;
+        let priv_key_b64 = matches.value_of("private-key");
+        let cert_b64 = matches.value_of("certificate");
+        start(app_id, agz_b64, deploy_token, domain, priv_key_b64, cert_b64).await;
       },
       _ => {
         // AppSettings::SubcommandRequiredElseHelp does not cut it here

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -162,7 +162,6 @@ fn main() {
         let agz_b64 = matches.value_of("AGZ_B64").unwrap();
         let deploy_token = matches.value_of("DEPLOY_TOKEN").unwrap();
         let domain = matches.value_of("DOMAIN").unwrap();
-        start(app_id, agz_b64, deploy_token, domain).await;
         let priv_key_b64 = matches.value_of("private-key");
         let cert_b64 = matches.value_of("certificate");
         start(app_id, agz_b64, deploy_token, domain, priv_key_b64, cert_b64).await;

--- a/avm/src/vm/program.rs
+++ b/avm/src/vm/program.rs
@@ -4,7 +4,7 @@ use once_cell::sync::OnceCell;
 
 use crate::vm::event::{BuiltInEvents, EventHandler};
 use crate::vm::instruction::Instruction;
-use crate::vm::opcode::{ByteOpcode, opcode_id, OPCODES};
+use crate::vm::opcode::{ByteOpcode, opcode_id, OPCODES, HttpType};
 
 // Facilitates parsing the alan graph code program
 struct BytecodeParser {
@@ -66,7 +66,7 @@ pub struct Program {
   /// Memory of the program for global variables and string literals
   pub(crate) gmem: Vec<(usize, i64)>,
   /// The port the http server should use
-  pub(crate) http_port: u16,
+  pub(crate) http_config: HttpType,
 }
 
 pub static PROGRAM: OnceCell<Program> = OnceCell::new();
@@ -95,13 +95,13 @@ impl Program {
   }
 
   // Parses and safely initializes the alan graph code program as static, global data
-  pub fn load(bytecode: Vec<i64>, http_port: u16) -> Program {
+  pub fn load(bytecode: Vec<i64>, http_config: HttpType) -> Program {
     let mut parser = BytecodeParser { pc: 0, bytecode };
     let mut program = Program {
       event_handlers: HashMap::new(),
       event_pls: HashMap::new(),
       gmem: Vec::new(),
-      http_port,
+      http_config,
     };
     program.load_builtin();
     // parse agc version

--- a/avm/src/vm/run.rs
+++ b/avm/src/vm/run.rs
@@ -97,6 +97,7 @@ pub async fn run_file(fp: &str, delete_after_load: bool) {
   run(bytecode, HttpType::HTTP(HttpConfig { port: 8000, })).await;
 }
 
+// Used by the `daemon` mode only
 pub async fn run_agz_b64(agz_b64: &str, priv_key_b64: Option<&str>, cert_b64: Option<&str>) {
   let bytes = base64::decode(agz_b64).unwrap();
   let agz = GzDecoder::new(bytes.as_slice());


### PR DESCRIPTION
If you provide base64-encoded PEM files for a private key and a certificate to the alan daemon, it will switch the HTTP server to port 443 and use the cert and private key to run an HTTPS server.