### PR TITLE
Implement compound types (structs), and the bare minimum of property access and booleans to get another test working

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1540,22 +1540,18 @@ test!(array_literals => r#"
     stdout "1\n2\n4\n";
 );
 test!(object_literals => r#"
-    from @std/app import start, print, exit
-
     type MyType {
-      foo: string,
+      foo: String,
       bar: bool,
     }
 
-    on start {
+    export fn main {
       const test = new MyType {
         foo: 'foo!',
         bar: true,
       };
       print(test.foo);
       print(test.bar);
-
-      emit exit 0;
     }"#;
     stdout "foo!\ntrue\n";
 );

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -1,15 +1,42 @@
 // TODO: Generics/Interfaces resolution
+use ordered_hash_map::OrderedHashMap;
 
 use crate::program::{Program, Scope, Type, TypeType};
 
 pub fn generate(
     typen: &Type,
-    _scope: &Scope,
-    _program: &Program,
-) -> Result<String, Box<dyn std::error::Error>> {
+    scope: &Scope,
+    program: &Program,
+    mut out: OrderedHashMap<String, String>,
+) -> Result<(String, OrderedHashMap<String, String>), Box<dyn std::error::Error>> {
     match &typen.typetype {
-        TypeType::Bind(s) => Ok(s.clone()),
-        TypeType::Alias(a) => Ok(a.to_string()),
-        TypeType::Structlike(_) => Ok(typen.typename.to_string()),
+        // The first value is the identifier, and the second is the generated source. For the
+        // `Bind` and `Alias` types, these already exist in the Rust environment (or should exist,
+        // assuming no bugs in the standard library) so they do not alter the generated source
+        // output, while the `Structlike` type requires a new struct to be created and inserted
+        // into the source definition, potentially inserting inner types as needed
+        TypeType::Bind(s) => Ok((s.clone(), out)),
+        TypeType::Alias(a) => Ok((a.to_string(), out)),
+        TypeType::Structlike(s) => {
+            let mut typestring = format!(r#"#[derive(Debug)]
+struct {} {{
+"#, typen.typename.to_string());
+            for typeline in &s.typelist {
+                let typename = typeline.fulltypename.to_string();
+                let (subtypen, subtypescope) = match program.resolve_type(scope, &typename) {
+                    None => Err(format!("Type {} not found", typename)),
+                    Some((t, s)) => Ok((t, s)),
+                }?;
+                let res = generate(subtypen, subtypescope, program, out)?;
+                let subtypename = res.0;
+                out = res.1;
+                typestring = format!(r#"{}
+    pub {}: {},"#, typestring, typeline.variable, subtypename);
+            }
+            typestring = format!(r#"{}
+}}"#, typestring);
+            out.insert(typen.typename.to_string(), typestring.to_string());
+            Ok((typen.typename.to_string(), out))
+        },
     }
 }

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -99,6 +99,9 @@ export fn max(a: Result<i64>, b: Result<i64>): Result<i64> binds maxi64_result;
 export fn max(a: i64, b: Result<i64>): Result<i64> = max(a.ok(), b);
 export fn max(a: Result<i64>, b: i64): Result<i64> = max(a, b.ok());
 
+// Boolean related bindings
+type bool binds bool;
+
 // Process exit-related bindings
 export type ExitCode binds std::process::ExitCode;
 export fn ExitCode(e: i8): ExitCode binds to_exit_code_i8;
@@ -114,6 +117,7 @@ export fn getOrExit(a: Result<i64>): i64 binds get_or_exit; // TODO: Support rea
 export type String binds String;
 export fn concat(a: String, b: String): String binds string_concat;
 export fn print(str: String) binds println;
+export fn print(b: bool) binds println;
 export fn print(i: i8) binds println;
 export fn print(i: i16) binds println;
 export fn print(i: Result<i16>) binds println_result;


### PR DESCRIPTION
I realized that I wanted to implement the basic GPU `run` function by passing in a type that has the wgsl shader code as a string and an array of arrays of GPU buffers (to represent the group and binding fields for mutable memory) that I could then build the better abstractions on top of, but that it was impossible because structs and arrays don't really exist, yet.

This PR gets structs working. It also partially implements arrays and the bare minimum of bool and property access to get another test working. I really need to clean up the property/method/etc logic into a properly recursive function instead of the spaghetti I have right now, but I wanted to reserve that refactor for later (both because I want to get a GPGPU benchmark working ASAP, regardless of the quality of that code there, but also because this PR is getting long in the tooth and I didn't want to make it too difficult to follow in the future).

Stopping here for tonight since it's getting late on a Friday.
