### PR TITLE
Eliminate the last flaky test

### DIFF
--- a/bdd/spec/023_http_spec.sh
+++ b/bdd/spec/023_http_spec.sh
@@ -242,6 +242,7 @@ connection not found"
     End
 
     It "runs agc"
+      sleep 1
       alan run test_$$/temp.agc 1>./out.txt 2>/dev/null &
       sleep 1
       When run curl -s localhost:8000

--- a/bdd/spec/023_http_spec.sh
+++ b/bdd/spec/023_http_spec.sh
@@ -214,6 +214,7 @@ correct"
           print(firstMessage);
           const secondMessage = res.body('Second Message').send();
           print(secondMessage);
+          wait(100);
           emit exit 0;
         }
       "

--- a/bdd/spec/023_http_spec.sh
+++ b/bdd/spec/023_http_spec.sh
@@ -214,7 +214,7 @@ correct"
           print(firstMessage);
           const secondMessage = res.body('Second Message').send();
           print(secondMessage);
-          wait(100);
+          wait(1000);
           emit exit 0;
         }
       "
@@ -242,7 +242,7 @@ connection not found"
     End
 
     It "runs agc"
-      sleep 1
+      sleep 2
       alan run test_$$/temp.agc 1>./out.txt 2>/dev/null &
       sleep 1
       When run curl -s localhost:8000


### PR DESCRIPTION
Realized that the test was failing occasionally because the last print statement wasn't being printed, and that was because of a race condition between the exit event running and stdout being flushed, so a 100ms wait should fix it.