### PR TITLE
Add the control port v0 implementation

### DIFF
--- a/avm/src/vm/run.rs
+++ b/avm/src/vm/run.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -6,6 +7,7 @@ use std::sync::Arc;
 use base64;
 use byteorder::{LittleEndian, ReadBytesExt};
 use flate2::read::GzDecoder;
+use hyper::{Body, Request, Response};
 use once_cell::sync::OnceCell;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
@@ -97,6 +99,11 @@ pub async fn run_file(fp: &str, delete_after_load: bool) {
   run(bytecode, HttpType::HTTP(HttpConfig { port: 8000, })).await;
 }
 
+async fn control_port(_req: Request<Body>) -> Result<Response<Body>, Infallible> {
+  // TODO: Add secret validation once the deploy service starts creating one for the cluster
+  Ok(Response::builder().status(200).body("ok".into()).unwrap())
+}
+
 // Used by the `daemon` mode only
 pub async fn run_agz_b64(agz_b64: &str, priv_key_b64: Option<&str>, cert_b64: Option<&str>) {
   let bytes = base64::decode(agz_b64).unwrap();
@@ -106,6 +113,12 @@ pub async fn run_agz_b64(agz_b64: &str, priv_key_b64: Option<&str>, cert_b64: Op
   let mut gz = GzDecoder::new(bytes.as_slice());
   gz.read_i64_into::<LittleEndian>(&mut bytecode).unwrap();
   if priv_key_b64.is_some() && cert_b64.is_some() {
+    // Spin up a control port if we can start a secure connection
+    make_server!(HttpType::HTTPS(HttpsConfig {
+      port: 4142, // 4 = A, 1 = L, 2 = N (sideways) => ALAN
+      priv_key_b64: priv_key_b64.unwrap().to_string(),
+      cert_b64: cert_b64.unwrap().to_string(),
+    }), control_port);
     run(bytecode, HttpType::HTTPS(HttpsConfig{
       port: 443,
       priv_key_b64: priv_key_b64.unwrap().to_string(),


### PR DESCRIPTION
Breaking this up into multiple PRs. The next one will be in the deploy service to make 4142 public and start using it for pinging, then a PR to add accepting an optional secret token to the AVM, then to get the deploy service to use that, then making it non-optional as the last PR for the initial version of the control port.