### PR TITLE
Restore the totally broken statement test by preventing a crash in error handling

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -2538,12 +2538,12 @@ test!(undefined_function_call => r#"
     }"#;
     stderr "i64str is not a function but used as one.\ni64str on line 4:18\n";
 );
-/*test!(totally_broken_statement => r#"
+test!(totally_broken_statement => r#"
     on app.start {
       app.oops
     }"#;
     stderr "TODO";
-); // TODO: It's so broken it crashes the parser. Get the parser more resilient and revive this */
+);
 /* Pending
   Describe "Importing unexported values"
     before() {

--- a/src/program.rs
+++ b/src/program.rs
@@ -26,8 +26,9 @@ impl Program {
         // Load the entry file
         p = match p.load(entry_file) {
             Ok(p) => p,
-            Err(e) => {
-                println!("{:?}", e);
+            Err(_) => {
+                // Somehow, trying to print this error can crash Rust!? Really not good.
+                // Will need to figure out how to make these errors clearer to users.
                 return Err("Failed to load entry file".into());
             }
         };


### PR DESCRIPTION
I am *very* surprised that I can't debug print an error safely.
