### PR TITLE
Constructor function naming pattern

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -113,18 +113,18 @@ test!(hello_world => r#"
 
 test!(normal_exit_code => r#"
     export fn main(): ExitCode {
-        return toExitCode(0);
+        return ExitCode(0);
     }"#;
     status 0;
 );
 test!(error_exit_code => r#"
-    export fn main(): ExitCode = toExitCode(1);"#;
+    export fn main(): ExitCode = ExitCode(1);"#;
     status 1;
 );
 test!(non_global_memory_exit_code => r#"
     export fn main(): ExitCode {
       let x: i64 = 0;
-      return toExitCode(x);
+      return ExitCode(x);
     }"#;
     status 0;
 );
@@ -151,7 +151,7 @@ test!(passing_ints_from_global_memory => r#"
 test!(print_function => r#"
     export fn main(): ExitCode {
       print('Hello, World');
-      return toExitCode(0);
+      return ExitCode(0);
     }"#;
     stdout "Hello, World\n";
     status 0;
@@ -169,27 +169,27 @@ test!(stdout_event => r#"
 // Basic Math Tests
 
 test!(int8_add => r#"
-    export fn main(): ExitCode = toExitCode(getOrExit(add(toI8(1), toI8(2))));"#;
+    export fn main(): ExitCode = ExitCode(getOrExit(add(toI8(1), toI8(2))));"#;
     status 3;
 );
 test!(int8_sub => r#"
-    export fn main(): ExitCode = toExitCode(getOrExit(sub(toI8(2), toI8(1))));"#;
+    export fn main(): ExitCode = ExitCode(getOrExit(sub(toI8(2), toI8(1))));"#;
     status 1;
 );
 test!(int8_mul => r#"
-    export fn main(): ExitCode = toExitCode(getOrExit(mul(toI8(2), toI8(1))));"#;
+    export fn main(): ExitCode = ExitCode(getOrExit(mul(toI8(2), toI8(1))));"#;
     status 2;
 );
 test!(int8_div => r#"
-    export fn main(): ExitCode = toExitCode(getOrExit(div(toI8(6), toI8(2))));"#;
+    export fn main(): ExitCode = ExitCode(getOrExit(div(toI8(6), toI8(2))));"#;
     status 3;
 );
 test!(int8_mod => r#"
-    export fn main(): ExitCode = toExitCode(getOrExit(mod(toI8(6), toI8(4))));"#;
+    export fn main(): ExitCode = ExitCode(getOrExit(mod(toI8(6), toI8(4))));"#;
     status 2;
 );
 test!(int8_pow => r#"
-    export fn main(): ExitCode = toExitCode(getOrExit(pow(toI8(6), toI8(2))));"#;
+    export fn main(): ExitCode = ExitCode(getOrExit(pow(toI8(6), toI8(2))));"#;
     status 36;
 );
 test!(int8_min => r#"

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -16,8 +16,8 @@ export fn max(a: i8, b: i8): i8 binds maxi8;
 
 // Process exit-related bindings
 export type ExitCode binds std::process::ExitCode;
-export fn toExitCode(e: i64): ExitCode binds to_exit_code_i64;
-export fn toExitCode(e: i8): ExitCode binds to_exit_code_i8;
+export fn ExitCode(e: i64): ExitCode binds to_exit_code_i64;
+export fn ExitCode(e: i8): ExitCode binds to_exit_code_i8;
 export fn getOrExit(a: Result<i8>): i8 binds get_or_exit; // TODO: Support real generics
 
 // Stdout/stderr-related bindings


### PR DESCRIPTION
In Alan, types are only used at compile time. There's no reflection, so we're free to even decompose the user's variables to just the parts that are necessary, if we wanted to.

And in the language design, they can only be defined at the top-level of a file, you can't define types within a function (since that would require either including a compiler within the compiled output, or some incredibly fancy way to determine at compile time all of the possible types that could be created and then used at run time and pre-build them). You also can't store them in a variable, or etc. They're "just" metadata for the compiler (and eventually intended to be non-required metadata that the compiler can create an substitute for as necessary).

So, the namespace for types vs functions and variables has zero collisions. Which means we can re-use a type's own name for a constructor function. So this PR demonstrates that by renaming the `toExitCode` functions to just `ExitCode`, and demonstrating that they work.

When method syntax comes along, it feels like it could be a partial solution to having units, since you could have something like `3.sec()` to represent a time delta of seconds, but I do wonder if there's anything "better" that could be done here without making parsing impossible while still looking "better" to human eyes.
