### PR TITLE
Implement @std/tcp for the js-runtime

### DIFF
--- a/bdd/spec/033_tcp_spec.sh
+++ b/bdd/spec/033_tcp_spec.sh
@@ -1,0 +1,60 @@
+Include build_tools.sh
+
+Describe "@std/tcp"
+  Describe "webserver tunnel test"
+    before() {
+      sourceToTemp "
+        from @std/tcpserver import tcpConn
+        from @std/tcp import TcpChannel, connect, addContext, ready, chunk, TcpContext, read, write, tcpClose, close
+
+        on tcpConn fn (channel: TcpChannel) {
+          const tunnel = connect('localhost', 8088);
+          channel.addContext(tunnel);
+          tunnel.addContext(channel);
+          channel.ready();
+          tunnel.ready();
+        }
+
+        on chunk fn (ctx: TcpContext<TcpChannel>) {
+          ctx.context.write(ctx.channel.read());
+        }
+
+        on tcpClose fn (ctx: TcpContext<TcpChannel>) {
+          ctx.context.close();
+        }
+      "
+      tempToAmm
+      tempToJs
+      sourceToFile test_server.js "
+        const http = require('http')
+
+        http.createServer((req, res) => res.end('Hello, World!')).listen(8088)
+      "
+    }
+    BeforeAll before
+
+    after() {
+      cleanTemp
+    }
+    AfterAll after
+
+    afterEach() {
+      kill $PID1
+      wait $PID1 2>/dev/null
+      kill $PID2
+      wait $PID2 2>/dev/null
+      return 0
+    }
+    After afterEach
+
+    It "runs js"
+      node test_$$/test_server.js 1>/dev/null 2>/dev/null &
+      PID1=$!
+      node test_$$/temp.js 1>/dev/null 2>/dev/null &
+      PID2=$!
+      sleep 1
+      When run curl -s localhost:8000
+      The output should eq "Hello, World!"
+    End
+  End
+End

--- a/compiler/src/ammtojs.ts
+++ b/compiler/src/ammtojs.ts
@@ -90,6 +90,7 @@ const ammToJsText = (amm: LPNode) => {
   // We can also skip the event declarations because they are lazily bound by EventEmitter
   // Now we convert the handlers to Javascript. This is the vast majority of the work
   let hasConn = false
+  let hasTcpConn = false
   for (const handler of amm.get('handlers').getAll()) {
     const rec = handler.get()
     if (!(rec instanceof NamedAnd)) continue
@@ -100,11 +101,13 @@ const ammToJsText = (amm: LPNode) => {
     const eventVarName = !(arg instanceof NulLP) ?
       arg.get('variable').t : ""
     if (rec.get('variable').t === '__conn') hasConn = true
+    if (rec.get('variable').t === 'tcpConn') hasTcpConn = true
     outFile += `r.on('${rec.get('variable').t}', async (${eventVarName}) => {\n`
     outFile += functionbodyToJsText(rec.get('functions').get('functionbody'), '')
     outFile += '})\n' // End this handler
   }
   if (hasConn) outFile += "r.on('_start', () => r.httplsn())\n" // Make sure a web server starts up
+  if (hasTcpConn) outFile += "r.on('_start', () => r.tcplsn())\n" // Make sure a server starts up
   outFile += "r.emit('_start', undefined)\n" // Let's get it started in here
   return outFile
 }

--- a/compiler/src/lntoamm/Type.ts
+++ b/compiler/src/lntoamm/Type.ts
@@ -678,6 +678,14 @@ export class Type {
       }),
       recurseFn: new Type("function", true),
     }),
