### PR TITLE
Run all tests on main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
       run: cargo build --verbose
     - if: ${{ github.ref_name == 'main' }}
       name: Run tests
-      run: cargo test --verbose -- --ignored
+      run: cargo test --verbose -- --include-ignored
     - if: ${{ github.ref_name != 'main' }}
       name: Run tests
       run: cargo test --verbose


### PR DESCRIPTION
I realized after actually running the test command on `main` that it's only running the ignored tests, not running all of them, and then realized that I needed a different flag. Tested locally. It *should* work, but I won't know until this is merged.
