### PR TITLE
Add some GPGPU benchmarking

### DIFF
--- a/benches/bench.ln
+++ b/benches/bench.ln
@@ -1,95 +1,99 @@
 // The benchmark in this directory is based on this file. That version unfortunately includes the
 // time it takes for `filled` to run, so the effective performance of `parmap` is underestimated
-fn double(x: i64): Result<i64> = x * 2;
+fn double(x: i32): Result<i32> = x * 2.i32();
+
+fn bench(l: i64) {
+  let v = filled(2.i32(), l);
+  v.length().print();
+  let t1 = now();
+  v.map(double);
+  t1.elapsed().print();
+  let t2 = now();
+  v.parmap(double);
+  t2.elapsed().print();
+  let t3 = now();
+  let g = GPU();
+  let b = g.createBuffer(storageBuffer(), v);
+  let plan = GPGPU("
+    @group(0)
+    @binding(0)
+    var<storage, read_write> vals: array<i32>;
+
+    @compute
+    @workgroup_size(1)
+    fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+      let i = id.x + 65535 * id.y + 4294836225 * id.z;
+      let l = arrayLength(&vals);
+      if i > l { return; }
+      vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+    }
+  ", b);
+  g.run(plan);
+  g.read(b);
+  t3.elapsed().print();
+}
+
+// Until I have conditionals working, I need to do this kind of tomfoolery
+fn bench_billion {
+  let v = filled(2.i32(), 1000000000);
+  v.length().print();
+  let t1 = now();
+  v.map(double);
+  t1.elapsed().print();
+  let t2 = now();
+  v.parmap(double);
+  t2.elapsed().print();
+  let v2 = filled(2.i32(), 500000000);
+  let t3 = now();
+  let g = GPU();
+  let b = g.createBuffer(storageBuffer(), v2);
+  let plan = GPGPU("
+    @group(0)
+    @binding(0)
+    var<storage, read_write> vals: array<i32>;
+
+    @compute
+    @workgroup_size(1)
+    fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+      let i = id.x + 65535 * id.y + 4294836225 * id.z;
+      let l = arrayLength(&vals);
+      if i > l { return; }
+      vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+    }
+  ", b);
+  g.run(plan);
+  g.read(b);
+  let b = g.createBuffer(storageBuffer(), v2);
+  let plan = GPGPU("
+    @group(0)
+    @binding(0)
+    var<storage, read_write> vals: array<i32>;
+
+    @compute
+    @workgroup_size(1)
+    fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+      let i = id.x + 65535 * id.y + 4294836225 * id.z;
+      let l = arrayLength(&vals);
+      if i > l { return; }
+      vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+    }
+  ", b);
+  g.run(plan);
+  g.read(b);
+  t3.elapsed().print();
+}
 
 export fn main {
-  print('1:');
-  let v = filled(2, 1);
-  let t1 = now();
-  v.map(double);
-  t1.elapsed().print();
-  let t2 = now();
-  v.parmap(double);
-  t2.elapsed().print();
-
-  print('10:');
-  let v = filled(2, 10);
-  let t1 = now();
-  v.map(double);
-  t1.elapsed().print();
-  let t2 = now();
-  v.parmap(double);
-  t2.elapsed().print();
-
-  print('100:');
-  let v = filled(2, 100);
-  let t1 = now();
-  v.map(double);
-  t1.elapsed().print();
-  let t2 = now();
-  v.parmap(double);
-  t2.elapsed().print();
-
-  print('1,000:');
-  let v = filled(2, 1000);
-  let t1 = now();
-  v.map(double);
-  t1.elapsed().print();
-  let t2 = now();
-  v.parmap(double);
-  t2.elapsed().print();
-
-  print('10,000:');
-  let v = filled(2, 10000);
-  let t1 = now();
-  v.map(double);
-  t1.elapsed().print();
-  let t2 = now();
-  v.parmap(double);
-  t2.elapsed().print();
-
-  print('100,000:');
-  let v = filled(2, 100000);
-  let t1 = now();
-  v.map(double);
-  t1.elapsed().print();
-  let t2 = now();
-  v.parmap(double);
-  t2.elapsed().print();
-
-  print('1,000,000:');
-  let v = filled(2, 1000000);
-  let t1 = now();
-  v.map(double);
-  t1.elapsed().print();
-  let t2 = now();
-  v.parmap(double);
-  t2.elapsed().print();
-
-  print('10,000,000:');
-  let v = filled(2, 10000000);
-  let t1 = now();
-  v.map(double);
-  t1.elapsed().print();
-  let t2 = now();
-  v.parmap(double);
-  t2.elapsed().print();
-
-  print('100,000,000:');
-  let v = filled(2, 100000000);
-  let t1 = now();
-  v.map(double);
-  t1.elapsed().print();
-  let t2 = now();
-  v.parmap(double);
-  t2.elapsed().print();
-
-  print('1,000,000,000:');
-  let v = filled(2, 1000000000);
-  let t1 = now();
-  v.map(double);
-  t1.elapsed().print();
-  let t2 = now();
-  v.parmap(double);
-  t2.elapsed().print();
+  bench(1);
+  bench(10);
+  bench(100);
+  bench(1000);
+  bench(10000);
+  bench(100000);
+  bench(1000000);
+  bench(10000000);
+  bench(100000000);
+  // Commented out because it crashes on my laptop GPU. Try swapping which is commented on your's!
+  // bench(1000000000);
+  bench_billion();
 }

