### PR TITLE
Create a void value in the AVM with restrictions on usage

### DIFF
--- a/compiler/src/lntoamm/UserFunction.ts
+++ b/compiler/src/lntoamm/UserFunction.ts
@@ -680,7 +680,14 @@ ${statements[i].statementAst.t.trim()} on line ${statements[i].statementAst.line
     const inputTypes = inputs.map(i => i.outputType)
     const originalTypes = Object.values(this.getArguments())
     const interfaceMap: Map<Type, Type> = new Map()
-    originalTypes.forEach((t, i) => t.typeApplies(inputTypes[i], scope, interfaceMap))
+    originalTypes.forEach((t, i) => {
+      t.typeApplies(inputTypes[i], scope, interfaceMap)
+      // if the parameter is a void, that's illegal!
+      // TODO: if ammtoaga throws an equivalent error, then typeApplies is missing some cases
+      if (t.typeApplies(Type.builtinTypes['void'], scope, interfaceMap)) {
+        throw new Error(`Illegal void parameter '${realArgNames[i]}' in function '${this.getName()}'`)
+      }
+    })
     for (let i = 0; i < internalNames.length; i++) {
       const realArgName = realArgNames[i]
       // Instead of copying the relevant data, define a reference to where the data is located with


### PR DESCRIPTION
As part of the work in #430, early returning from conditionally executed code works in all cases except in functions that are returning a `void` value. This is because conditionally executed closures return a `Maybe<T>`, where `T` is the return value of the topmost function. If the closure returns `Some` value, that indicates that the current function being executed is done, as a result has been computed and should be provided to the caller, while `None` means that no value has been computed yet and more work has to be done in order for the top-most function to compute its return value. However, as it currently stands in the AVM, there is no way to early-return from a `void` function, as `void` is supposed to indicate the *absence* of a value - exactly the same as what `None` is supposed to indicate. Since the compiler currently cannot change these meanings, that means that we must work around this constraint in order to get early-returning from functions that return `void` to work. As a temporary solution, we've determined offline to add a special `void` value at the AVM level to work around this issue until the compiler is smart enough to change the meaning of product types that contain `void`.

The goal of this PR is very similar to #433, except:
1. This is creating a value, not a closure (although the value of `void` itself will be aliased to the same value as `NOP`)
2. Usages of the `void` value must be validated by enforcing certain rules

The proposed rules of the `void` value are:
- may be `return`ed
- may be used as an argument to functions that accept either `any` or `void`
- may not be used as a parameter in user-defined functions (ideally, it would never be used as a parameter, but the `copyvoid` opcode must exist for now)
- may not be mutated
- may not be observed

In order to accomplish this:
- [ ] Determine which stage(s) of the compiler should enforce (which of) the rules
- [ ] Implement the rule-enforcement scheme(s)
- [ ] Rewrite all `void` values to use the single-instance `void` value