### PR TITLE
Stop using rustls internals for pemfile support

### DIFF
--- a/avm/Cargo.lock
+++ b/avm/Cargo.lock
@@ -32,7 +32,7 @@ version = "0.1.45-beta3"
 dependencies = [
  "ascii_table",
  "async-stream",
- "base64",
+ "base64 0.13.0",
  "byteorder",
  "clap",
  "dashmap",
@@ -54,6 +54,7 @@ dependencies = [
  "rand 0.8.3",
  "regex",
  "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_ini",
  "serde_json",
@@ -135,6 +136,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "bitflags"
@@ -1448,7 +1455,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "log",
  "ring",
  "sct",
@@ -1465,6 +1472,15 @@ dependencies = [
  "rustls",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.5",
 ]
 
 [[package]]

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -35,6 +35,7 @@ protobuf = "2.23.0"
 rand = "0.8.3"
 regex = "1"
 rustls = { version = "0.19.0", features = ["dangerous_configuration"] }
+rustls-pemfile = "1.0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_ini = { version = "0.2" }
 serde_json = { version = "1.0" }

--- a/avm/src/vm/http.rs
+++ b/avm/src/vm/http.rs
@@ -74,19 +74,15 @@ macro_rules! make_server {
         let port_num = https.port;
         let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port_num));
         let tls_cfg = {
-          let certs = rustls::internal::pemfile::certs(&mut std::io::BufReader::new(
-            https.cert.as_str().as_bytes(),
-          ));
-          let certs = certs.expect("Failed to load certificate");
-          let key = {
-            let keys = rustls::internal::pemfile::pkcs8_private_keys(&mut std::io::BufReader::new(
-              https.priv_key.as_str().as_bytes(),
-            ));
-            let keys = keys.expect("Failed to load private key");
-            if keys.len() != 1 {
-              panic!("Expected a single private key");
-            }
-            keys[0].clone()
+          // These *should* all have a singular Item in them. Assuming this is the case and blowing
+          // up if otherwise
+          let certs = match rustls_pemfile::read_all(&mut https.cert.as_str().as_bytes()).unwrap().pop().unwrap() {
+            rustls_pemfile::Item::X509Certificate(cert) => vec!(rustls::Certificate(cert)),
+            _ => panic!("Misconfigured HTTPS mode missing certificate"),
+          };
+          let key = match rustls_pemfile::read_all(&mut https.priv_key.as_str().as_bytes()).unwrap().pop().unwrap() {
+            rustls_pemfile::Item::PKCS8Key(priv_key) => rustls::PrivateKey(priv_key),
+            _ => panic!("Misconfigured HTTPS mode missing PKCS8 private key"),
           };
           let mut cfg = rustls::ServerConfig::new(rustls::NoClientAuth::new());
           cfg.set_single_cert(certs, key).unwrap();
@@ -172,19 +168,15 @@ macro_rules! make_tunnel {
         let port_num = https.port;
         let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port_num));
         let tls_cfg = {
-          let certs = rustls::internal::pemfile::certs(&mut std::io::BufReader::new(
-            https.cert.as_str().as_bytes(),
-          ));
-          let certs = certs.expect("Failed to load certificate");
-          let key = {
-            let keys = rustls::internal::pemfile::pkcs8_private_keys(&mut std::io::BufReader::new(
-              https.priv_key.as_str().as_bytes(),
-            ));
-            let keys = keys.expect("Failed to load private key");
-            if keys.len() != 1 {
-              panic!("Expected a single private key");
-            }
-            keys[0].clone()
+          // These *should* all have a singular Item in them. Assuming this is the case and blowing
+          // up if otherwise
+          let certs = match rustls_pemfile::read_all(&mut https.cert.as_str().as_bytes()).unwrap().pop().unwrap() {
+            rustls_pemfile::Item::X509Certificate(cert) => vec!(rustls::Certificate(cert)),
+            _ => panic!("Misconfigured HTTPS mode missing certificate"),
+          };
+          let key = match rustls_pemfile::read_all(&mut https.priv_key.as_str().as_bytes()).unwrap().pop().unwrap() {
+            rustls_pemfile::Item::PKCS8Key(priv_key) => rustls::PrivateKey(priv_key),
+            _ => panic!("Misconfigured HTTPS mode missing PKCS8 private key"),
           };
           let mut cfg = rustls::ServerConfig::new(rustls::NoClientAuth::new());
           cfg.set_single_cert(certs, key).unwrap();

--- a/avm/src/vm/http.rs
+++ b/avm/src/vm/http.rs
@@ -76,11 +76,19 @@ macro_rules! make_server {
         let tls_cfg = {
           // These *should* all have a singular Item in them. Assuming this is the case and blowing
           // up if otherwise
-          let certs = match rustls_pemfile::read_all(&mut https.cert.as_str().as_bytes()).unwrap().pop().unwrap() {
-            rustls_pemfile::Item::X509Certificate(cert) => vec!(rustls::Certificate(cert)),
+          let certs = match rustls_pemfile::read_all(&mut https.cert.as_str().as_bytes())
+            .unwrap()
+            .pop()
+            .unwrap()
+          {
+            rustls_pemfile::Item::X509Certificate(cert) => vec![rustls::Certificate(cert)],
             _ => panic!("Misconfigured HTTPS mode missing certificate"),
           };
-          let key = match rustls_pemfile::read_all(&mut https.priv_key.as_str().as_bytes()).unwrap().pop().unwrap() {
+          let key = match rustls_pemfile::read_all(&mut https.priv_key.as_str().as_bytes())
+            .unwrap()
+            .pop()
+            .unwrap()
+          {
             rustls_pemfile::Item::PKCS8Key(priv_key) => rustls::PrivateKey(priv_key),
             _ => panic!("Misconfigured HTTPS mode missing PKCS8 private key"),
           };


### PR DESCRIPTION
Necessary to upgrade rustls because these internal entities don't exist anymore
