### PR TITLE
Clean up the method and array access logic in the base assignables to be restricted to the 'Variable' branch

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -501,7 +501,16 @@ named_or!(varsegment: VarSegment =>
     MethodSep: String as and!(optwhitespace, dot, optwhitespace),
     ArrayAccess: Vec<WithOperators> as arrayaccess,
 );
-build!(var, one_or_more!(varsegment));
+impl VarSegment {
+    pub fn to_string(&self) -> String {
+        match self {
+            Self::Variable(v) => v.clone(),
+            Self::MethodSep(_) => ".".to_string(),
+            Self::ArrayAccess(_) => "[ TODO ]".to_string(),
+        }
+    }
+}
+list!(var: VarSegment => varsegment);
 test!(var =>
     pass "hm.lookup";
 );
@@ -799,9 +808,8 @@ named_or!(baseassignable: BaseAssignable =>
     ObjectLiterals: ObjectLiterals as objectliterals,
     Functions: Functions as functions,
     FnCall: FnCall as fncall,
-    Variable: String as variable,
+    Variable: Vec<VarSegment> as var,
     Constants: Constants as constants,
-    MethodSep: String as and!(optwhitespace, dot, optwhitespace),
 );
 test!(baseassignable =>
     pass "new Foo{}" => "", super::BaseAssignable::ObjectLiterals(super::ObjectLiterals::TypeLiteral(super::TypeLiteral{
@@ -935,7 +943,7 @@ named_or!(declarations: Declarations =>
     Let: LetDeclaration as letdeclaration,
 );
 named_and!(assignments: Assignments =>
-    var: String as var,
+    var: Vec<VarSegment> as var,
     a: String as optwhitespace,
     eq: String as eq,
     b: String as optwhitespace,
@@ -962,7 +970,7 @@ test!(returns =>
 named_and!(emits: Emits =>
     emit: String as emit,
     a: String as optwhitespace,
-    eventname: String as var,
+    eventname: Vec<VarSegment> as var,
     b: String as optwhitespace,
     retval: Option<RetVal> as optretval,
     semicolon: String as semicolon,
@@ -1035,7 +1043,7 @@ test!(functions =>
 named_or!(blocklike: Blocklike =>
     Functions: Functions as functions,
     FunctionBody: FunctionBody as functionbody,
-    FnName: String as var,
+    FnName: Vec<VarSegment> as var,
 );
 named_or!(condorblock: CondOrBlock =>
     Conditional: Conditional as conditional,
@@ -1426,7 +1434,7 @@ named_or!(handler: Handler =>
 named_and!(handlers: Handlers =>
     on: String as on,
     a: String as whitespace,
-    eventname: String as var,
+    eventname: Vec<VarSegment> as var,
     b: String as whitespace,
     handler: Handler as handler,
 );

--- a/src/program.rs
+++ b/src/program.rs
@@ -422,17 +422,19 @@ fn baseassignablelist_to_microstatements(
                                 }
                             }
                             microstatements.push(Microstatement::FnCall {
-                                function: var.to_string(),
+                                function: var.iter().map(|segment| segment.to_string()).collect::<Vec<String>>().join("").to_string(), // TODO: Support method/property/array access eventually
                                 args,
                             });
                         }
                         _ => {
-                            return Err(format!("Invalid syntax after {}", var).into());
+                            // TODO: Properly support method/property/array access eventually
+                            return Err(format!("Invalid syntax after {}", var.iter().map(|segment| segment.to_string()).collect::<Vec<String>>().join("").to_string()).into());
                         }
                     }
                 } else {
                     let typen = match microstatements.iter().find(|m| match m {
-                        Microstatement::Assignment { name, .. } => var == name,
+                        // TODO: Properly support method/property/array access eventually
+                        Microstatement::Assignment { name, .. } => &var.iter().map(|segment| segment.to_string()).collect::<Vec<String>>().join("") == name,
                         _ => false,
                     }) {
                         // Reaching the `Some` path requires it to be of type
@@ -444,11 +446,12 @@ fn baseassignablelist_to_microstatements(
                             }
                             _ => unreachable!(),
                         }),
-                        None => Err(format!("Couldn't find variable {}", var)),
+                        None => Err(format!("Couldn't find variable {}", var.iter().map(|segment| segment.to_string()).collect::<Vec<String>>().join(""))),
                     }?;
                     microstatements.push(Microstatement::Value {
                         typen,
-                        representation: var.to_string(),
+                        // TODO: Properly support method/property/array access eventually
+                        representation: var.iter().map(|segment| segment.to_string()).collect::<Vec<String>>().join("").to_string(),
                     });
                 }
             }
@@ -485,8 +488,11 @@ fn baseassignablelist_to_microstatements(
                     },
                 }
             }
-            _ => {
-                return Err("Unsupported assignable type".into());
+            parse::BaseAssignable::ObjectLiterals(o) => {
+                todo!("Implement me");
+            }
+            parse::BaseAssignable::Functions(f) => {
+                todo!("Implement me");
             }
         }
     }
@@ -725,7 +731,8 @@ impl Handler {
                 // function list for this scope, otherwise
                 let name = match &function.optname {
                     Some(name) => name.clone(),
-                    None => format!(":::on:::{}", &handler_ast.eventname).to_string(), // Impossible for users to write, so no collisions ever
+                    // TODO: Properly support method/property/array access eventually
+                    None => format!(":::on:::{}", &handler_ast.eventname.iter().map(|segment| segment.to_string()).collect::<Vec<String>>().join("")).to_string(), // Impossible for users to write, so no collisions ever
                 };
                 let _ = Function::from_ast_with_name(scope, program, function, false, name.clone());
                 name
@@ -736,7 +743,8 @@ impl Handler {
             // Function object initialization in here instead of as a new method on the Function
             // type.
             parse::Handler::FunctionBody(body) => {
-                let name = format!(":::on:::{}", &handler_ast.eventname).to_string();
+                // TODO: Properly support method/property/array access eventually
+                let name = format!(":::on:::{}", &handler_ast.eventname.iter().map(|segment| segment.to_string()).collect::<Vec<String>>().join("")).to_string();
                 let function = Function {
                     name: name.clone(),
                     args: Vec::new(),
@@ -761,7 +769,7 @@ impl Handler {
             } // TODO: Should you be allowed to bind a Rust function as a handler directly?
         };
         let h = Handler {
-            eventname: handler_ast.eventname.clone(),
+            eventname: handler_ast.eventname.iter().map(|segment| segment.to_string()).collect::<Vec<String>>().join("").to_string(),
             functionname,
         };
         scope.handlers.insert(h.eventname.clone(), h);


### PR DESCRIPTION
This turns the base assignable variable into a vector of VarSegment entries, which should help reduce the spread of logic on accessing properties or array locations to a singular spot and minimize the amount of nonsensical text it can parse.

Did this as a separate PR and just mushed it back into a string for now to prove that the parser change doesn't cause regressions in the test suite. (Which is true, still the same # of successful tests)
