### PR TITLE
Add a 'ctype' concept

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -430,6 +430,8 @@ build!(
         token!("*"),
         token!("^"),
         token!("."),
+        // token!(","), TODO: Enable this after tuples are added to the language and used for
+        // function arguments
         token!("~"),
         token!("`"),
         token!("!"),
@@ -459,10 +461,12 @@ build!(returnn, token!("return"));
 build!(letn, token!("let"));
 build!(constn, token!("const"));
 build!(export, token!("export"));
+build!(ctype, token!("ctype"));
 build!(typen, token!("type"));
 build!(import, token!("import"));
 build!(from, token!("from"));
 build!(fnn, token!("fn"));
+build!(cfn, token!("cfn"));
 build!(binds, token!("binds"));
 build!(quote, token!("'"));
 build!(doublequote, token!("\""));
@@ -780,6 +784,13 @@ test!(types =>
     pass "type Result<T, Error> binds Result<T, Error>";
     pass "type ExitCode binds std::process::ExitCode;";
     pass "type<Windows> Path {\n driveLetter: string, pathsegments: Array<string>, \n}";
+);
+named_and!(ctypes: CTypes =>
+    ctype: String as ctype,
+    a: String as blank,
+    name: String as variable,
+    b: String as optblank,
+    optsemicolon: String as optsemicolon,
 );
 named_or!(constants: Constants =>
     Bool: String as booln,
@@ -1470,6 +1481,7 @@ named_or!(rootelements: RootElements =>
     Whitespace: String as whitespace,
     Exports: Exports as exports,
     Functions: Functions as functions,
+    CTypes: CTypes as ctypes,
     Types: Types as types,
     ConstDeclaration: ConstDeclaration as constdeclaration,
     OperatorMapping: OperatorMapping as operatormapping,

--- a/src/program.rs
+++ b/src/program.rs
@@ -214,7 +214,30 @@ impl Scope {
                     e => println!("TODO: Not yet supported export syntax: {:?}", e),
                 },
                 parse::RootElements::Whitespace(_) => { /* Do nothing */ }
-                _ => println!("TODO: Not yet supported top-level module syntax"),
+                parse::RootElements::Interfaces(_) => {
+                    return Err("Interfaces not yet implemented".into());
+                }
+                parse::RootElements::CTypes(c) => {
+                    // For now this is just declaring in the Alan source code the compile-time
+                    // types that can be used, and is simply a special kind of documentation.
+                    // *Only* the root scope is allowed to use this syntax, and I cannot imagine
+                    // any other way, since the compiler needs to exactly match what is declared.
+                    // So we return an error if they're encountered outside of the root scope and
+                    // simply verify that each `ctype` we encounter is one of a set the compiler
+                    // expects to exist. Later when `cfn` is implemented these will be loaded up
+                    // for verification of the meta-typing of the compile-time functions.
+                    if path == "@root" {
+                        match c.name.as_str() {
+                            "Type" | "Int" | "Float" | "Bool" | "String" => { /* Do nothing */ }
+                            unknown => {
+                                println!("What!? {}", unknown);
+                                return Err(format!("Unknown ctype {} defined in root scope. There's something wrong with the compiler.", unknown).into());
+                            }
+                        }
+                    } else {
+                        return Err("ctypes can only be defined in the compiler internals".into());
+                    }
+                }
             }
         }
         Ok((p, (txt, ast, s)))

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -3,6 +3,15 @@
  * library, or are defined in the sibling root.rs file
  **/
 
+/// Type system setup
+
+// Declaration of the types the compiler-time type system is built on
+ctype Type;
+ctype Int;
+ctype Float;
+ctype Bool;
+ctype String;
+
 /// Integer-related bindings
 
 export type i8 binds i8;
@@ -164,10 +173,12 @@ export fn max(a: Result<i64>, b: Result<i64>): Result<i64> binds maxi64_result;
 export fn max(a: i64, b: Result<i64>): Result<i64> = max(a.ok, b);
 export fn max(a: Result<i64>, b: i64): Result<i64> = max(a, b.ok);
 
-// Boolean related bindings
+/// Boolean related bindings
+
 type bool binds bool;
 
-// Process exit-related bindings
+/// Process exit-related bindings
+
 export type ExitCode binds std::process::ExitCode;
 export fn ExitCode(e: i8): ExitCode binds to_exit_code_i8;
 export fn ExitCode(e: i16): ExitCode = ExitCode(e.i8);
@@ -178,7 +189,8 @@ export fn getOrExit(a: Result<i16>): i16 binds get_or_exit; // TODO: Support rea
 export fn getOrExit(a: Result<i32>): i32 binds get_or_exit; // TODO: Support real generics
 export fn getOrExit(a: Result<i64>): i64 binds get_or_exit; // TODO: Support real generics
 
-// Stdout/stderr-related bindings
+/// Stdout/stderr-related bindings
+
 export type string binds String;
 export fn concat(a: string, b: string): string binds string_concat;
 export fn print(str: string) binds println;
@@ -191,17 +203,20 @@ export fn print(i: Result<i32>) binds println_result;
 export fn print(i: i64) binds println;
 export fn print(i: Result<i64>) binds println_result;
 
-// Thread-related bindings
+/// Thread-related bindings
+
 export fn wait(t: i64) binds wait;
 
-// Time-related bindings
+/// Time-related bindings
+
 export type Instant binds std::time::Instant;
 export fn now(): Instant binds now;
 export type Duration binds std::time::Duration;
 export fn elapsed(i: Instant): Duration binds elapsed;
 export fn print(d: Duration) binds print_duration;
 
-// Vector-related bindings
+/// Vector-related bindings
+
 export type Vec<i64> binds Vec<i64>;
 export type Vec<Result<i64>> binds Vec<Result_i64>;
 export fn filled(i: i64, l: i64): Vec<i64> binds filled;
@@ -216,7 +231,8 @@ export fn push(v: Vec<i64>, a: i64) binds push;
 export fn length(v: Vec<i64>): i64 binds vec_len;
 export fn length(v: Vec<i32>): i64 binds vec_len;
 
-// GPU-related bindings
+/// GPU-related bindings
+
 export type GPU binds GPU;
 export fn GPU(): GPU binds GPU_new;
 export type BufferUsages binds wgpu::BufferUsages;
@@ -240,7 +256,8 @@ export fn GPGPU(source: string, buffer: Buffer): GPGPU binds GPGPU_new_easy;
 export fn run(g: GPU, gg: GPGPU) binds gpu_run;
 export fn read(g: GPU, b: Buffer): Vec<i32> binds read_buffer; // TODO: Support other output types
 
-// Built-in operator definitions
+/// Built-in operator definitions
+
 export infix add as + precedence 2;
 // export infix concat as + precedence 2;
 export infix sub as - precedence 2;


### PR DESCRIPTION
So the new type system has compile-time functions to generate types, or pull in specified files as strings, or etc, and itself has a very limited type system to support it.

I realized that having those types be 100% undocumented in the Alan source code would just be too magical, so I've added a `ctype` syntax to declare them in the root scope to make it clearer where they come from. They can't be created or altered, so the compiler will just be checking that the exact set expected has been specified and that there are no `ctype`s that it doesn't know, which is an immediate compiler error.
