### PR TITLE
Fix CI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h2>The Alan Programming Language</h2>
 </div>
 
-[![CI](https://github.com/alantech/alan/workflows/CI/badge.svg)](https://github.com/alantech/alan/actions?query=workflow%3ACI)
+[![CI](https://github.com/alantech/alan/actions/workflows/tests.yml/badge.svg)](https://github.com/alantech/alan/actions/workflows/tests.yml)
 [![Docs](https://img.shields.io/badge/docs-mdbook-blue)](https://docs.alan-lang.org)
 [![Discord](https://img.shields.io/badge/discord-alanlang-purple)](https://discord.gg/XatB9we)
 [![Reddit](https://img.shields.io/badge/reddit-alanlang-red)](https://www.reddit.com/r/alanlang)


### PR DESCRIPTION
Apparently Github dropped the old badge URLs, but instead of breaking the image, it's just set to whatever the last result was, basically forever, which I don't understand the logic of.
