### PR TITLE
Compile rust transpile as cargo projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,11 @@ name = "alan"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "dirs",
  "divan",
  "nom",
  "ordered_hash_map",
+ "sysinfo",
 ]
 
 [[package]]
@@ -71,6 +73,12 @@ dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -138,6 +146,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "divan"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +223,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +236,17 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -192,6 +269,17 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -222,10 +310,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered_hash_map"
@@ -238,20 +341,60 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -266,7 +409,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -281,13 +424,28 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c385888ef380a852a16209afc8cfad22795dd8873d69c9a14d2e2088f118d18"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
 ]
 
 [[package]]
@@ -298,6 +456,26 @@ checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -317,6 +495,53 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.4.18", features = ["derive"] }
+dirs = "5.0.1"
 nom = "7.1.3"
 ordered_hash_map = "0.4.0"
+sysinfo = "0.30.7"
 
 [dev-dependencies]
 divan = "0.1.14"

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,41 +1,264 @@
-use std::fs::{remove_file, write};
+use std::env::current_dir;
+use std::fs::{create_dir_all, read_to_string, remove_file, write};
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::{Command, Stdio, id};
+use std::thread::sleep;
+use std::time::Duration;
+
+use dirs::config_dir;
+use sysinfo::System;
 
 use crate::lntors::lntors;
 
