### PR TITLE
Start implementation for representing type operators

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -790,6 +790,8 @@ named_and!(ctypes: CTypes =>
     a: String as blank,
     name: String as variable,
     b: String as optblank,
+    opttypegenerics: Option<TypeGenerics> as opt(typegenerics),
+    c: String as optblank,
     optsemicolon: String as optsemicolon,
 );
 named_or!(constants: Constants =>
@@ -1290,6 +1292,15 @@ named_and!(operatormapping: OperatorMapping =>
     opmap: OpMap as opmap,
     optsemicolon: String as optsemicolon,
 );
+named_and!(typeoperatormapping: TypeOperatorMapping =>
+    typen: String as typen,
+    fix: Fix as fix,
+    a: String as optblank,
+    opttypegenerics: Option<TypeGenerics> as opt(typegenerics),
+    blank: String as optblank,
+    opmap: OpMap as opmap,
+    optsemicolon: String as optsemicolon,
+);
 named_and!(propertytypeline: PropertyTypeline =>
     variable: String as variable,
     a: String as blank,
@@ -1462,8 +1473,10 @@ named_or!(exportable: Exportable =>
     Functions: Functions as functions,
     ConstDeclaration: ConstDeclaration as constdeclaration,
     Types: Types as types,
+    CTypes: CTypes as ctypes,
     Intefaces: Interfaces as interfaces,
     OperatorMapping: OperatorMapping as operatormapping,
+    TypeOperatorMapping: TypeOperatorMapping as typeoperatormapping,
     Ref: String as variable,
 );
 named_and!(exports: Exports =>
@@ -1481,10 +1494,10 @@ named_or!(rootelements: RootElements =>
     Whitespace: String as whitespace,
     Exports: Exports as exports,
     Functions: Functions as functions,
-    CTypes: CTypes as ctypes,
     Types: Types as types,
     ConstDeclaration: ConstDeclaration as constdeclaration,
     OperatorMapping: OperatorMapping as operatormapping,
+    TypeOperatorMapping: TypeOperatorMapping as typeoperatormapping,
     Interfaces: Interfaces as interfaces,
 );
 list!(opt body: RootElements => rootelements);

--- a/src/program.rs
+++ b/src/program.rs
@@ -74,12 +74,10 @@ impl Program {
                 // TODO: Loop over imports looking for the type
                 match self.scopes_by_file.get("@root") {
                     None => None,
-                    Some((_, _, root_scope)) => {
-                        match &root_scope.types.get(typename) {
-                            Some(t) => Some((&t, &root_scope)),
-                            None => None,
-                        }
-                    }
+                    Some((_, _, root_scope)) => match &root_scope.types.get(typename) {
+                        Some(t) => Some((&t, &root_scope)),
+                        None => None,
+                    },
                 }
             }
         }
@@ -144,29 +142,27 @@ impl Program {
                 // TODO: Loop over imports looking for the function
                 match self.scopes_by_file.get("@root") {
                     None => None,
-                    Some((_, _, root_scope)) => {
-                        match root_scope.functions.get(function) {
-                            Some(fs) => {
-                                for f in fs {
-                                    if args.len() != f.args.len() {
-                                        continue;
-                                    }
-                                    let mut args_match = true;
-                                    for (i, arg) in args.iter().enumerate() {
-                                        if &f.args[i].1 != arg {
-                                            args_match = false;
-                                            break;
-                                        }
-                                    }
-                                    if args_match {
-                                        return Some((f, &root_scope));
+                    Some((_, _, root_scope)) => match root_scope.functions.get(function) {
+                        Some(fs) => {
+                            for f in fs {
+                                if args.len() != f.args.len() {
+                                    continue;
+                                }
+                                let mut args_match = true;
+                                for (i, arg) in args.iter().enumerate() {
+                                    if &f.args[i].1 != arg {
+                                        args_match = false;
+                                        break;
                                     }
                                 }
-                                None
+                                if args_match {
+                                    return Some((f, &root_scope));
+                                }
                             }
-                            None => None,
+                            None
                         }
-                    }
+                        None => None,
+                    },
                 }
             }
         }
@@ -245,13 +241,16 @@ impl Scope {
                         // to construct their own types.
                         if path == "@root" {
                             match c.name.as_str() {
-                                "Type" | "Int" | "Float" | "Bool" | "String" | "Function" | "Tuple" | "Label" | "Field" => { /* Do nothing */ }
+                                "Type" | "Int" | "Float" | "Bool" | "String" | "Function"
+                                | "Tuple" | "Label" | "Field" => { /* Do nothing */ }
                                 unknown => {
                                     return Err(format!("Unknown ctype {} defined in root scope. There's something wrong with the compiler.", unknown).into());
                                 }
                             }
                         } else {
-                            return Err("ctypes can only be defined in the compiler internals".into());
+                            return Err(
+                                "ctypes can only be defined in the compiler internals".into()
+                            );
                         }
                     }
                     e => println!("TODO: Not yet supported export syntax: {:?}", e),

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -6,11 +6,19 @@
 /// Type system setup
 
 // Declaration of the types the compiler-time type system is built on
-ctype Type;
-ctype Int;
-ctype Float;
-ctype Bool;
-ctype String;
+export ctype Type;
+export ctype Int;
+export ctype Float;
+export ctype Bool;
+export ctype String;
+export ctype Function<I, O>;
+export ctype Tuple<A, B>;
+export ctype Label;
+export ctype Field<Label, V>; // TODO: Add constraint logic to typegenerics so I can call this `L: Label` instead
+
+export type infix Function as -> precedence 1;
+export type infix Tuple as & precedence 2; // TODO: Switch to `,` after I rewrite the current function generation logic
+export type infix Field as : precedence 3;
 
 /// Integer-related bindings
 


### PR DESCRIPTION
Also in this PR is a fix to the `ctype`s. I realized that they conceptually *need* to be exported to all contexts so that they can be used when creating new types.

And another small bit is fixing a bug where attempting to look up functions and types inside of the root scope can cause the compiler to crash, rather than provide a sane error message. No release would ever have to worry about this, but it does make development more difficult when this crashing causes the test suite to spin forever instead of fail with an error message.
