### PR TITLE
Implement events

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -103,7 +103,7 @@ macro_rules! status {
 // The only test that works for now
 test!(hello_world => r#"
     export fn main {
-        print("Hello, World!");
+        print('Hello, World!');
     }"#;
     stdout "Hello, World!\n";
     status 0;
@@ -157,11 +157,10 @@ test!(print_function => r#"
     status 0;
 );
 test!(stdout_event => r#"
-    from @std/app import start, stdout, exit
-    on start {
+    export fn main(): ExitCode {
       emit stdout 'Hello, World';
-      wait(10);
-      emit exit 0;
+      wait(10); // Because emits run on another thread, we need to wait to be sure it actually runs
+      return ExitCode(0);
     }"#;
     stdout "Hello, World";
 );
@@ -169,38 +168,38 @@ test!(stdout_event => r#"
 // Basic Math Tests
 
 test!(int8_add => r#"
-    export fn main(): ExitCode = ExitCode(getOrExit(add(toI8(1), toI8(2))));"#;
+    export fn main(): ExitCode = ExitCode(getOrExit(add(i8(1), i8(2))));"#;
     status 3;
 );
 test!(int8_sub => r#"
-    export fn main(): ExitCode = ExitCode(getOrExit(sub(toI8(2), toI8(1))));"#;
+    export fn main(): ExitCode = ExitCode(getOrExit(sub(i8(2), i8(1))));"#;
     status 1;
 );
 test!(int8_mul => r#"
-    export fn main(): ExitCode = ExitCode(getOrExit(mul(toI8(2), toI8(1))));"#;
+    export fn main(): ExitCode = ExitCode(getOrExit(mul(i8(2), i8(1))));"#;
     status 2;
 );
 test!(int8_div => r#"
-    export fn main(): ExitCode = ExitCode(getOrExit(div(toI8(6), toI8(2))));"#;
+    export fn main(): ExitCode = ExitCode(getOrExit(div(i8(6), i8(2))));"#;
     status 3;
 );
 test!(int8_mod => r#"
-    export fn main(): ExitCode = ExitCode(getOrExit(mod(toI8(6), toI8(4))));"#;
+    export fn main(): ExitCode = ExitCode(getOrExit(mod(i8(6), i8(4))));"#;
     status 2;
 );
 test!(int8_pow => r#"
-    export fn main(): ExitCode = ExitCode(getOrExit(pow(toI8(6), toI8(2))));"#;
+    export fn main(): ExitCode = ExitCode(getOrExit(pow(i8(6), i8(2))));"#;
     status 36;
 );
 test!(int8_min => r#"
     export fn main() {
-      print(min(toI8(3), toI8(5)));
+      print(min(i8(3), i8(5)));
     }"#;
     stdout "3\n";
 );
 test!(int8_max => r#"
     export fn main() {
-      print(max(toI8(3), toI8(5)));
+      print(max(i8(3), i8(5)));
     }"#;
     stdout "5\n";
 );

--- a/src/lntors/event.rs
+++ b/src/lntors/event.rs
@@ -1,0 +1,122 @@
+// Builds the event functions using the code from their handlers. Currently an O(n^2) algo for
+// simplicity.
+
+use crate::program::{Function, Microstatement, Program};
+use crate::lntors::function::from_microstatement;
+
+pub fn generate(
+    program: &Program,
+) -> Result<String, Box<dyn std::error::Error>> {
+    // The events will all go into an `event` sub-module with every function marked public. These
+    // event functions are what the `emit <eventName> <optionalValue>;` statements will call, so
+    // something like:
+    // emit foo "bar";
+    // becomes something like:
+    // event::foo("bar");
+    //
+    // The event functions copy their input argument for each handler, which is run within a
+    // thread, looking something like:
+    // let arg_copy = arg.clone();
+    // std::thread::spawn(move || {
+    //     <generated code that references arg_copy>
+    // });
+    //
+    // With the generated code coming from the handler functions, in the order they're discovered
+    // across the scopes.
+    let mut out = "mod event {\n".to_string();
+    // First scan through all scopes for each defined event
+    for (_, (_, _, eventscope)) in program.scopes_by_file.iter() {
+        for (eventname, event) in eventscope.events.iter() {
+            // Define the function for this event
+            out = format!("{}    pub fn {}{} {{\n",
+                          out,
+                          eventname,
+                          match event.typename.as_str() {
+                              "void" => "".to_string(),
+                              x => format!("(arg: {})", x).to_string(),
+                          },
+            );
+            let expected_arg_type = match event.typename.as_str() {
+                "void" => None,
+                x => Some(x.to_string()),
+            };
+            // Next scan through all scopes for handlers that bind to this particular event
+            for (_, (_, _, handlerscope)) in program.scopes_by_file.iter() {
+                for (handlereventname, handler) in handlerscope.handlers.iter() {
+                    if eventname == handlereventname {
+                        // We have a match, grab the function(s) from this scope
+                        let fns: &Vec<Function> = match handlerscope.functions.get(&handler.functionname) {
+                            Some(res) => Ok(res),
+                            None => Err("Somehow unable to find function for handler"),
+                        }?;
+                        // Determine the correct function from the vector by finding the last one
+                        // that implements the correct interface (if the event has an argument,
+                        // then exactly one argument of the same type and no return type, if no
+                        // argument then no arguments to the function)
+                        let mut handler_pos = None;
+                        for (i, possible_fn) in fns.iter().enumerate() {
+                            if let Some(_) = &possible_fn.rettype {
+                                continue;
+                            }
+                            match expected_arg_type {
+                                None => {
+                                    if possible_fn.args.len() == 0 {
+                                        handler_pos = Some(i);         
+                                    }
+                                },
+                                Some(ref arg_type) => {
+                                    if possible_fn.args.len() == 1 && &possible_fn.args[0].1 == arg_type {
+                                        handler_pos = Some(i);
+                                    }
+                                },
+                            }
+                        }
+                        let handler_fn = match handler_pos {
+                          None => Err("No function properly matches the event signature"),
+                          Some(i) => Ok(&fns[i]),
+                        }?;
+                        // Because of what we validated above, we *know* that if this event takes
+                        // an argument, then the first microstatement is an Arg microstatement that
+                        // the normal code generation path is going to ignore. We're going to peek
+                        // at the first microstatement of the function and decide if we need to
+                        // insert the special `let <argname> = arg.clone();` statement or not
+                        match &handler_fn.microstatements[0] {
+                            Microstatement::Arg { name, .. } => {
+                                // TODO: guard against valid alan variable names that are no valid
+                                // rust variable names
+                                out = format!("{}        let {} = arg.clone();\n", out, name).to_string();
+                            },
+                            _ => {},
+                        }
+                        // Now we generate the thread to run this event handler on
+                        out = format!("{}        std::thread::spawn(move || {{\n", out).to_string();
+                        if let Some(b) = &handler_fn.bind {
+                            // If it's a bound function, just call it with the argument, if there
+                            // is one
+                            let arg_str = match &handler_fn.microstatements[0] {
+                                Microstatement::Arg { name, .. } => name.clone(),
+                                _ => "".to_string(),
+                            };
+                            out = format!("{}            super::{}({});\n", out, b, arg_str);
+                        } else {
+                            // Inline the microstatements if it's an Alan function
+                            for microstatement in &handler_fn.microstatements {
+                                let stmt = from_microstatement(microstatement, handlerscope, program)?;
+                                if stmt != "" {
+                                    out = format!("{}            {};\n", out, stmt);
+                                }
+                            }
+                        }
+                        // And close out the thread
+                        out = format!("{}        }});\n", out).to_string();
+                    }
+                }
+            }
+            // Now we finally close out this function
+            out = format!("{}   }}\n", out).to_string();
+        }
+    }
+    // And close out the event module
+    out = format!("{}}}\n", out).to_string();
+    Ok(out)
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1259,6 +1259,7 @@ named_and!(events: Events =>
     colon: String as colon,
     c: String as optwhitespace,
     fulltypename: FullTypename as fulltypename,
+    optsemicolon: String as optsemicolon,
 );
 named_and!(propertytypeline: PropertyTypeline =>
     variable: String as variable,
@@ -1454,6 +1455,7 @@ named_and!(handlers: Handlers =>
     eventname: Vec<VarSegment> as var,
     b: String as whitespace,
     handler: Handler as handler,
+    optsemicolon: String as optsemicolon,
 );
 named_or!(rootelements: RootElements =>
     Whitespace: String as whitespace,

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -4,7 +4,7 @@
  **/
 
 // Integer-related bindings
-export fn toI8(i: i64): i8 binds i64toi8;
+export fn i8(i: i64): i8 binds i64toi8;
 export fn add(a: i8, b: i8): Result<i8> binds addi8;
 export fn sub(a: i8, b: i8): Result<i8> binds subi8;
 export fn mul(a: i8, b: i8): Result<i8> binds muli8;
@@ -16,11 +16,19 @@ export fn max(a: i8, b: i8): i8 binds maxi8;
 
 // Process exit-related bindings
 export type ExitCode binds std::process::ExitCode;
-export fn ExitCode(e: i64): ExitCode binds to_exit_code_i64;
 export fn ExitCode(e: i8): ExitCode binds to_exit_code_i8;
+export fn ExitCode(e: i64): ExitCode binds to_exit_code_i64;
+// export fn ExitCode(e: i64): ExitCode = ExitCode(i8(e));
 export fn getOrExit(a: Result<i8>): i8 binds get_or_exit; // TODO: Support real generics
 
 // Stdout/stderr-related bindings
-export fn print(str: String) binds println!;
-export fn print(i: i8) binds print;
-export fn print(i: i64) binds print;
+export fn print(str: String) binds println;
+export fn print(i: i8) binds println;
+export fn print(i: i64) binds println;
+
+export event stdout: String;
+fn toStdout(strn: String) binds stdout;
+on stdout toStdout;
+
+// Thread-related bindings
+export fn wait(t: i64) binds wait;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -81,7 +81,17 @@ fn get_or_exit<A>(a: Result<A, Box<dyn std::error::Error>>) -> A {
     a.unwrap()
 }
 
-/// `print` is a simple function that prints basically anything other than String
-fn print<A: std::fmt::Display>(a: A) {
+/// `println` is a simple function that prints basically anything
+fn println<A: std::fmt::Display>(a: A) {
     println!("{}", a);
+}
+
+/// `stdout` is a simple function that prints basically anything without a newline attached
+fn stdout<A: std::fmt::Display>(a: A) {
+    print!("{}", a);
+}
+
+/// `wait` is a function that sleeps the current thread for the specified number of milliseconds
+fn wait(t: i64) {
+    std::thread::sleep(std::time::Duration::from_millis(t as u64));
 }


### PR DESCRIPTION
Implements threads, unning each event handler on a separate thread and copying the data they use,

Also turns `toI8` into just `i8` for consistency and sets up a new Microstatement type, Arg, to make variable resolution work for arguments, though it doesn't guard against argument names that are valid in Alan and not in Rust.

And several bugfixes along the way.