### PR TITLE
[lnn] fn selection fix

### DIFF
--- a/compiler/src/lnntoamm/Expr.ts
+++ b/compiler/src/lnntoamm/Expr.ts
@@ -420,7 +420,7 @@ export default abstract class Expr {
           stmts.push(dec);
           right = dec.ref();
         }
-        let retTys: Type[] = [];
+        const retTys: Type[] = [];
         while (ops.length > 0) {
           const op = ops.pop();
           const selected = op.select(metadata.scope, left.ty, right.ty);
@@ -588,12 +588,17 @@ class Call extends Expr {
   }
 
   private fnSelect(): [Fn[], Type[]] {
-    return FunctionType
-      .matrixSelect(this.fns, this.args.map(a => a.ty), this.scope)
-      .reduce(
-        ([fns, tys], [fn, ty]) => [[...fns, fn], [...tys, ty]],
-        [new Array<Fn>(), new Array<Type>()],
-      );
+    return FunctionType.matrixSelect(
+      this.fns,
+      this.args.map((a) => a.ty),
+      this.scope,
+    ).reduce(
+      ([fns, tys], [fn, ty]) => [
+        [...fns, fn],
+        [...tys, ty],
+      ],
+      [new Array<Fn>(), new Array<Type>()],
+    );
   }
 
   cleanup() {

--- a/compiler/src/lnntoamm/Expr.ts
+++ b/compiler/src/lnntoamm/Expr.ts
@@ -363,7 +363,7 @@ export default abstract class Expr {
               retTys = [...retTys, ...selTys];
               return [fns, retTys];
             },
-            [new Array<Fn>(), new Array<Type>()] as [Fn[], Type[]],
+            [new Array<Fn>(), new Array<Type>()],
           );
           const retTy = Type.oneOf(retTys);
           precedences[applyIdx] = new Call(
@@ -566,7 +566,7 @@ class Call extends Expr {
     // first reduction
     const argTys = args.map((arg) => arg.ty);
     const selFns = FunctionType.matrixSelect(fns, argTys, metadata.scope);
-    fns = selFns.map(([fn, _ty]) => fn);
+    fns = selFns.map((selFn) => selFn[0]);
     const retTy = Type.oneOf(selFns.map(([_fn, ty]) => ty));
     // now, constrain all of the args to their possible types
     // makes it so that the type of the parameters in each position are in their own list
@@ -654,8 +654,12 @@ class Call extends Expr {
       console.log('expected output type:', ty);
       throw new Error(`no function selected`);
     }
-    // Fn.select should implement the matrix so that the most reasonable
-    // choice is last in the fn array.
+    // FunctionType.matrixSelect implements the matrix so that the most
+    // reasonable choice is last in the fn array. "Reasonableness" is computed
+    // with 2 factors: 1st is alignment with given OneOf types. If `add(1, 0)`
+    // is called, the literal types should prefer `int64` to `int32` etc. The
+    // other factor is order of declaration - Alan should always prefer using
+    // functions that are defined last.
     const fn = selFns.pop();
     fn.inline(amm, this.args, kind, name, ty);
   }

--- a/compiler/src/lnntoamm/Expr.ts
+++ b/compiler/src/lnntoamm/Expr.ts
@@ -448,6 +448,9 @@ export default abstract class Expr {
     return [stmts, precedences.pop() as Ref];
   }
 
+  /**
+   * @returns true if more cleanup might be required
+   */
   cleanup(): boolean {
     // most implementing Exprs don't have anything they need to do.
     // I just didn't want to expose any of the Expr classes except
@@ -595,7 +598,7 @@ class Call extends Expr {
 
   cleanup() {
     const [fns, tys] = this.fnSelect();
-    const isChanged = this.fns.length === fns.length;
+    const isChanged = this.fns.length !== fns.length;
     this.fns = fns;
     this.retTy.constrain(Type.oneOf(tys), this.scope);
     return isChanged;

--- a/compiler/src/lnntoamm/Fn.ts
+++ b/compiler/src/lnntoamm/Fn.ts
@@ -43,26 +43,27 @@ export default class Fn {
     this.metadata =
       metadata !== null ? metadata : new MetaData(scope, this.retTy);
     while (this.body.reduce((carry, stmt) => carry && stmt.cleanup(), false));
+    const tyAst = ((fnAst: LPNode) => {
+      if (fnAst instanceof NulLP) {
+        // assume it's for an opcode
+        const compilerDefinition = '<compiler definition>';
+        const makeToken = (tok: string) => new Token(tok, compilerDefinition, -1, -1);
+        return new NamedAnd(
+          `opcode ${this.name}`,
+          {
+            opcode: makeToken('opcode'),
+            _whitespace: makeToken(' '),
+            opcodeName: makeToken(this.name),
+          },
+          compilerDefinition,
+          -1,
+          -1,
+        );
+      }
+      return null;
+    })(this.ast);
     this.ty = new FunctionType(
-      ((fnAst: LPNode) => {
-        if (fnAst instanceof NulLP) {
-          // assume it's for an opcode
-          const compilerDefinition = '<compiler definition>';
-          const makeToken = (tok: string) => new Token(tok, compilerDefinition, -1, -1);
-          return new NamedAnd(
-            `opcode ${this.name}`,
-            {
-              opcode: makeToken('opcode'),
-              _whitespace: makeToken(' '),
-              opcodeName: makeToken(this.name),
-            },
-            compilerDefinition,
-            -1,
-            -1,
-          );
-        }
-        return null;
-      })(this.ast),
+      tyAst,
       this.params.map((param) => param.ty),
       this.retTy,
     );
@@ -145,21 +146,6 @@ export default class Fn {
       body,
       metadata,
     );
-  }
-
-  // FIXME: this should implement the matrix that i mentioned in the FIXME comment
-  // for Expr#inline
-  static select(fns: Fn[], argTys: Type[], scope: Scope): [Fn[], Type[]] {
-    return null;
-    // return fns.filter((fn) => {
-    //   const params = Object.values(fn.params);
-    //   return (
-    //     params.length === argTys.length &&
-    //     params.every((param, ii) =>
-    //       argTys[ii].compatibleWithConstraint(param.ty, scope),
-    //     )
-    //   );
-    // });
   }
 
   asHandler(amm: Output, event: string) {

--- a/compiler/src/lnntoamm/Fn.ts
+++ b/compiler/src/lnntoamm/Fn.ts
@@ -41,6 +41,7 @@ export default class Fn {
     this.body = body;
     this.metadata =
       metadata !== null ? metadata : new MetaData(scope, this.retTy);
+    while (this.body.reduce((carry, stmt) => carry && stmt.cleanup(), false));
   }
 
   static fromFunctionsAst(ast: LPNode, scope: Scope): Fn {
@@ -124,16 +125,17 @@ export default class Fn {
 
   // FIXME: this should implement the matrix that i mentioned in the FIXME comment
   // for Expr#inline
-  static select(fns: Fn[], argTys: Type[], scope: Scope): Fn[] {
-    return fns.filter((fn) => {
-      const params = Object.values(fn.params);
-      return (
-        params.length === argTys.length &&
-        params.every((param, ii) =>
-          argTys[ii].compatibleWithConstraint(param.ty, scope),
-        )
-      );
-    });
+  static select(fns: Fn[], argTys: Type[], scope: Scope): [Fn[], Type[]] {
+    return null;
+    // return fns.filter((fn) => {
+    //   const params = Object.values(fn.params);
+    //   return (
+    //     params.length === argTys.length &&
+    //     params.every((param, ii) =>
+    //       argTys[ii].compatibleWithConstraint(param.ty, scope),
+    //     )
+    //   );
+    // });
   }
 
   asHandler(amm: Output, event: string) {

--- a/compiler/src/lnntoamm/Fn.ts
+++ b/compiler/src/lnntoamm/Fn.ts
@@ -229,6 +229,20 @@ export default class Fn {
     }
     this.params.forEach((param) => param.unassign());
   }
+
+  resultTyFor(argTys: Type[], scope: Scope): Type | null {
+    let res: Type | null = null;
+    try {
+      this.params.forEach((param, ii) => param.ty.tempConstrain(argTys[ii], scope));
+      res = this.retTy.instance();
+    } catch (_e) {
+      // do nothing: the args aren't applicable to the params so
+      // we return null (`res` is already `null`) and we need to
+      // ensure the param tys have `resetTemp` called on them.
+    }
+    this.params.forEach((param) => param.ty.resetTemp());
+    return res;
+  }
 }
 
 // circular dependency issue when this is defined in opcodes.ts :(

--- a/compiler/src/lnntoamm/Fn.ts
+++ b/compiler/src/lnntoamm/Fn.ts
@@ -5,7 +5,7 @@ import opcodes from './opcodes';
 import Scope from './Scope';
 import Stmt, { Dec, Exit, FnParam, MetaData } from './Stmt';
 import Type, { FunctionType } from './Types';
-import { DBG, TODO } from './util';
+import { TODO } from './util';
 
 export default class Fn {
   // null if it's an anonymous fn

--- a/compiler/src/lnntoamm/Fn.ts
+++ b/compiler/src/lnntoamm/Fn.ts
@@ -19,7 +19,7 @@ export default class Fn {
   exprFn: Expr;
   // not used by this class, but used by Statements
   metadata: MetaData;
-  ty: FunctionType
+  ty: FunctionType;
 
   get argNames(): string[] {
     return Object.keys(this.params);
@@ -42,12 +42,18 @@ export default class Fn {
     this.body = body;
     this.metadata =
       metadata !== null ? metadata : new MetaData(scope, this.retTy);
-    while (this.body.reduce((carry, stmt) => stmt.cleanup(this.scope) || carry, false));
+    while (
+      this.body.reduce(
+        (carry, stmt) => stmt.cleanup(this.scope) || carry,
+        false,
+      )
+    );
     const tyAst = ((fnAst: LPNode) => {
       if (fnAst instanceof NulLP) {
         // assume it's for an opcode
         const compilerDefinition = '<compiler definition>';
-        const makeToken = (tok: string) => new Token(tok, compilerDefinition, -1, -1);
+        const makeToken = (tok: string) =>
+          new Token(tok, compilerDefinition, -1, -1);
         return new NamedAnd(
           `opcode ${this.name}`,
           {
@@ -219,7 +225,9 @@ export default class Fn {
   resultTyFor(argTys: Type[], scope: Scope): Type | null {
     let res: Type | null = null;
     try {
-      this.params.forEach((param, ii) => param.ty.tempConstrain(argTys[ii], scope));
+      this.params.forEach((param, ii) =>
+        param.ty.tempConstrain(argTys[ii], scope),
+      );
       res = this.retTy.instance();
     } catch (_e) {
       // do nothing: the args aren't applicable to the params so

--- a/compiler/src/lnntoamm/Fn.ts
+++ b/compiler/src/lnntoamm/Fn.ts
@@ -5,7 +5,7 @@ import opcodes from './opcodes';
 import Scope from './Scope';
 import Stmt, { Dec, Exit, FnParam, MetaData } from './Stmt';
 import Type, { FunctionType } from './Types';
-import { TODO } from './util';
+import { DBG, TODO } from './util';
 
 export default class Fn {
   // null if it's an anonymous fn
@@ -42,7 +42,7 @@ export default class Fn {
     this.body = body;
     this.metadata =
       metadata !== null ? metadata : new MetaData(scope, this.retTy);
-    while (this.body.reduce((carry, stmt) => carry && stmt.cleanup(), false));
+    while (this.body.reduce((carry, stmt) => stmt.cleanup(this.scope) || carry, false));
     const tyAst = ((fnAst: LPNode) => {
       if (fnAst instanceof NulLP) {
         // assume it's for an opcode
@@ -116,11 +116,11 @@ export default class Fn {
       let exitVal: Expr;
       [body, exitVal] = Expr.fromAssignablesAst(bodyAsts, metadata);
       if (exitVal instanceof Ref) {
-        body.push(new Exit(bodyAsts, exitVal));
+        body.push(new Exit(bodyAsts, exitVal, retTy));
       } else {
         const retVal = Dec.gen(exitVal, metadata);
         body.push(retVal);
-        body.push(new Exit(bodyAsts, retVal.ref()));
+        body.push(new Exit(bodyAsts, retVal.ref(), retTy));
       }
     }
 

--- a/compiler/src/lnntoamm/Operator.ts
+++ b/compiler/src/lnntoamm/Operator.ts
@@ -51,7 +51,7 @@ class Operator {
     );
   }
 
-  select(scope: Scope, arg1: Type, arg2?: Type): Fn[] {
+  select(scope: Scope, arg1: Type, arg2?: Type): [Fn[], Type[]] {
     if ((this.isPrefix && arg2) || (!this.isPrefix && !arg2)) {
       console.log('~~~ ERROR');
       console.log('for operator:', this);

--- a/compiler/src/lnntoamm/Operator.ts
+++ b/compiler/src/lnntoamm/Operator.ts
@@ -1,7 +1,7 @@
 import { LPNode } from '../lp';
 import Fn from './Fn';
 import Scope from './Scope';
-import Type from './Types';
+import Type, { FunctionType } from './Types';
 import { isFnArray } from './util';
 
 class Operator {
@@ -62,7 +62,12 @@ class Operator {
       throw new Error(`nope`);
     }
     const tys = [arg1, ...(arg2 ? [arg2] : [])];
-    return Fn.select(this.fns, tys, scope);
+    return FunctionType
+      .matrixSelect(this.fns, tys, scope)
+      .reduce(
+        ([fns, tys], [fn, ty]) => [[...fns, fn], [...tys, ty]],
+        [new Array<Fn>(), new Array<Type>()],
+      );
   }
 }
 

--- a/compiler/src/lnntoamm/Operator.ts
+++ b/compiler/src/lnntoamm/Operator.ts
@@ -62,12 +62,13 @@ class Operator {
       throw new Error(`nope`);
     }
     const tys = [arg1, ...(arg2 ? [arg2] : [])];
-    return FunctionType
-      .matrixSelect(this.fns, tys, scope)
-      .reduce(
-        ([fns, tys], [fn, ty]) => [[...fns, fn], [...tys, ty]],
-        [new Array<Fn>(), new Array<Type>()],
-      );
+    return FunctionType.matrixSelect(this.fns, tys, scope).reduce(
+      ([fns, tys], [fn, ty]) => [
+        [...fns, fn],
+        [...tys, ty],
+      ],
+      [new Array<Fn>(), new Array<Type>()],
+    );
   }
 }
 

--- a/compiler/src/lnntoamm/Stmt.ts
+++ b/compiler/src/lnntoamm/Stmt.ts
@@ -335,14 +335,18 @@ class Emit extends Stmt {
     }
     stmts.push(new Emit(ast, event, emitRef));
     if (!event.eventTy.compatibleWithConstraint(emitRef.ty, metadata.scope)) {
-      throw new Error(`cannot emit value of type ${emitRef.ty.name} to event ${event.name} because it requires ${event.eventTy.name}`);
+      throw new Error(
+        `cannot emit value of type ${emitRef.ty.name} to event ${event.name} because it requires ${event.eventTy.name}`,
+      );
     }
     return stmts;
   }
 
   cleanup(scope: Scope): boolean {
     if (!this.event.eventTy.compatibleWithConstraint(this.emitVal.ty, scope)) {
-      throw new Error(`cannot emit value of type ${this.emitVal.ty.name} to event ${this.event.name} because it requires ${this.event.eventTy.name}`);
+      throw new Error(
+        `cannot emit value of type ${this.emitVal.ty.name} to event ${this.event.name} because it requires ${this.event.eventTy.name}`,
+      );
     }
     return false;
   }
@@ -372,7 +376,11 @@ export class Exit extends Stmt {
       const exitValAst = ast.get('retval').get('assignables');
       const [generated, expr] = Expr.fromAssignablesAst(exitValAst, metadata);
       const retVal = Dec.gen(expr, metadata);
-      stmts.push(...generated, retVal, new Exit(ast, retVal.ref(), metadata.retTy));
+      stmts.push(
+        ...generated,
+        retVal,
+        new Exit(ast, retVal.ref(), metadata.retTy),
+      );
       metadata.retTy.constrain(expr.ty, metadata.scope);
     } else {
       stmts.push(new Exit(ast, null, opcodes().get('void')));

--- a/compiler/src/lnntoamm/Stmt.ts
+++ b/compiler/src/lnntoamm/Stmt.ts
@@ -182,9 +182,16 @@ export class Dec extends VarDef {
     let ty: Type = expr.ty;
     if (work.has('typedec')) {
       const tyName = work.get('typedec').get('fulltypename');
-      ty = Type.getFromTypename(tyName, metadata.scope);
+      const found = Type.getFromTypename(tyName, metadata.scope);
+      // if the type hint is an interface, then all we have to do
+      // is ensure that the expr's ty matches the interface
+      if (found.dupIfNotLocalInterface() === null) {
+        ty = found;
+        ty.constrain(expr.ty, metadata.scope);
+      } else {
+        found.constrain(ty, metadata.scope);
+      }
     }
-    ty.constrain(expr.ty, metadata.scope);
     const dec = new Dec(ast, immutable, name, ty, expr);
     stmts.push(...generated, dec);
     metadata.define(dec);

--- a/compiler/src/lnntoamm/Stmt.ts
+++ b/compiler/src/lnntoamm/Stmt.ts
@@ -185,11 +185,12 @@ export class Dec extends VarDef {
       const found = Type.getFromTypename(tyName, metadata.scope);
       // if the type hint is an interface, then all we have to do
       // is ensure that the expr's ty matches the interface
-      if (found.dupIfNotLocalInterface() === null) {
+      const duped = found.dupIfNotLocalInterface();
+      if (duped === null) {
         ty = found;
         ty.constrain(expr.ty, metadata.scope);
       } else {
-        found.constrain(ty, metadata.scope);
+        ty.constrain(duped, metadata.scope);
       }
     }
     const dec = new Dec(ast, immutable, name, ty, expr);

--- a/compiler/src/lnntoamm/Stmt.ts
+++ b/compiler/src/lnntoamm/Stmt.ts
@@ -44,6 +44,7 @@ export default abstract class Stmt {
     this.ast = ast;
   }
 
+  abstract cleanup(): boolean;
   abstract inline(amm: Output): void;
 
   static fromAst(ast: LPNode, metadata: MetaData): Stmt[] {
@@ -96,6 +97,10 @@ export class Assign extends Stmt {
     return stmts;
   }
 
+  cleanup(): boolean {
+    return this.expr.cleanup();
+  }
+
   inline(amm: Output) {
     this.expr.inline(
       amm,
@@ -109,6 +114,10 @@ export class Assign extends Stmt {
 class Cond extends Stmt {
   static fromConditionals(_ast: LPNode, _metadata: MetaData): Stmt[] {
     return TODO('conditionals');
+  }
+
+  cleanup(): boolean {
+    return false;
   }
 
   inline(_amm: Output) {
@@ -196,6 +205,10 @@ export class Dec extends VarDef {
     return dec;
   }
 
+  cleanup(): boolean {
+    return this.expr.cleanup();
+  }
+
   inline(amm: Output) {
     // refs don't escape the current scope and this only happens 1x/scope,
     // so this is fine
@@ -255,6 +268,10 @@ export class FnParam extends VarDef {
     this.ty.tempConstrain(to.ty, scope);
   }
 
+  cleanup(): boolean {
+    return false;
+  }
+
   inline(_amm: Output) {
     throw new Error(`function parameters shouldn't be inlined`);
   }
@@ -308,6 +325,10 @@ class Emit extends Stmt {
     return stmts;
   }
 
+  cleanup(): boolean {
+    return false;
+  }
+
   inline(amm: Output) {
     if (!this.event.eventTy.eq(opcodes().get('void'))) {
       amm.emit(this.event.ammName, this.emitVal.ammName);
@@ -338,6 +359,10 @@ export class Exit extends Stmt {
       metadata.retTy.constrain(opcodes().get('void'), metadata.scope);
     }
     return stmts;
+  }
+
+  cleanup(): boolean {
+    return false;
   }
 
   inline(amm: Output) {

--- a/compiler/src/lnntoamm/Types.ts
+++ b/compiler/src/lnntoamm/Types.ts
@@ -281,11 +281,11 @@ export class FunctionType extends Type {
     // having the greatest preference
     let fnsByWeight = new Map<number, [Fn, Type][]>();
     let indices = matrix.map(() => 0);
-    while (true) {
+    for (let i = 0;; i++) {
       const weight = indices.reduce((w, c) => w + c);
       const argTys = matrix.map((options, ii) => options[indices[ii]]);
-      let alreadyInWeightMap = fnsByWeight.get(weight) || [];
-      alreadyInWeightMap.push(
+      let fnsForWeight = fnsByWeight.get(weight) || [];
+      fnsForWeight.push(
         ...fns.reduce(
           (fns, fn) => {
             const retTy = fn.resultTyFor(argTys, scope);
@@ -301,6 +301,7 @@ export class FunctionType extends Type {
           new Array<[Fn, Type]>(),
         ),
       );
+      fnsByWeight.set(weight, fnsForWeight);
       if (indices.every((idxInDim, dimIdx) => idxInDim === (matrix[dimIdx].length - 1))) {
         break;
       }

--- a/compiler/src/lnntoamm/Types.ts
+++ b/compiler/src/lnntoamm/Types.ts
@@ -247,8 +247,8 @@ class Builtin extends Type {
 }
 
 export class FunctionType extends Type {
-  params: Type[]
-  retTy: Type
+  params: Type[];
+  retTy: Type;
 
   get ammName(): string {
     throw new Error('Method not implemented.');
@@ -275,68 +275,63 @@ export class FunctionType extends Type {
     // and now to generate the matrix
     // every argument is a dimension within the matrix, but we're
     // representing each dimension _d_ as an index in the matrix
-	  let matrix: Array<Type[]> = args.map((arg) => {
-      return arg.fnselectOptions()
+    const matrix: Array<Type[]> = args.map((arg) => {
+      return arg.fnselectOptions();
     });
     // TODO: this weight system feels like it can be inaccurate
     // the weight of a particular function is computed by the sum
     // of the indices in each dimension, with the highest sum
     // having the greatest preference
-    let fnsByWeight = new Map<number, [Fn, Type][]>();
-    let indices = matrix.map(() => 0);
+    const fnsByWeight = new Map<number, [Fn, Type][]>();
+    const indices = matrix.map(() => 0);
     // keep it as for instead of while for debugging reasons
-    for (let i = 0;; i++) {
+    for (let i = 0; ; i++) {
       const weight = indices.reduce((w, c) => w + c);
       const argTys = matrix.map((options, ii) => options[indices[ii]]);
-      let fnsForWeight = fnsByWeight.get(weight) || [];
+      const fnsForWeight = fnsByWeight.get(weight) || [];
       fnsForWeight.push(
-        ...fns.reduce(
-          (fns, fn) => {
-            const retTy = fn.resultTyFor(argTys, scope);
-            if (retTy === null) {
-              return fns;
-            } else {
-              return [
-                ...fns,
-                [fn, retTy] as [Fn, Type],
-              ];
-            }
-          },
-          new Array<[Fn, Type]>(),
-        ),
+        ...fns.reduce((fns, fn) => {
+          const retTy = fn.resultTyFor(argTys, scope);
+          if (retTy === null) {
+            return fns;
+          } else {
+            return [...fns, [fn, retTy] as [Fn, Type]];
+          }
+        }, new Array<[Fn, Type]>()),
       );
       fnsByWeight.set(weight, fnsForWeight);
-      if (indices.every((idxInDim, dimIdx) => idxInDim === (matrix[dimIdx].length - 1))) {
+      if (
+        indices.every(
+          (idxInDim, dimIdx) => idxInDim === matrix[dimIdx].length - 1,
+        )
+      ) {
         break;
       }
       // now change the indices. This mostly works like binary addition,
       // except each digit `i` is in base `j` where `j = matrix[i].length`
       // so if `matrix[1].length === 1` then the carry for `indices[1]`
       // is just passed to `matrix[0]`
-      indices.reduceRight(
-        (carry, _matIdx, idx) => {
-          indices[idx] += carry;
-          if (indices[idx] === matrix[idx].length) {
-            indices[idx] = 0;
-            return 1;
-          } else {
-            return 0;
-          }
-        },
-        1
-      )
+      indices.reduceRight((carry, _matIdx, idx) => {
+        indices[idx] += carry;
+        if (indices[idx] === matrix[idx].length) {
+          indices[idx] = 0;
+          return 1;
+        } else {
+          return 0;
+        }
+      }, 1);
     }
     const weights = Array.from(fnsByWeight.keys()).sort();
     // weights is ordered lowest->highest so it's just a matter of
     // appending the tuple at each weight to a list
-    const ret = weights.reduce(
-      (fns, weight) => {
-        let weightFns = fnsByWeight.get(weight);
-        weightFns = weightFns.filter(([weightedFn, _retTy]) => fns.findIndex(([fn, _retTy]) => fn === weightedFn) === -1);
-        return [...fns, ...weightFns];
-      },
-      new Array<[Fn, Type]>(),
-    );
+    const ret = weights.reduce((fns, weight) => {
+      let weightFns = fnsByWeight.get(weight);
+      weightFns = weightFns.filter(
+        ([weightedFn, _retTy]) =>
+          fns.findIndex(([fn, _retTy]) => fn === weightedFn) === -1,
+      );
+      return [...fns, ...weightFns];
+    }, new Array<[Fn, Type]>());
     if (ret.length > originalLength) {
       console.log('~~~ ERROR');
       console.log('original:', originalLength);
@@ -352,9 +347,13 @@ export class FunctionType extends Type {
 
   compatibleWithConstraint(ty: Type, scope: Scope): boolean {
     if (ty instanceof FunctionType) {
-      return this.params.length === ty.params.length &&
-        this.params.every((param, ii) => param.compatibleWithConstraint(ty.params[ii], scope)) &&
-        this.retTy.compatibleWithConstraint(ty.retTy, scope);
+      return (
+        this.params.length === ty.params.length &&
+        this.params.every((param, ii) =>
+          param.compatibleWithConstraint(ty.params[ii], scope),
+        ) &&
+        this.retTy.compatibleWithConstraint(ty.retTy, scope)
+      );
     } else if (ty instanceof OneOf || ty instanceof Generated) {
       return ty.compatibleWithConstraint(this, scope);
     } else {
@@ -369,7 +368,11 @@ export class FunctionType extends Type {
 
   eq(that: Equalable): boolean {
     if (that instanceof FunctionType) {
-      return this.params.length === that.params.length && this.params.every((param, ii) => param.eq(that.params[ii])) && this.retTy.eq(that.retTy);
+      return (
+        this.params.length === that.params.length &&
+        this.params.every((param, ii) => param.eq(that.params[ii])) &&
+        this.retTy.eq(that.retTy)
+      );
     } else if (that instanceof Generated || that instanceof OneOf) {
       return that.eq(this);
     } else {
@@ -592,7 +595,9 @@ abstract class Has extends Type {
 
   // it returns `any` to make the type system happy
   private nope(msg: string): any {
-    throw new Error(`Has constraints ${msg} (this error should never be thrown)`);
+    throw new Error(
+      `Has constraints ${msg} (this error should never be thrown)`,
+    );
   }
 
   instance(): Type {
@@ -614,7 +619,9 @@ abstract class Has extends Type {
   }
 
   fnselectOptions(): Type[] {
-    return this.nope('should not be used as a Type when computing function selection');
+    return this.nope(
+      'should not be used as a Type when computing function selection',
+    );
   }
 }
 
@@ -977,7 +984,7 @@ class Interface extends Type {
 
   fnselectOptions(): Type[] {
     if (this.tempDelegate !== null) {
-      return this.tempDelegate.fnselectOptions()
+      return this.tempDelegate.fnselectOptions();
     } else {
       return [this];
     }
@@ -1145,9 +1152,9 @@ class OneOf extends Type {
     // in matrix selection. Since no other values are added to the list,
     // there's no need to do this any time later.
     selection = selection.reduce(
-      (sel, fn) => sel.some((selFn) => selFn.eq(fn)) ? sel : [...sel, fn],
+      (sel, fn) => (sel.some((selFn) => selFn.eq(fn)) ? sel : [...sel, fn]),
       new Array<Type>(),
-    )
+    );
     this.selection = selection;
     this.tempSelect = tempSelect;
     this.selected = null;

--- a/compiler/src/lnntoamm/Types.ts
+++ b/compiler/src/lnntoamm/Types.ts
@@ -334,12 +334,12 @@ export class FunctionType extends Type {
     }, new Array<[Fn, Type]>());
     if (ret.length > originalLength) {
       console.log('~~~ ERROR');
-      console.log('original:', originalLength);
-      console.log('retLengt:', ret.length);
-      console.log('args:    ', args);
-      console.log('matrix:  ', matrix);
-      console.log('byweight:', fnsByWeight);
-      console.log('indices: ', indices);
+      console.log('original: ', originalLength);
+      console.log('retLength:', ret.length);
+      console.log('args:     ', args);
+      console.log('matrix:   ', matrix);
+      console.log('byweight: ', fnsByWeight);
+      console.log('indices:  ', indices);
       throw new Error('somehow got more options when fn selecting');
     }
     return ret;

--- a/compiler/src/lnntoamm/Types.ts
+++ b/compiler/src/lnntoamm/Types.ts
@@ -274,13 +274,16 @@ export class FunctionType extends Type {
     // and now to generate the matrix
     // every argument is a dimension within the matrix, but we're
     // representing each dimension _d_ as an index in the matrix
-	  let matrix: Array<Type[]> = args.map((arg) => arg.fnselectOptions());
+	  let matrix: Array<Type[]> = args.map((arg) => {
+      return arg.fnselectOptions()
+    });
     // TODO: this weight system feels like it can be inaccurate
     // the weight of a particular function is computed by the sum
     // of the indices in each dimension, with the highest sum
     // having the greatest preference
     let fnsByWeight = new Map<number, [Fn, Type][]>();
     let indices = matrix.map(() => 0);
+    // keep it as for instead of while for debugging reasons
     for (let i = 0;; i++) {
       const weight = indices.reduce((w, c) => w + c);
       const argTys = matrix.map((options, ii) => options[indices[ii]]);
@@ -957,7 +960,7 @@ class Interface extends Type {
   }
 
   fnselectOptions(): Type[] {
-    return TODO('figure out how interfaces comply with fn selection options');
+    return [this];
   }
 }
 

--- a/compiler/src/lnntoamm/Types.ts
+++ b/compiler/src/lnntoamm/Types.ts
@@ -330,13 +330,18 @@ export class FunctionType extends Type {
     // weights is ordered lowest->highest so it's just a matter of
     // appending the tuple at each weight to a list
     const ret = weights.reduce(
-      (fns, weight) => [...fns, ...fnsByWeight.get(weight)],
+      (fns, weight) => {
+        let weightFns = fnsByWeight.get(weight);
+        weightFns = weightFns.filter(([weightedFn, _retTy]) => fns.findIndex(([fn, _retTy]) => fn === weightedFn) === -1);
+        return [...fns, ...weightFns];
+      },
       new Array<[Fn, Type]>(),
     );
     if (ret.length > originalLength) {
       console.log('~~~ ERROR');
       console.log('original:', originalLength);
       console.log('retLengt:', ret.length);
+      console.log('args:    ', args);
       console.log('matrix:  ', matrix);
       console.log('byweight:', fnsByWeight);
       console.log('indices: ', indices);

--- a/compiler/src/lnntoamm/Types.ts
+++ b/compiler/src/lnntoamm/Types.ts
@@ -140,7 +140,7 @@ class Builtin extends Type {
     } else if (ty instanceof HasOperator) {
       return Has.operator(ty, scope, this).length !== 0;
     } else if (ty instanceof HasMethod) {
-      return Has.method(ty, scope, this)[0].length !== 0;
+      return Has.method(ty, scope, this).length !== 0;
     } else if (ty instanceof HasField) {
       return TODO('add field support for builtins');
     } else if (ty instanceof Interface) {
@@ -168,7 +168,7 @@ class Builtin extends Type {
       }
     } else if (
       ty instanceof HasMethod &&
-      Has.method(ty, scope, this)[0].length === 0
+      Has.method(ty, scope, this).length === 0
     ) {
       throw new Error(
         `type ${this.name} does not have method ${ty.name}(${ty.params
@@ -520,12 +520,12 @@ abstract class Has extends Type {
     return false;
   }
 
-  static method(method: HasMethod, scope: Scope, ty: Type): [Fn[], Type[]] {
+  static method(method: HasMethod, scope: Scope, ty: Type): [Fn, Type][] {
     const fns = scope.get(method.name);
     if (!isFnArray(fns)) {
-      return [[], []];
+      return [];
     }
-    return Fn.select(
+    return FunctionType.matrixSelect(
       fns,
       method.params.map((p) => (p === null ? ty : p)),
       scope,

--- a/compiler/src/lnntoamm/Types.ts
+++ b/compiler/src/lnntoamm/Types.ts
@@ -971,7 +971,11 @@ class Interface extends Type {
   }
 
   fnselectOptions(): Type[] {
-    return [this];
+    if (this.tempDelegate !== null) {
+      return this.tempDelegate.fnselectOptions()
+    } else {
+      return [this];
+    }
   }
 }
 

--- a/compiler/src/lnntoamm/util.ts
+++ b/compiler/src/lnntoamm/util.ts
@@ -14,6 +14,25 @@ export const isOpArray = (val: any): val is Array<Operator> => {
   );
 };
 
+/**
+ * Assumes valOrMsg is a message if more than 1 argument passed. TS should prevent that though
+ * @param valOrMsg the value to debug print or the message to print alongside other values
+ * @param vals the values to print after a message
+ * @returns the first value passed
+ */
+export const DBG = function<T>(
+  valOrMsg: T | string,
+  ...vals: T[]
+): T {
+  if (vals.length > 0) {
+    console.log('->', valOrMsg, ...vals);
+    return vals[0];
+  } else {
+    console.log('~~', valOrMsg);
+    return valOrMsg as T;
+  }
+}
+
 export const TODO = (task?: string) => {
   throw new Error(`TODO${task !== undefined ? ': ' + task : ''}`);
 };

--- a/compiler/src/lnntoamm/util.ts
+++ b/compiler/src/lnntoamm/util.ts
@@ -20,10 +20,7 @@ export const isOpArray = (val: any): val is Array<Operator> => {
  * @param vals the values to print after a message
  * @returns the first value passed
  */
-export const DBG = function<T>(
-  valOrMsg: T | string,
-  ...vals: T[]
-): T {
+export const DBG = function <T>(valOrMsg: T | string, ...vals: T[]): T {
   if (vals.length > 0) {
     console.log('->', valOrMsg, ...vals);
     return vals[0];
@@ -31,7 +28,7 @@ export const DBG = function<T>(
     console.log('~~', valOrMsg);
     return valOrMsg as T;
   }
-}
+};
 
 export const TODO = (task?: string) => {
   throw new Error(`TODO${task !== undefined ? ': ' + task : ''}`);

--- a/compiler/temp.lnn
+++ b/compiler/temp.lnn
@@ -1,0 +1,5 @@
+from @std/app import start, exit
+
+on start {
+  emit exit 0;
+}

--- a/compiler/temp.lnn
+++ b/compiler/temp.lnn
@@ -1,5 +1,0 @@
-from @std/app import start, exit
-
-on start {
-  emit exit 0;
-}


### PR DESCRIPTION
fixes #599 

I kept some debug output *in case* something happens but I don't expect any of them to actually print. Other than that the documentation should be pretty thorough and should in the end be more accurate than the current selection system. This system should also determine all types of values except for those that depend on the parameters of the function, which means that functions are fully type-checked (instead of only partially type-checked) before inlining, even if they're on the cold path (functions not used by any handler).