### PR TITLE
Implement basic method syntax and i16 math functions

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -30,8 +30,8 @@ pub fn compile(source_file: String) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// The `tors` function is an even thinner wrapper on top of `lntors` that shoves the output into a
-/// `.rs` file.
+/// The `to_rs` function is an even thinner wrapper on top of `lntors` that shoves the output into
+/// a `.rs` file.
 pub fn to_rs(source_file: String) -> Result<(), Box<dyn std::error::Error>> {
     // Generate the rust code to compile
     let rs_str = lntors(source_file.clone())?;
@@ -214,66 +214,50 @@ test!(int8_max => r#"
 );
 
 test!(int16_add => r#"
-    from @std/app import start, print, exit
-    on start {
-      print(add(toInt16(1), toInt16(2)));
-      emit exit 0;
+    export fn main {
+      print(add(i16(1), i16(2)));
     }"#;
     stdout "3\n";
 );
 test!(int16_sub => r#"
-    from @std/app import start, print, exit
-    on start {
-      print(sub(toInt16(2), toInt16(1)));
-      emit exit 0;
+    export fn main {
+      print(sub(i16(2), i16(1)));
     }"#;
     stdout "1\n";
 );
 test!(int16_mul => r#"
-    from @std/app import start, print, exit
-    on start {
-      print(mul(toInt16(2), toInt16(1)));
-      emit exit 0;
+    export fn main {
+      print(mul(i16(2), i16(1)));
     }"#;
     stdout "2\n";
 );
 test!(int16_div => r#"
-    from @std/app import start, print, exit
-    on start {
-      print(div(toInt16(6), toInt16(2)));
-      emit exit 0;
+    export fn main {
+      print(div(i16(6), i16(2)));
     }"#;
     stdout "3\n";
 );
 test!(int16_mod => r#"
-    from @std/app import start, print, exit
-    on start {
-      print(mod(toInt16(6), toInt16(4)));
-      emit exit 0;
+    export fn main{
+      print(mod(i16(6), i16(4)));
     }"#;
     stdout "2\n";
 );
 test!(int16_pow => r#"
-    from @std/app import start, print, exit
-    on start {
-      print(pow(toInt16(6), toInt16(2)));
-      emit exit 0;
+    export fn main {
+      print(pow(i16(6), i16(2)));
     }"#;
     stdout "36\n";
 );
 test!(int16_min => r#"
-    from @std/app import start, print, exit
-    on start {
-      min(3.toInt16(), 5.toInt16()).print();
-      emit exit 0;
+    export fn main {
+      min(3.i16(), 5.i16()).print();
     }"#;
     stdout "3\n";
 );
 test!(int16_max => r#"
-    from @std/app import start, print, exit
-    on start {
-      max(3.toInt16(), 5.toInt16()).print();
-      emit exit 0;
+    export fn main {
+      max(3.i16(), 5.i16()).print();
     }"#;
     stdout "5\n";
 );

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -13,6 +13,15 @@ export fn mod(a: i8, b: i8): Result<i8> binds modi8;
 export fn pow(a: i8, b: i8): Result<i8> binds powi8;
 export fn min(a: i8, b: i8): i8 binds mini8;
 export fn max(a: i8, b: i8): i8 binds maxi8;
+export fn i16(i: i64): i16 binds i64toi16;
+export fn add(a: i16, b: i16): Result<i16> binds addi16;
+export fn sub(a: i16, b: i16): Result<i16> binds subi16;
+export fn mul(a: i16, b: i16): Result<i16> binds muli16;
+export fn div(a: i16, b: i16): Result<i16> binds divi16;
+export fn mod(a: i16, b: i16): Result<i16> binds modi16;
+export fn pow(a: i16, b: i16): Result<i16> binds powi16;
+export fn min(a: i16, b: i16): i16 binds mini16;
+export fn max(a: i16, b: i16): i16 binds maxi16;
 
 // Process exit-related bindings
 export type ExitCode binds std::process::ExitCode;
@@ -24,6 +33,8 @@ export fn getOrExit(a: Result<i8>): i8 binds get_or_exit; // TODO: Support real 
 // Stdout/stderr-related bindings
 export fn print(str: String) binds println;
 export fn print(i: i8) binds println;
+export fn print(i: i16) binds println;
+export fn print(i: Result<i16>) binds println_result;
 export fn print(i: i64) binds println;
 
 export event stdout: String;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -76,6 +76,70 @@ fn maxi8(a: i8, b: i8) -> i8 {
     if a > b { a } else { b }
 }
 
+/// `i64toi16` casts an i64 to an i16.
+fn i64toi16(i: i64) -> i16 {
+    i as i16
+}
+
+/// `addi16` safely adds two i16s together, returning a Result-wrapped i16 (or an error on overflow)
+fn addi16(a: i16, b: i16) -> Result<i16, Box<dyn std::error::Error>> {
+    match a.checked_add(b) {
+        Some(c) => Ok(c),
+        None => Err("Overflow".into()),
+    }
+}
+
+/// `subi16` safely subtracts two i16s, returning a Result-wrapped i16 (or an error on underflow)
+fn subi16(a: i16, b: i16) -> Result<i16, Box<dyn std::error::Error>> {
+    match a.checked_sub(b) {
+        Some(c) => Ok(c),
+        None => Err("Underflow".into()),
+    }
+}
+
+/// `muli16` safely multiplies two i16s, returning a Result-wrapped i16 (or an error on under/overflow)
+fn muli16(a: i16, b: i16) -> Result<i16, Box<dyn std::error::Error>> {
+    match a.checked_mul(b) {
+        Some(c) => Ok(c),
+        None => Err("Underflow or Overflow".into()),
+    }
+}
+
+/// `divi16` safely divides two i16s, returning a Result-wrapped i16 (or an error on divide-by-zero)
+fn divi16(a: i16, b: i16) -> Result<i16, Box<dyn std::error::Error>> {
+    match a.checked_div(b) {
+        Some(c) => Ok(c),
+        None => Err("Divide-by-zero".into()),
+    }
+}
+
+/// `modi16` safely divides two i16s, returning a Result-wrapped remainder in i16 (or an error on divide-by-zero)
+fn modi16(a: i16, b: i16) -> Result<i16, Box<dyn std::error::Error>> {
+    match a.checked_rem(b) {
+        Some(c) => Ok(c),
+        None => Err("Divide-by-zero".into()),
+    }
+}
+
+/// `powi16` safely raises the first i16 to the second i16, returning a Result-wrapped i16 (or an error on under/overflow)
+fn powi16(a: i16, b: i16) -> Result<i16, Box<dyn std::error::Error>> {
+    // TODO: Support b being negative correctly
+    match a.checked_pow(b as u32) {
+        Some(c) => Ok(c),
+        None => Err("Underflow or Overflow".into()),
+    }
+}
+
+/// `mini16` returns the smaller of the two i16 values
+fn mini16(a: i16, b: i16) -> i16 {
+    if a < b { a } else { b }
+}
+
+/// `maxi16` returns the larger of the two i16 values
+fn maxi16(a: i16, b: i16) -> i16 {
+    if a > b { a } else { b }
+}
+
 /// `get_or_exit` is basically an alias to `unwrap`, but as a function instead of a method
 fn get_or_exit<A>(a: Result<A, Box<dyn std::error::Error>>) -> A {
     a.unwrap()
@@ -84,6 +148,14 @@ fn get_or_exit<A>(a: Result<A, Box<dyn std::error::Error>>) -> A {
 /// `println` is a simple function that prints basically anything
 fn println<A: std::fmt::Display>(a: A) {
     println!("{}", a);
+}
+
+/// `println_result` is a small wrapper function that makes printing Result types easy
+fn println_result<A: std::fmt::Display>(a: Result<A, Box<dyn std::error::Error>>) {
+    match a {
+      Ok(o) => println!("{}", o),
+      Err(e) => println!("{:?}", e),
+    };
 }
 
 /// `stdout` is a simple function that prints basically anything without a newline attached


### PR DESCRIPTION
Two of the tests for the i16 math used methods, so that's why I went with them to test the method syntax.

It currently only supports "direct" method access, not via properties, so something like `http.request("https://google.com")` would work but calling a method off of a property of a variable name would not (eg `http.request("https://google.com").response.status()` would fail to compile).

I've also set up grouping syntax (eg `(1 + 2)`) but since operators don't exist yet, that's not actually tested, yet.