--- a/benches/map.rs
+++ b/benches/map.rs
@@ -102,6 +102,204 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         fn double(x: i64): Result<i64> = x * 2;
         export fn main { filled(2, 100000000).parmap(double); }
     "#);
+    build!(gpgpu_1 => r#"
+        export fn main {
+          let g = GPU();
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 1));
+          let plan = GPGPU("
+            @group(0)
+            @binding(0)
+            var<storage, read_write> vals: array<i32>;
+
+            @compute
+            @workgroup_size(1)
+            fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+              let i = id.x + 65535 * id.y + 4294836225 * id.z;
+              let l = arrayLength(&vals);
+              if i > l { return; }
+              vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+            }
+          ", b);
+          g.run(plan);
+          g.read(b);
+        }
+    "#);
+    build!(gpgpu_10 => r#"
+        export fn main {
+          let g = GPU();
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 10));
+          let plan = GPGPU("
+            @group(0)
+            @binding(0)
+            var<storage, read_write> vals: array<i32>;
+
+            @compute
+            @workgroup_size(1)
+            fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+              let i = id.x + 65535 * id.y + 4294836225 * id.z;
+              let l = arrayLength(&vals);
+              if i > l { return; }
+              vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+            }
+          ", b);
+          g.run(plan);
+          g.read(b);
+        }
+    "#);
+    build!(gpgpu_100 => r#"
+        export fn main {
+          let g = GPU();
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 100));
+          let plan = GPGPU("
+            @group(0)
+            @binding(0)
+            var<storage, read_write> vals: array<i32>;
+
+            @compute
+            @workgroup_size(1)
+            fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+              let i = id.x + 65535 * id.y + 4294836225 * id.z;
+              let l = arrayLength(&vals);
+              if i > l { return; }
+              vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+            }
+          ", b);
+          g.run(plan);
+          g.read(b);
+        }
+    "#);
+    build!(gpgpu_1000 => r#"
+        export fn main {
+          let g = GPU();
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 1000));
+          let plan = GPGPU("
+            @group(0)
+            @binding(0)
+            var<storage, read_write> vals: array<i32>;
+
+            @compute
+            @workgroup_size(1)
+            fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+              let i = id.x + 65535 * id.y + 4294836225 * id.z;
+              let l = arrayLength(&vals);
+              if i > l { return; }
+              vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+            }
+          ", b);
+          g.run(plan);
+          g.read(b);
+        }
+    "#);
+    build!(gpgpu_10000 => r#"
+        export fn main {
+          let g = GPU();
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 10000));
+          let plan = GPGPU("
+            @group(0)
+            @binding(0)
+            var<storage, read_write> vals: array<i32>;
+
+            @compute
+            @workgroup_size(1)
+            fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+              let i = id.x + 65535 * id.y + 4294836225 * id.z;
+              let l = arrayLength(&vals);
+              if i > l { return; }
+              vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+            }
+          ", b);
+          g.run(plan);
+          g.read(b);
+        }
+    "#);
+    build!(gpgpu_100000 => r#"
+        export fn main {
+          let g = GPU();
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 100000));
+          let plan = GPGPU("
+            @group(0)
+            @binding(0)
+            var<storage, read_write> vals: array<i32>;
+
+            @compute
+            @workgroup_size(1)
+            fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+              let i = id.x + 65535 * id.y + 4294836225 * id.z;
+              let l = arrayLength(&vals);
+              if i > l { return; }
+              vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+            }
+          ", b);
+          g.run(plan);
+          g.read(b);
+        }
+    "#);
+    build!(gpgpu_1000000 => r#"
+        export fn main {
+          let g = GPU();
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 1000000));
+          let plan = GPGPU("
+            @group(0)
+            @binding(0)
+            var<storage, read_write> vals: array<i32>;
+
+            @compute
+            @workgroup_size(1)
+            fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+              let i = id.x + 65535 * id.y + 4294836225 * id.z;
+              let l = arrayLength(&vals);
+              if i > l { return; }
+              vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+            }
+          ", b);
+          g.run(plan);
+          g.read(b);
+        }
+    "#);
+    build!(gpgpu_10000000 => r#"
+        export fn main {
+          let g = GPU();
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 10000000));
+          let plan = GPGPU("
+            @group(0)
+            @binding(0)
+            var<storage, read_write> vals: array<i32>;
+
+            @compute
+            @workgroup_size(1)
+            fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+              let i = id.x + 65535 * id.y + 4294836225 * id.z;
+              let l = arrayLength(&vals);
+              if i > l { return; }
+              vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+            }
+          ", b);
+          g.run(plan);
+          g.read(b);
+        }
+    "#);
+    build!(gpgpu_100000000 => r#"
+        export fn main {
+          let g = GPU();
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 100000000));
+          let plan = GPGPU("
+            @group(0)
+            @binding(0)
+            var<storage, read_write> vals: array<i32>;
+
+            @compute
+            @workgroup_size(1)
+            fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+              let i = id.x + 65535 * id.y + 4294836225 * id.z;
+              let l = arrayLength(&vals);
+              if i > l { return; }
+              vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+            }
+          ", b);
+          g.run(plan);
+          g.read(b);
+        }
+    "#);
     divan::main();
     clean!(map_1);
     clean!(map_10);
