### PR TITLE
more consistent cli api naming proposal

### DIFF
--- a/anycloud/cli/src/main.rs
+++ b/anycloud/cli/src/main.rs
@@ -129,7 +129,7 @@ pub async fn main() {
       .about("Deploys your repository to a new App with a Deploy Config from anycloud.json")
       .arg_from_usage("-e, --env-file=[ENV_FILE] 'Specifies an optional environment file'")
     )
-    .subcommand(SubCommand::with_name("info")
+    .subcommand(SubCommand::with_name("list")
       .about("Displays all the Apps deployed with the Deploy Configs from anycloud.json")
     )
     .subcommand(SubCommand::with_name("terminate")
@@ -142,7 +142,7 @@ pub async fn main() {
     .subcommand(SubCommand::with_name("config")
       .about("Manage Deploy Configs used by Apps from the anycloud.json in the current directory")
       .setting(AppSettings::SubcommandRequiredElseHelp)
-      .subcommand(SubCommand::with_name("add")
+      .subcommand(SubCommand::with_name("new")
         .about("Add a new Deploy Config to the anycloud.json in the current directory and creates the file if it doesn't exist.")
       )
       .subcommand(SubCommand::with_name("list")
@@ -158,7 +158,7 @@ pub async fn main() {
     .subcommand(SubCommand::with_name("credentials")
       .about("Manage all Credentials used by Deploy Configs from the credentials file at ~/.anycloud/credentials.json")
       .setting(AppSettings::SubcommandRequiredElseHelp)
-      .subcommand(SubCommand::with_name("add")
+      .subcommand(SubCommand::with_name("new")
         .about("Add a new Credentials")
       )
       .subcommand(SubCommand::with_name("list")
@@ -204,10 +204,10 @@ pub async fn main() {
       )
       .await;
     }
-    ("info", _) => deploy::info().await,
+    ("list", _) => deploy::info().await,
     ("credentials", Some(sub_matches)) => {
       match sub_matches.subcommand() {
-        ("add", _) => {
+        ("new", _) => {
           deploy::add_cred().await;
         }
         ("edit", _) => deploy::edit_cred().await,
@@ -219,7 +219,7 @@ pub async fn main() {
     }
     ("config", Some(sub_matches)) => {
       match sub_matches.subcommand() {
-        ("add", _) => deploy::add_deploy_config().await,
+        ("new", _) => deploy::add_deploy_config().await,
         ("list", _) => deploy::list_deploy_configs().await,
         ("edit", _) => deploy::edit_deploy_config().await,
         ("remove", _) => deploy::remove_deploy_config().await,

--- a/anycloud/docs/reference/cli-api.md
+++ b/anycloud/docs/reference/cli-api.md
@@ -18,7 +18,7 @@ SUBCOMMANDS:
     credentials    Manage all Credentials used by Deploy Configs from the credentials file at
                    ~/.anycloud/credentials.json
     help           Prints this message or the help of the given subcommand(s)
-    info           Displays all the Apps deployed with the Deploy Configs from anycloud.json
+    list           Displays all the Apps deployed with the Deploy Configs from anycloud.json
     new            Deploys your repository to a new App with a Deploy Config from anycloud.json
     terminate      Terminate an App hosted in one of the Deploy Configs from anycloud.json
     upgrade        Deploys your repository to an existing App hosted in one of the Deploy Configs from anycloud.json
@@ -58,14 +58,14 @@ OPTIONS:
     -e, --env-file <ENV_FILE>    Specifies an optional environment file relative path
 ```
 
-## info
+## list
 
 ```
-$ anycloud help info
+$ anycloud help list
 Displays all the Apps deployed with the Deploy Configs from anycloud.json
 
 USAGE:
-    anycloud info
+    anycloud list
 
 FLAGS:
     -h, --help       Prints help information
@@ -100,7 +100,7 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
-    add       Add a new Credentials
+    new       Add a new Credentials
     edit      Edit an existing Credentials
     help      Prints this message or the help of the given subcommand(s)
     list      List all the available Credentials
@@ -121,7 +121,7 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
-    add       Add a new Deploy Config to the anycloud.json in the current directory and creates the file if it
+    new       Add a new Deploy Config to the anycloud.json in the current directory and creates the file if it
               doesn't exist.
     edit      Edit an existing Deploy Config from the anycloud.json in the current directory
     help      Prints this message or the help of the given subcommand(s)

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
         .about("Deploys an .agz file to a new app with one of the Deploy Configs from anycloud.json")
         .arg_from_usage("<AGZ_FILE> 'Specifies the .agz file to deploy'")
       )
-      .subcommand(SubCommand::with_name("info")
+      .subcommand(SubCommand::with_name("list")
         .about("Displays all the Apps deployed with the Deploy Configs from anycloud.json")
       )
       .subcommand(SubCommand::with_name("terminate")
@@ -74,7 +74,7 @@ fn main() {
       .subcommand(SubCommand::with_name("config")
         .about("Manage Deploy Configs used by Apps from the anycloud.json in the current directory")
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .subcommand(SubCommand::with_name("add")
+        .subcommand(SubCommand::with_name("new")
           .about("Add a new Deploy Config to the anycloud.json in the current directory and creates the file if it doesn't exist.")
         )
         .subcommand(SubCommand::with_name("list")
@@ -90,7 +90,7 @@ fn main() {
       .subcommand(SubCommand::with_name("credentials")
         .about("Manage all Credentials used by Deploy Configs from the credentials file at ~/.anycloud/credentials.json")
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .subcommand(SubCommand::with_name("add")
+        .subcommand(SubCommand::with_name("new")
           .about("Add a new Credentials")
         )
         .subcommand(SubCommand::with_name("list")
@@ -168,10 +168,10 @@ fn main() {
             let agz_file = matches.value_of("AGZ_FILE").unwrap();
             deploy::upgrade(get_agz_b64(agz_file), None, None).await;
           }
-          ("info", _) => deploy::info().await,
+          ("list", _) => deploy::info().await,
           ("credentials", Some(sub_matches)) => {
             match sub_matches.subcommand() {
-              ("add", _) => {
+              ("new", _) => {
                 deploy::add_cred().await;
               }
               ("edit", _) => deploy::edit_cred().await,
@@ -183,7 +183,7 @@ fn main() {
           }
           ("config", Some(sub_matches)) => {
             match sub_matches.subcommand() {
-              ("add", _) => deploy::add_deploy_config().await,
+              ("new", _) => deploy::add_deploy_config().await,
               ("list", _) => deploy::list_deploy_configs().await,
               ("edit", _) => deploy::edit_deploy_config().await,
               ("remove", _) => deploy::remove_deploy_config().await,


### PR DESCRIPTION
now top-level `app` cli commands and `credential`/`config` only differ in the nomenclature for editing them which is `upgrade` and `edit` respectively