### PR TITLE
Change test suite to Node 14 and up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.20.1, 12.x, 14.x]
+        node-version: [14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -81,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.20.1, 12.x, 14.x]
+        node-version: [14.x, 16.x]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
This unblocks the `??` and `?.` operators (amongst other features) that need at least Node 14. Since all major browsers support these operators now, it's safe to require and we can make the compiler a bit easier to read in certain circumstances.