### PR TITLE
Implement a faster parmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ name = "alan"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "divan",
  "nom",
  "ordered_hash_map",
 ]
@@ -58,7 +59,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -68,8 +69,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "cfg-if"
@@ -97,6 +104,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -124,6 +132,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
+
+[[package]]
+name = "divan"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d567df2c9c2870a43f3f2bd65aaeb18dbce1c18f217c3e564b4fbaeb3ee56c"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27540baf49be0d484d8f0130d7d8da3011c32a44d4fc873368154f1510e574a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +186,18 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "libc"
+version = "0.2.153"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "memchr"
@@ -194,6 +255,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +288,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -230,11 +320,35 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -243,14 +357,20 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -260,9 +380,21 @@ checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -272,9 +404,21 @@ checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -284,9 +428,21 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,10 @@ edition = "2021"
 clap = { version = "4.4.18", features = ["derive"] }
 nom = "7.1.3"
 ordered_hash_map = "0.4.0"
+
+[dev-dependencies]
+divan = "0.1.14"
+
+[[bench]]
+name = "map"
+harness = false

--- a/benches/bench.ln
+++ b/benches/bench.ln
@@ -1,0 +1,95 @@
+// The benchmark in this directory is based on this file. That version unfortunately includes the
+// time it takes for `filled` to run, so the effective performance of `parmap` is underestimated
+fn double(x: i64): Result<i64> = x * 2;
+
+export fn main {
+  print('1:');
+  let v = filled(2, 1);
+  let t1 = now();
+  v.map(double);
+  t1.elapsed().print();
+  let t2 = now();
+  v.parmap(double);
+  t2.elapsed().print();
+
+  print('10:');
+  let v = filled(2, 10);
+  let t1 = now();
+  v.map(double);
+  t1.elapsed().print();
+  let t2 = now();
+  v.parmap(double);
+  t2.elapsed().print();
+
+  print('100:');
+  let v = filled(2, 100);
+  let t1 = now();
+  v.map(double);
+  t1.elapsed().print();
+  let t2 = now();
+  v.parmap(double);
+  t2.elapsed().print();
+
+  print('1,000:');
+  let v = filled(2, 1000);
+  let t1 = now();
+  v.map(double);
+  t1.elapsed().print();
+  let t2 = now();
+  v.parmap(double);
+  t2.elapsed().print();
+
+  print('10,000:');
+  let v = filled(2, 10000);
+  let t1 = now();
+  v.map(double);
+  t1.elapsed().print();
+  let t2 = now();
+  v.parmap(double);
+  t2.elapsed().print();
+
+  print('100,000:');
+  let v = filled(2, 100000);
+  let t1 = now();
+  v.map(double);
+  t1.elapsed().print();
+  let t2 = now();
+  v.parmap(double);
+  t2.elapsed().print();
+
+  print('1,000,000:');
+  let v = filled(2, 1000000);
+  let t1 = now();
+  v.map(double);
+  t1.elapsed().print();
+  let t2 = now();
+  v.parmap(double);
+  t2.elapsed().print();
+
+  print('10,000,000:');
+  let v = filled(2, 10000000);
+  let t1 = now();
+  v.map(double);
+  t1.elapsed().print();
+  let t2 = now();
+  v.parmap(double);
+  t2.elapsed().print();
+
+  print('100,000,000:');
+  let v = filled(2, 100000000);
+  let t1 = now();
+  v.map(double);
+  t1.elapsed().print();
+  let t2 = now();
+  v.parmap(double);
+  t2.elapsed().print();
+
+  print('1,000,000,000:');
+  let v = filled(2, 1000000000);
+  let t1 = now();
+  v.map(double);
+  t1.elapsed().print();
+  let t2 = now();
+  v.parmap(double);
+  t2.elapsed().print();
+}