@@ -121,6 +319,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     clean!(parmap_1000000);
     clean!(parmap_10000000);
     clean!(parmap_100000000);
+    clean!(gpgpu_1);
+    clean!(gpgpu_10);
+    clean!(gpgpu_100);
+    clean!(gpgpu_1000);
+    clean!(gpgpu_10000);
+    clean!(gpgpu_100000);
+    clean!(gpgpu_1000000);
+    clean!(gpgpu_10000000);
+    clean!(gpgpu_100000000);
     Ok(())
 }
 
@@ -142,3 +349,12 @@ run!(parmap_100000);
 run!(parmap_1000000);
 run!(parmap_10000000);
 run!(parmap_100000000);
+run!(gpgpu_1);
+run!(gpgpu_10);
+run!(gpgpu_100);
+run!(gpgpu_1000);
+run!(gpgpu_10000);
+run!(gpgpu_100000);
+run!(gpgpu_1000000);
+run!(gpgpu_10000000);
+run!(gpgpu_100000000);

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -756,7 +756,7 @@ test!(hello_gpu => r#"
         var<storage, read_write> vals: array<i32>;
 
         @compute
-        @workgroup_size(4)
+        @workgroup_size(1)
         fn main(@builtin(global_invocation_id) id: vec3<u32>) {
           vals[id.x] = vals[id.x] * bitcast<i32>(id.x);
         }

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -52,6 +52,7 @@ export fn pow(a: i16, b: i16): Result<i16> binds powi16;
 export fn min(a: i16, b: i16): i16 binds mini16;
 export fn max(a: i16, b: i16): i16 binds maxi16;
 export type i32 binds i32;
+export type Result<i32> binds Result_i32;
 export fn i32(i: i64): i32 binds i64toi32;
 export fn add(a: i32, b: i32): Result<i32> binds addi32;
 export fn sub(a: i32, b: i32): Result<i32> binds subi32;
@@ -149,7 +150,11 @@ export fn print(v: Vec<i64>) binds print_vec;
 export fn print(v: Vec<Result<i64>>) binds print_vec_result;
 export fn map(v: Vec<i64>, m: function): Vec<Result<i64>> binds map_onearg; // TODO: This is terrible
 export fn parmap(v: Vec<i64>, m: function): Vec<Result<i64>> binds parmap_onearg; // TODO: This is terrible
+export fn map(v: Vec<i32>, m: function): Vec<Result<i32>> binds map_onearg; // TODO: This is terrible
+export fn parmap(v: Vec<i32>, m: function): Vec<Result<i32>> binds parmap_onearg; // TODO: This is terrible
 export fn push(v: Vec<i64>, a: i64) binds push;
+export fn length(v: Vec<i64>): i64 binds vec_len;
+export fn length(v: Vec<i32>): i64 binds vec_len;
 
 // GPU-related bindings
 export type GPU binds GPU;


### PR DESCRIPTION
I had to make some modifications to handle very large arrays. Surprisingly the default limit for buffers is just 256MB. I changed it from the default to whatever the limits are for the hardware/OS combo, instead and I got ~2GB per buffer instead. This still meant my 1 billion 32-bit integers buffer was too large, so the benchmark has suffered some complexity.

I think I can use the limits object to bolt on some safety to the API, but the fact that wgpu defaults to `panic!` so much makes me uneasy. But perhaps that is impossible to avoid with GPUs right now?
