### PR TITLE
Increase the benchmark size

### DIFF
--- a/benches/bench.ln
+++ b/benches/bench.ln
@@ -84,8 +84,6 @@ export fn main {
   v.parmap(double);
   t2.elapsed().print();
 
-// Github CI doesn't have enough RAM for this level
-/*
   print('1,000,000,000:');
   let v = filled(2, 1000000000);
   let t1 = now();
@@ -94,5 +92,4 @@ export fn main {
   let t2 = now();
   v.parmap(double);
   t2.elapsed().print();
-*/
 }


### PR DESCRIPTION
Now that I'm self-hosting the github actions runs so I can use a GPU, I can also increase the RAM usage of the benchmark to get a better performance boost measurement for large arrays.
