### PR TITLE
Keep track of mutability in microstatements, afterall

### DIFF
--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -13,12 +13,12 @@ pub fn from_microstatement(
 ) -> Result<(String, OrderedHashMap<String, String>), Box<dyn std::error::Error>> {
     match microstatement {
         Microstatement::Arg { .. } => Ok(("".to_string(), out)), // Skip arg microstatements that are just used for discovery during generation
-        Microstatement::Assignment { name, value } => {
+        Microstatement::Assignment { name, value, mutable } => {
             let (val, o) = from_microstatement(value, scope, program, out)?;
             // I wish I didn't have to write the following line because you can't re-assign a
             // variable in a let destructuring, afaict
             out = o;
-            Ok((format!("let {} = {}", name, val,).to_string(), out))
+            Ok((format!("let {} {} = {}", if *mutable { "mut" } else { "" }, name, val,).to_string(), out))
         }
         Microstatement::Value {
             typen,


### PR DESCRIPTION
I was thinking about how to efficiently implement some black box vector types to test with, and realized that ignoring mutability is going to significantly harm performance, so I modified the microstatement type to keep track of it and serialize to Rust appropriately.