-/// The `compile` function is a very thin wrapper on top of `lntors`, just handling the file
-/// loading and temporary file storage and removal on the path to generating the binary.
+/// The `compile` function creates a temporary directory that is a Cargo project primarily
+/// consisting of a single source file, plus a Cargo.toml file including the 3rd party dependencies
+/// in the standard library. While this *should* be some configurable thing in the standard library
+/// code instead, the contents of the Cargo.toml are just hardwired in here for now.
 pub fn compile(source_file: String) -> Result<(), Box<dyn std::error::Error>> {
-    // Fail if rustc is not present
+    // Fail if rustc is not present TODO: Present a better error to the user
     Command::new("which").arg("rustc").output()?;
-    // Generate the rust code to compile
-    let rs_str = lntors(source_file.clone())?;
-    // Shove it into a temp file for rustc
-    let tmp_file = match PathBuf::from(source_file).file_stem() {
-        Some(pb) => format!("{}.rs", pb.to_string_lossy().to_string()),
-        None => {
-            return Err("Invalid path".into());
-        }
+    // Also fail if cargo is not present
+    Command::new("which").arg("cargo").output()?;
+    // Because all Alan programs use the same Rust dependencies (for now), we can cut down a *lot*
+    // of build time by re-using the `./target/release/build` and `./target/release/deps` directory
+    // in subsequent builds. Since it takes over 30 seconds to make a release build on my laptop
+    // there needs to be a multi-step process to detect if there's a concurrent build happening
+    // that we should wait for. First we need to look for a `{CONFIG}/alan` directory. If it's not
+    // there, make one, build a guaranteed Hello, World app within it, then use it in the regular
+    // build flow. If it *is* there *and* the `hello_world` application is present, we need to see
+    // if another Alan compile is concurrently running, if so, we sleep wait until it is gone
+    // (either the lockfile is deleted or the process ID in the lockfile is no longer running and
+    // then we delete it and continue. Then we continue with the regular build flow.
+    let config_dir = match config_dir() {
+        Some(c) => Ok(c),
+        None => Err("Somehow no configuration directory exists on this operating system"),
+    }?;
+    let alan_config = { // All this because `push` is not chainable :/
+        let mut a = config_dir.clone();
+        a.push("alan");
+        a
     };
-    write(&tmp_file, rs_str)?;
+    let lockfile = {
+        let mut l = alan_config.clone();
+        l.push(".lockfile");
+        l
+    };
+    let project_dir = {
+        let mut p = alan_config.clone();
+        p.push("alan_generated_bin");
+        p
+    };
+    let release_path = {
+        let mut r = project_dir.clone();
+        r.push("target");
+        r.push("release");
+        r
+    };
+    if alan_config.exists() {
+        if lockfile.exists() {
+            let mut count = 0;
+            while lockfile.exists() && count < 300 {
+                // Check if the pid in the lockfile is still running
+                match read_to_string(lockfile.clone()) {
+                    Err(_) => { // Probably being deleted while we were trying to read, we'll check next time
+                        sleep(Duration::from_secs(1));
+                        count = count + 1;
+                    }, 
+                    Ok(pid) => {
+                        let pid = pid.parse::<u32>().unwrap();
+                        let sys = System::new_all();
+                        let mut found = false;
+                        for (p, _) in sys.processes() {
+                            if p.as_u32() == pid {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if found {
+                            // The process is still running, let's wait
+                            sleep(Duration::from_secs(1));
+                            count = count + 1;
+                        } else {
+                            // The process exited without removing the lockfile, we're taking over
+                            remove_file(lockfile.clone())?;
+                            sleep(Duration::from_secs(1));
+                            return compile(source_file);
+                        }
+                    }
+                }
+            }
+            if count == 300 {
+                panic!("Build initialization failed. Please retry with an active internet connection");
+            }
+            // If we got here, the lockfile shouldn't exist, so let's acquire it
+            write(lockfile.clone(), format!("{}", id()))?;
+        } else {
+            // We'll assume that this has been created correctly and no other process is running
+            write(lockfile.clone(), format!("{}", id()))?;
+        }
+    } else {
+        // First time initialization of the alan config directory
+        create_dir_all(alan_config.clone())?;
+        write(lockfile.clone(), format!("{}", id()))?;
+        match create_dir_all(project_dir.clone()) {
+            Ok(a) => Ok(a),
+            Err(e) => {
+                remove_file(lockfile.clone())?;
+                Err(e)
+            }
+        }?;
+        let cargo_str = r#"[package]
+name = "alan_generated_bin"
+edition = "2021"
+
+[dependencies]
+wgpu = "0.19.3""#;
+        let cargo_path = {
+            let mut c = project_dir.clone();
+            c.push("Cargo.toml");
+            c
+        };
+        match write(cargo_path, cargo_str) {
+            Ok(a) => Ok(a),
+            Err(e) => {
+                remove_file(lockfile.clone())?;
+                Err(e)
+            }
+        }?;
+        let src_path = {
+            let mut s = project_dir.clone();
+            s.push("src");
+            s
+        };
+        match create_dir_all(src_path.clone()) {
+            Ok(a) => Ok(a),
+            Err(e) => {
+                remove_file(lockfile.clone())?;
+                Err(e)
+            }
+        }?;
+        let hello_ln = "export fn main = print('Hello, World!');";
+        let hello_path = {
+            let mut l = src_path.clone();
+            l.push("hello.ln");
+            l
+        };
+        match write(hello_path.clone(), hello_ln) {
+            Ok(a) => Ok(a),
+            Err(e) => {
+                remove_file(lockfile.clone())?;
+                Err(e)
+            }
+        }?;
+        let rs_str = match lntors(hello_path.to_string_lossy().to_string()) {
+            Ok(a) => Ok(a),
+            Err(e) => {
+                remove_file(lockfile.clone())?;
+                Err(e)
+            }
+        }?;
+        let main_path = {
+            let mut m = src_path.clone();
+            m.push("main.rs");
+            m
+        };
+        match write(main_path, rs_str) {
+            Ok(a) => Ok(a),
+            Err(e) => {
+                remove_file(lockfile.clone())?;
+                Err(e)
+            }
+        }?;
+        match remove_file(hello_path) {
+            Ok(a) => Ok(a),
+            Err(e) => {
+                remove_file(lockfile.clone())?;
+                Err(e)
+            }
+        }?;
+        match Command::new("cargo")
+            .current_dir(project_dir.clone())
+            .arg("build")
+            .arg("--release")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output() {
+            Ok(a) => Ok(a),
+            Err(e) => {
+                remove_file(lockfile.clone())?;
+                Err(e)
+            }
+        }?;
+    }
+    // Once we're here, the base hello world app we use as a build cache definitely exists, so
+    // let's get to work! We can't use the `?` operator directly here, because we need to make sure
+    // we remove the lockfile on any failure.
+    let src_dir = {
+      let mut s = project_dir.clone();
+      s.push("src");
+      s
+    };
+    // Generate the rust code to compile
+    let rs_str = match lntors(source_file.clone()) {
+        Ok(s) => Ok(s),
+        Err(e) => {
+            remove_file(lockfile.clone())?;
+            Err(e)
+        }
+    }?;
+    // Shove it into a temp file for rustc
+    let rs_path = {
+        let mut r = src_dir.clone();
+        r.push("main.rs");
+        r
+    };
+    match write(rs_path, rs_str) {
+        Ok(a) => Ok(a),
+        Err(e) => {
+            remove_file(lockfile.clone())?;
+            Err(e)
+        }
+    }?;
     // Build the executable
-    Command::new("rustc")
-        .arg("--edition")
-        .arg("2021")
-        .arg("-C")
-        .arg("opt-level=3")
-        .arg(&tmp_file)
+    match Command::new("cargo")
+        .current_dir(project_dir.clone())
+        .arg("build")
+        .arg("--release")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()?;
-    // Drop the temp file
-    remove_file(tmp_file)?;
+        .output() {
+        Ok(a) => Ok(a),
+        Err(e) => {
+            remove_file(lockfile.clone())?;
+            Err(e)
+        }
+    }?;
+    // Copy the binary from the temp directory to the current directory
+    let project_name_path = PathBuf::from(source_file);
+    let project_name_str = match project_name_path.file_stem() {
+        None => panic!("Somehow can't parse the source file name as a path?"),
+        Some(n) => n.to_string_lossy().to_string(),
+    };
+    match Command::new("cp")
+        .current_dir(release_path)
+        .arg("alan_generated_bin")
+        .arg(format!("{}/{}", current_dir()?.to_string_lossy(), project_name_str))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output() {
+        Ok(a) => Ok(a),
+        Err(e) => {
+            remove_file(lockfile.clone())?;
+            Err(e)
+        }
+    }?;
+    // Drop the lockfile
+    remove_file(lockfile)?;
     Ok(())
 }
 
-/// The `to_rs` function is an even thinner wrapper on top of `lntors` that shoves the output into
-/// a `.rs` file.
+/// The `to_rs` function is an thin wrapper on top of `lntors` that shoves the output into a `.rs`
+/// file.
 pub fn to_rs(source_file: String) -> Result<(), Box<dyn std::error::Error>> {
     // Generate the rust code to compile
     let rs_str = lntors(source_file.clone())?;
@@ -75,8 +298,8 @@ macro_rules! test {
                 let run = super::Command::new(format!("./{}", stringify!($rule))).output()?;
                 $( $type!($test_val, &run); )+
                 // Cleanup the temp files. TODO: Make this happen regardless of test failure?
-                super::remove_file(&filename)?;
-                super::remove_file(stringify!($rule))?;
+                std::fs::remove_file(&filename)?;
+                std::fs::remove_file(stringify!($rule))?;
                 Ok(())
             }
         }


### PR DESCRIPTION
This took a lot longer than I expected (when attempting to keep the compilation time at least somewhat close to what it was before) because [`wgpu`](https://wgpu.rs), the library I am interested in using in the transpilation, takes >30sec to compile on my machine, and doing that for every single test is madness.

So after digging into how cargo's build cache works (terribly, btw), I'm making a singular project and serializing compilation through it via a lockfile, which isn't great, but at least the test suite finishes within a minute, still.