+    TcpChannel: new Type("TcpChannel", true),
+    TcpContext: new Type("TcpContext", true, false, {
+      context: new Type("C", true, true),
+      channel: new Type("TcpChannel", true),
+    }, {
+      C: 0,
+    }),
+    Chunk: new Type("Chunk", true),
     "function": new Type("function", true),
     operator: new Type("operator", true),
     Event: new Type("Event", true, false, {

--- a/compiler/src/lntoamm/opcodes.ts
+++ b/compiler/src/lntoamm/opcodes.ts
@@ -861,6 +861,7 @@ addopcodes({
   seqrec: [{ seq: t('Seq'), recurseFn: t('function'), }, t('Self')],
   tcpconn: [{ host: t('string'), port: t('int16'), }, t('TcpChannel')],
   tcpAddC: [{ channel: t('TcpChannel'), context: t('any'), }, t('TcpChannel')],
+  tcpReady: [{ channel: t('TcpChannel'), }, t('TcpChannel')],
   tcpRead: [{ channel: t('TcpChannel'), }, t('Chunk')],
   tcpWrite: [{ channel: t('TcpChannel'), chunk: t('Chunk'), }, t('TcpChannel')],
   tcpTerm: [{ channel: t('TcpChannel'), }, t('void')],

--- a/compiler/src/lntoamm/opcodes.ts
+++ b/compiler/src/lntoamm/opcodes.ts
@@ -19,7 +19,8 @@ const addBuiltIn = (name: string) => {
 ([
   'void', 'int8', 'int16', 'int32', 'int64', 'float32', 'float64', 'bool', 'string', 'function',
   'operator', 'Error', 'Maybe', 'Result', 'Either', 'Array', 'ExecRes', 'InitialReduce',
-  'KeyVal', 'InternalRequest', 'InternalResponse', 'Seq', 'Self',
+  'KeyVal', 'InternalRequest', 'InternalResponse', 'Seq', 'Self', 'TcpChannel', 'TcpContext',
+  'Chunk',
 ].map(addBuiltIn))
 Type.builtinTypes['Array'].solidify(['string'], opcodeScope)
 opcodeScope.put('any', new Type('any', true, false, {}, {}, null, new Interface('any')))
@@ -31,6 +32,7 @@ Type.builtinTypes['Array'].solidify(['any'], opcodeScope)
 Type.builtinTypes['Array'].solidify(['anythingElse'], opcodeScope)
 Type.builtinTypes['KeyVal'].solidify(['string', 'string'], opcodeScope)
 Type.builtinTypes['Array'].solidify(['KeyVal<string, string>'], opcodeScope)
+Type.builtinTypes['TcpContext'].solidify(['any'], opcodeScope)
 // HTTP server opcode-related builtin Types hackery, also defined in std/http.ln
 Type.builtinTypes.InternalRequest.properties = {
   method: opcodeScope.get('string') as Type,

--- a/compiler/src/lntoamm/opcodes.ts
+++ b/compiler/src/lntoamm/opcodes.ts
@@ -62,6 +62,9 @@ Type.builtinTypes.Either.solidify(['any', 'anythingElse'], opcodeScope)
 Type.builtinTypes.InitialReduce.solidify(['any', 'anythingElse'], opcodeScope)
 opcodeScope.put("start", new Event("_start", Type.builtinTypes.void, true))
 opcodeScope.put("__conn", new Event("__conn", Type.builtinTypes.InternalRequest, true))
+opcodeScope.put("tcpConn", new Event("tcpConn", Type.builtinTypes.TcpChannel, true))
+opcodeScope.put("chunk", new Event("chunk", opcodeScope.get('TcpContext<any>') as Type, true))
+opcodeScope.put("tcpClose", new Event("tcpClose", opcodeScope.get('TcpContext<any>') as Type, true))
 const t = (str: string) => opcodeScope.get(str)
 
 // opcode declarations
@@ -856,6 +859,11 @@ addopcodes({
   seqdo: [{ seq: t('Seq'), bodyFn: t('function'), }, t('void')],
   selfrec: [{ self: t('Self'), arg: t('any'), }, t('Result<anythingElse>')],
   seqrec: [{ seq: t('Seq'), recurseFn: t('function'), }, t('Self')],
+  tcpconn: [{ host: t('string'), port: t('int16'), }, t('TcpChannel')],
+  tcpAddC: [{ channel: t('TcpChannel'), context: t('any'), }, t('TcpChannel')],
+  tcpRead: [{ channel: t('TcpChannel'), }, t('Chunk')],
+  tcpWrite: [{ channel: t('TcpChannel'), chunk: t('Chunk'), }, t('TcpChannel')],
+  tcpTerm: [{ channel: t('TcpChannel'), }, t('void')],
 })
 
 export default opcodeModule

--- a/rfcs/015 - TCP RFC.md
+++ b/rfcs/015 - TCP RFC.md
@@ -17,7 +17,8 @@
 
 ### Implementation
 
-- [ ] Implemented: [One or more PRs](https://github.com/alantech/alan/some-pr-link-here) YYYY-MM-DD
+- Implemented: 
+  - [x] [Implement @std/tcp for the js-runtime](https://github.com/alantech/alan/pull/470) 2021-03-31 
 - [ ] Revoked/Superceded by: [RFC ###](./000 - RFC Template.md) YYYY-MM-DD
 
 ## Author(s)

--- a/std/tcp.ln
+++ b/std/tcp.ln
@@ -28,6 +28,11 @@ export fn connect(host: string, port: int16) = tcpconn(host, port);
 // but this type is opaque so it is fine. `tcpAddC` has the type `fn(TcpChannel, any): TcpChannel`
 export fn addContext(channel: TcpChannel, context: any) = tcpAddC(channel, context);
 
+// Marks the channel as ready to receive data from the other side. Useful if data is immediately
+// pushed at you, which is common for servers, but also possible for clients
+// `tcpReady` has the type `fn (TcpChannel): void`
+export fn ready(channel: TcpChannel) = tcpReady(channel);
+
 // Reads a chunk of data from a channel. Since this is supposed to be called when the `chunk` event
 // is triggered, it is a CPU-bound operation that returns a chunk referencing actual data on the
 // first call, and a chunk representing no data on subsequent calls until the event is triggered

--- a/std/tcp.ln
+++ b/std/tcp.ln
@@ -22,7 +22,7 @@ export tcpClose
 // Creates a client connection to a TCP server.
 // `tcpconn` has the type signature `fn(string, int16): TcpChannel`
 export fn connect(host: string, port: int64) = tcpconn(host, port.toInt16());
-export fn connect(host: string, port: int16) = tcpconn(host, port));
+export fn connect(host: string, port: int16) = tcpconn(host, port);
 
 // Attaches a context value to a channel. Exposed to the other events wrapped the other way around
 // but this type is opaque so it is fine. `tcpAddC` has the type `fn(TcpChannel, any): TcpChannel`
@@ -65,8 +65,9 @@ export fn write(channel: TcpChannel, chunk: Chunk) = tcpWrite(channel, chunk);
  */
 
 // Closes a channel. Always succeeds even if the underlying channel is already closed.
-// `tcpClose` has the type `fn(TcpChannel): void`
-export fn close(channel: TcpChannel) = tcpClose(channel);
+// `tcpTerm` has the type `fn(TcpChannel): void` (called `tcpTerm` to not clash with the `tcpClose`
+// event defined above
+export fn close(channel: TcpChannel) = tcpTerm(channel);
 
 /**
  * TODO: The following functions should eventually be added for inspecting channel status, but they

--- a/std/tcp.ln
+++ b/std/tcp.ln
@@ -1,0 +1,78 @@
+/**
+ * @std/tcp - Built-in client for TCP
+ */
+
+// Built-in opaque types for the AVM and js-runtime to implement
+export TcpChannel
+export Chunk
+
+// The TcpContext type. This type is also built-in as the it is emitted in the
+// `chunk` and `tcpClose` events
+export type TcpContext<C> {
+  channel: TcpChannel,
+  context: C,
+}
+
+// Built-in events for TCP channels, both client and server.
+// `chunk` has the signature `event chunk: Chunk`
+export chunk
+// `tcpClose` has the signature `event tcpClose: TcpContext<C>`
+export tcpClose
+
+// Creates a client connection to a TCP server.
+// `tcpconn` has the type signature `fn(string, int16): TcpChannel`
+export fn connect(host: string, port: int64) = tcpconn(host, port.toInt16());
+export fn connect(host: string, port: int16) = tcpconn(host, port));
+
+// Attaches a context value to a channel. Exposed to the other events wrapped the other way around
+// but this type is opaque so it is fine. `tcpAddC` has the type `fn(TcpChannel, any): TcpChannel`
+export fn addContext(channel: TcpChannel, context: any) = tcpAddC(channel, context);
+
+// Reads a chunk of data from a channel. Since this is supposed to be called when the `chunk` event
+// is triggered, it is a CPU-bound operation that returns a chunk referencing actual data on the
+// first call, and a chunk representing no data on subsequent calls until the event is triggered
+// again. `tcpRead` has the type `fn(TcpChannel): Chunk`
+export fn read(channel: TcpChannel) = tcpRead(channel);
+
+/**
+ * TODO: The following functions should eventually be added for manipulating chunks, but they will
+ * be implemented in a followup PR.
+ *
+ * fn toInt8Array(chunk: Chunk): Array<int8>
+ * fn toAsciiString(chunk: Chunk): String
+ * fn toUTF8ResultString(chunk: Chunk): Result<String>
+ *
+ */
+
+// Writes a chunk of data to a channel. This can be called as many times as desired whenever desired
+// but likely makes sense to happen on `chunk` events when there is some data to respond to. Though
+// an HTTP client built on top of this would likely write a lot of data immediately after creating
+// the connection. `tcpWrite` has the type `fn(TcpChannel, Chunk): TcpChannel`
+export fn write(channel: TcpChannel, chunk: Chunk) = tcpWrite(channel, chunk);
+
+/**
+ * TODO: The following functions should eventually be added for manipulating Alan types into chunks,
+ * but they will be implemented in a followup PR.
+ *
+ * fn toChunk(a8: Array<int8>): Chunk
+ * fn toChunk(s: String): Chunk
+ * fn toChunk(s: String, encoding: String): Result<Chunk>
+ *
+ * `encoding` would ideally be an enum if/when we add them to the language, but for now is an
+ * arbitrary string of the encoding format. Can fail if the encoding isn't known or if the
+ * provided string can't be encoded in the specified format.
+ *
+ */
+
+// Closes a channel. Always succeeds even if the underlying channel is already closed.
+// `tcpClose` has the type `fn(TcpChannel): void`
+export fn close(channel: TcpChannel) = tcpClose(channel);
+
+/**
+ * TODO: The following functions should eventually be added for inspecting channel status, but they
+ * will be implemented in a followup PR.
+ *
+ * fn getState(channel: TcpChannel): string
+ * fn getCloseReason(channel: TcpChannel): string
+ *
+ */

--- a/std/tcpserver.ln
+++ b/std/tcpserver.ln
@@ -1,0 +1,6 @@
+/**
+ * @std/tcpserver - Built-in server for TCP
+ */
+
+// Built-in event solely for the TCP server. Has the signature `event tcpConn: TcpChannel`
+export tcpConn


### PR DESCRIPTION
Needed to add a `ready` function to get it working as desired. Glad it was caught by the js-runtime since I think the AVM is even more vulnerable to this problem.