### PR TITLE
Add a multi-line Hello, World test

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -109,11 +109,9 @@ test!(hello_world => r#"
     status 0;
 );
 test!(multi_line_hello_world => r#"
-    export fn main() {
-      print(
+export fn main = print(
 "Hello,
-World!");
-    }"#;
+World!");"#;
     stdout r#"Hello,
 World!
 "#;

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -100,12 +100,23 @@ macro_rules! status {
     };
 }
 
-// The only test that works for now
+// The gold standard test. If you can't do this, are you even a language at all? :P
 test!(hello_world => r#"
     export fn main {
         print('Hello, World!');
     }"#;
     stdout "Hello, World!\n";
+    status 0;
+);
+test!(multi_line_hello_world => r#"
+    export fn main() {
+      print(
+"Hello,
+World!");
+    }"#;
+    stdout r#"Hello,
+World!
+"#;
     status 0;
 );
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -188,10 +188,10 @@ impl Scope {
                     parse::Exportable::Functions(f) => Function::from_ast(&mut s, &p, f, true)?,
                     parse::Exportable::ConstDeclaration(c) => Const::from_ast(&mut s, c, true)?,
                     parse::Exportable::Types(t) => Type::from_ast(&mut s, t, true)?,
-                    _ => println!("TODO"),
+                    _ => println!("TODO: Not yet supported export syntax"),
                 },
                 parse::RootElements::Whitespace(_) => { /* Do nothing */ }
-                _ => println!("TODO"),
+                _ => println!("TODO: Not yet supported top-level module syntax"),
             }
         }
         Ok((p, (txt, ast, s)))


### PR DESCRIPTION
I realized that while the syntax for strings makes them multi-line by default, there was no test to demonstrate that (and the vim highlighting broke on it, so I also fixed that).

And a tiny change on some todo lines so it's more clear what it is to be done in the future.