--- a/benches/map.rs
+++ b/benches/map.rs
@@ -1,0 +1,144 @@
+use std::fs::{remove_file, write};
+use std::process::{Command, Output};
+
+use alan::compile::compile;
+
+macro_rules! build {
+    ( $name:ident => $code:expr ) => {
+        let filename = format!("{}.ln", stringify!($name));
+        write(&filename, $code)?;
+        compile(filename.to_string())?;
+    }
+}
+
+macro_rules! run {
+    ( $name:ident ) => {
+        #[divan::bench(max_time = 60)]
+        fn $name() -> Result<Output, std::io::Error> {
+            Command::new(format!("./{}", stringify!($name))).output()
+        }
+    }
+}
+
+macro_rules! clean {
+    ( $name:ident ) => {
+        let sourcefile = format!("{}.ln", stringify!($name));
+        let executable = format!("{}", stringify!($name));
+        remove_file(&sourcefile)?;
+        remove_file(&executable)?;
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    build!(map_1 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 1).map(double); }
+    "#);
+    build!(map_10 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 10).map(double); }
+    "#);
+    build!(map_100 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 100).map(double); }
+    "#);
+    build!(map_1000 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 1000).map(double); }
+    "#);
+    build!(map_10000 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 10000).map(double); }
+    "#);
+    build!(map_100000 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 100000).map(double); }
+    "#);
+    build!(map_1000000 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 1000000).map(double); }
+    "#);
+    build!(map_10000000 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 10000000).map(double); }
+    "#);
+    build!(map_100000000 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 100000000).map(double); }
+    "#);
+    build!(parmap_1 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 1).parmap(double); }
+    "#);
+    build!(parmap_10 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 10).parmap(double); }
+    "#);
+    build!(parmap_100 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 100).parmap(double); }
+    "#);
+    build!(parmap_1000 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 1000).parmap(double); }
+    "#);
+    build!(parmap_10000 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 10000).parmap(double); }
+    "#);
+    build!(parmap_100000 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 100000).parmap(double); }
+    "#);
+    build!(parmap_1000000 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 1000000).parmap(double); }
+    "#);
+    build!(parmap_10000000 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 10000000).parmap(double); }
+    "#);
+    build!(parmap_100000000 => r#"
+        fn double(x: i64): Result<i64> = x * 2;
+        export fn main { filled(2, 100000000).parmap(double); }
+    "#);
+    divan::main();
+    clean!(map_1);
+    clean!(map_10);
+    clean!(map_100);
+    clean!(map_1000);
+    clean!(map_10000);
+    clean!(map_100000);
+    clean!(map_1000000);
+    clean!(map_10000000);
+    clean!(map_100000000);
+    clean!(parmap_1);
+    clean!(parmap_10);
+    clean!(parmap_100);
+    clean!(parmap_1000);
+    clean!(parmap_10000);
+    clean!(parmap_100000);
+    clean!(parmap_1000000);
+    clean!(parmap_10000000);
+    clean!(parmap_100000000);
+    Ok(())
+}
+
+run!(map_1);
+run!(map_10);
+run!(map_100);
+run!(map_1000);
+run!(map_10000);
+run!(map_100000);
+run!(map_1000000);
+run!(map_10000000);
+run!(map_100000000);
+run!(parmap_1);
+run!(parmap_10);
+run!(parmap_100);
+run!(parmap_1000);
+run!(parmap_10000);
+run!(parmap_100000);
+run!(parmap_1000000);
+run!(parmap_10000000);
+run!(parmap_100000000);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod compile;
+pub mod lntors;
+pub mod parse;
+pub mod program;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
-use compile::{compile, to_rs};
-use program::Program;
+use crate::compile::{compile, to_rs};
+use crate::program::Program;
 
 mod compile;
 mod lntors;


### PR DESCRIPTION
The prior implementation using `Vec::append` nullified *most* of the performance benefit of parallelization because of all of the copying and resizing, likely. (It was only 10-20% faster for large vectors)

This new implementation uses some unsafe shenanigans to write directly into the output vector, and is about 4.25x faster than running sequentially on my 16-thread CPU. There's probably some contention at play since I think there's only 8 *real* cores and it's hyperthreading (or whatever AMD's equivalent is called) causes contention between them, but I might also be hitting some memory bandwidth limits, as all it's doing is multiplying values by 2, wrapping in a `Result`, and storing that in the vector.

I have been hesitant for the generated Rust code to depend on any third-party libraries, but thinking about it, that will be the case once I start using `wgpu`, so I might look into a more advanced library to determine *actual* core count, instead of just using `available_parallelism`, assuming that cutting that value in half keeps the same performance (or potentially improves it). That will be a follow-up PR if the test goes well.

But I am still quite happy with perf now vs the 0.1 days :)
