### PR TITLE
Fix http requests in Node 18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -75,7 +75,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/bdd/spec/023_http_spec.sh
+++ b/bdd/spec/023_http_spec.sh
@@ -72,7 +72,7 @@ Describe "@std/http"
           const res = fetch(new Request {
             method: 'GET',
             url: 'https://raw.githubusercontent.com/alantech/hellodep/aea1ce817a423d00107577a430a046993e4e6cad/index.ln',
-            headers: newHashMap('Content-Length', '0'),
+            headers: newHashMap('User-Agent', 'Alanlang'),
             body: '',
           });
           print(res.isOk());

--- a/std/http.ln
+++ b/std/http.ln
@@ -61,7 +61,7 @@ export fn getEager(url: string): Result<string> {
   const res = fetchEager(new Request {
     method: 'GET',
     url: url,
-    headers: newHashMap('Content-Length', '0'),
+    headers: newHashMap('User-Agent', 'Alanlang'),
     body: '',
   });
   if res.isOk() {
@@ -79,7 +79,7 @@ export fn get(url: string): Result<string> {
   const res = fetch(new Request {
     method: 'GET',
     url: url,
-    headers: newHashMap('Content-Length', '0'),
+    headers: newHashMap('User-Agent', 'Alanlang'),
     body: '',
   });
   if res.isOk() {


### PR DESCRIPTION
A `Content-Length` header in a GET request is invalid. Node 16 and earlier (as well as `hyper` in Rust) simply ignored the invalid header, but Node 18 is more strict. Fixed by changing the header set for GET requests to `User-Agent` with a value of `Alanlang` for now.
