### PR TITLE
Switch to an arrow (->) for function type signatures

### DIFF
--- a/benches/bench.ln
+++ b/benches/bench.ln
@@ -1,16 +1,16 @@
 // The benchmark in this directory is based on this file. That version unfortunately includes the
 // time it takes for `filled` to run, so the effective performance of `parmap` is underestimated
-fn double(x: i32): Result<i32> = x * 2.i32();
+fn double(x: i32) -> Result<i32> = x * 2.i32;
 
 fn bench(l: i64) {
-  let v = filled(2.i32(), l);
-  v.length().print();
+  let v = filled(2.i32, l);
+  v.length.print;
   let t1 = now();
   v.map(double);
-  t1.elapsed().print();
+  t1.elapsed.print;
   let t2 = now();
   v.parmap(double);
-  t2.elapsed().print();
+  t2.elapsed.print;
   let t3 = now();
   let g = GPU();
   let b = g.createBuffer(storageBuffer(), v);
@@ -30,20 +30,20 @@ fn bench(l: i64) {
   ", b);
   g.run(plan);
   g.read(b);
-  t3.elapsed().print();
+  t3.elapsed.print;
 }
 
 // Until I have conditionals working, I need to do this kind of tomfoolery
 fn bench_billion {
-  let v = filled(2.i32(), 1000000000);
-  v.length().print();
+  let v = filled(2.i32, 1000000000);
+  v.length.print;
   let t1 = now();
   v.map(double);
-  t1.elapsed().print();
+  t1.elapsed.print;
   let t2 = now();
   v.parmap(double);
-  t2.elapsed().print();
-  let v2 = filled(2.i32(), 500000000);
+  t2.elapsed.print;
+  let v2 = filled(2.i32, 500000000);
   let t3 = now();
   let g = GPU();
   let b = g.createBuffer(storageBuffer(), v2);
@@ -80,7 +80,7 @@ fn bench_billion {
   ", b);
   g.run(plan);
   g.read(b);
-  t3.elapsed().print();
+  t3.elapsed.print;
 }
 
 export fn main {

--- a/benches/map.rs
+++ b/benches/map.rs
@@ -31,75 +31,75 @@ macro_rules! clean {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build!(map_1 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 1).map(double); }
     "#);
     build!(map_10 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 10).map(double); }
     "#);
     build!(map_100 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 100).map(double); }
     "#);
     build!(map_1000 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 1000).map(double); }
     "#);
     build!(map_10000 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 10000).map(double); }
     "#);
     build!(map_100000 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 100000).map(double); }
     "#);
     build!(map_1000000 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 1000000).map(double); }
     "#);
     build!(map_10000000 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 10000000).map(double); }
     "#);
     build!(map_100000000 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 100000000).map(double); }
     "#);
     build!(parmap_1 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 1).parmap(double); }
     "#);
     build!(parmap_10 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 10).parmap(double); }
     "#);
     build!(parmap_100 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 100).parmap(double); }
     "#);
     build!(parmap_1000 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 1000).parmap(double); }
     "#);
     build!(parmap_10000 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 10000).parmap(double); }
     "#);
     build!(parmap_100000 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 100000).parmap(double); }
     "#);
     build!(parmap_1000000 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 1000000).parmap(double); }
     "#);
     build!(parmap_10000000 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 10000000).parmap(double); }
     "#);
     build!(parmap_100000000 => r#"
-        fn double(x: i64): Result<i64> = x * 2;
+        fn double(x: i64) -> Result<i64> = x * 2;
         export fn main { filled(2, 100000000).parmap(double); }
     "#);
     build!(gpgpu_1 => r#"

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -418,17 +418,17 @@ World!
 // Event Tests
 
 test!(normal_exit_code => r#"
-    export fn main(): ExitCode {
+    export fn main() -> ExitCode {
         return ExitCode(0);
     }"#;
     status 0;
 );
 test!(error_exit_code => r#"
-    export fn main(): ExitCode = ExitCode(1);"#;
+    export fn main() -> ExitCode = ExitCode(1);"#;
     status 1;
 );
 test!(non_global_memory_exit_code => r#"
-    export fn main(): ExitCode {
+    export fn main() -> ExitCode {
       let x: i64 = 0;
       return x.ExitCode;
     }"#;
@@ -450,7 +450,7 @@ test_ignore!(passing_ints_from_global_memory => r#"
 
 // This one will replace the hello_world test above once the syntax is updated
 test!(print_function => r#"
-    export fn main(): ExitCode {
+    export fn main() -> ExitCode {
       print('Hello, World');
       return ExitCode(0);
     }"#;
@@ -470,27 +470,27 @@ test!(duration_print => r#"
 // Basic Math Tests
 
 test!(int8_add => r#"
-    export fn main(): ExitCode = ExitCode(getOrExit(add(i8(1), i8(2))));"#;
+    export fn main() -> ExitCode = ExitCode(getOrExit(add(i8(1), i8(2))));"#;
     status 3;
 );
 test!(int8_sub => r#"
-    export fn main(): ExitCode = ExitCode(getOrExit(sub(i8(2), i8(1))));"#;
+    export fn main() -> ExitCode = ExitCode(getOrExit(sub(i8(2), i8(1))));"#;
     status 1;
 );
 test!(int8_mul => r#"
-    export fn main(): ExitCode = ExitCode(getOrExit(mul(i8(2), i8(1))));"#;
+    export fn main() -> ExitCode = ExitCode(getOrExit(mul(i8(2), i8(1))));"#;
     status 2;
 );
 test!(int8_div => r#"
-    export fn main(): ExitCode = ExitCode(getOrExit(div(i8(6), i8(2))));"#;
+    export fn main() -> ExitCode = ExitCode(getOrExit(div(i8(6), i8(2))));"#;
     status 3;
 );
 test!(int8_mod => r#"
-    export fn main(): ExitCode = ExitCode(getOrExit(mod(i8(6), i8(4))));"#;
+    export fn main() -> ExitCode = ExitCode(getOrExit(mod(i8(6), i8(4))));"#;
     status 2;
 );
 test!(int8_pow => r#"
-    export fn main(): ExitCode = ExitCode(getOrExit(pow(i8(6), i8(2))));"#;
+    export fn main() -> ExitCode = ExitCode(getOrExit(pow(i8(6), i8(2))));"#;
     status 36;
 );
 test!(int8_min => r#"
@@ -1271,7 +1271,7 @@ test_ignore!(type_coercion_aliases => r#"
 test!(basic_function_usage => r#"
     fn foo() = print('foo');
 
-    fn bar(s: string): string = s.concat("bar");
+    fn bar(s: string) -> string = s.concat("bar");
 
     export fn main {
       foo();
@@ -1287,11 +1287,11 @@ test_ignore!(functions_and_custom_operators => r#"
       print('foo');
     }
 
-    fn bar(str: string, a: int64, b: int64): string {
+    fn bar(str: string, a: int64, b: int64) -> string {
       return str * a + b.string;
     }
 
-    fn baz(pre: string, body: string): void {
+    fn baz(pre: string, body: string) -> void {
       print(pre + bar(body, 1, 2));
     }
 
@@ -1396,7 +1396,7 @@ test_ignore!(nested_conditionals => r#"
     stdout "1\n2\n3\n";
 );
 test_ignore!(early_return => r#"
-    fn nearOrFar(distance: float64): string {
+    fn nearOrFar(distance: float64) -> string {
       if distance < 5.0 {
         return 'Near!';
       } else {
@@ -1461,14 +1461,14 @@ test!(vec_construction => r#"
     stdout "[5, 5, 5, 5, 5]\n[3, 3, 3]\n";
 );
 test!(vec_map => r#"
-    fn double(x: i64): Result<i64> = x * 2;
+    fn double(x: i64) -> Result<i64> = x * 2;
     export fn main {
       filled(5, 5).map(double).print;
     }"#;
     stdout "[10, 10, 10, 10, 10]\n";
 );
 test!(vec_parmap => r#"
-    fn double(x: i64): Result<i64> = x * 2;
+    fn double(x: i64) -> Result<i64> = x * 2;
     export fn main {
       let v = filled(0, 0);
       v.push(1);
@@ -1665,7 +1665,7 @@ Hello, World!
 test_ignore!(array_map => r#"
     export fn main {
       const count = [1, 2, 3, 4, 5]; // Ah, ah, ahh!
-      const byTwos = count.map(fn (n: int64): Result<int64> = n * 2);
+      const byTwos = count.map(fn (n: int64) -> Result<int64> = n * 2);
       count.map(fn (n: int64) = string(n)).join(', ').print;
       byTwos.map(fn (n: Result<int64>) = string(n)).join(', ').print;
     }"#;
@@ -1674,7 +1674,7 @@ test_ignore!(array_map => r#"
 test_ignore!(array_repeat_and_map_lin => r#"
     export fn main {
       const arr = [1, 2, 3] * 3;
-      const out = arr.mapLin(fn (x: int64): string = x.string).join(', ');
+      const out = arr.mapLin(fn (x: int64) -> string = x.string).join(', ');
       print(out);
     }"#;
     stdout "1, 2, 3, 1, 2, 3, 1, 2, 3\n";
@@ -1682,7 +1682,7 @@ test_ignore!(array_repeat_and_map_lin => r#"
 test_ignore!(array_each_and_find => r#"
     export fn main {
       const test = [ 1, 1, 2, 3, 5, 8 ];
-      test.find(fn (val: int64): bool = val % 2 == 1).getOr(0).print;
+      test.find(fn (val: int64) -> bool = val % 2 == 1).getOr(0).print;
       test.each(fn (val: int64) = print('=' * val));
     }"#;
     stdout r#"1
@@ -1695,7 +1695,7 @@ test_ignore!(array_each_and_find => r#"
 "#;
 );
 test_ignore!(array_every_some_del => r#"
-    fn isOdd (val: int64): bool = val % 2 == 1;
+    fn isOdd (val: int64) -> bool = val % 2 == 1;
 
     export fn main {
       const test = [ 1, 1, 2, 3, 5, 8 ];
@@ -1719,30 +1719,30 @@ test_ignore!(array_reduce_filter_concat => r#"
       const test = [ 1, 1, 2, 3, 5, 8 ];
       const test2 = [ 4, 5, 6 ];
       print('reduce test');
-      test.reduce(fn (a: int, b: int): int = a + b || 0).print;
+      test.reduce(fn (a: int, b: int) -> int = a + b || 0).print;
       test.reduce(min).print;
       test.reduce(max).print;
 
       print('filter test');
-      test.filter(fn (val: int64): bool {
+      test.filter(fn (val: int64) -> bool {
         return val % 2 == 1;
-      }).map(fn (val: int64): string {
+      }).map(fn (val: int64) -> string {
         return string(val);
       }).join(', ').print;
 
       print('concat test');
-      test.concat(test2).map(fn (val: int64): string {
+      test.concat(test2).map(fn (val: int64) -> string {
         return string(val);
       }).join(', ').print;
-      (test + test2).map(fn (val: int64): string {
+      (test + test2).map(fn (val: int64) -> string {
         return string(val);
       }).join(', ').print;
 
       print('reduce as filter and concat test');
       // TODO: Lots of improvements needed for closures passed directly to opcodes. This one-liner is ridiculous
-      test.reduce(fn (acc: string, i: int): string = ((acc == '') && (i % 2 == 1)) ? i.string : (i % 2 == 1 ? (acc + ', ' + i.string) : acc), '').print;
+      test.reduce(fn (acc: string, i: int) -> string = ((acc == '') && (i % 2 == 1)) ? i.string : (i % 2 == 1 ? (acc + ', ' + i.string) : acc), '').print;
       // TODO: Even more ridiculous when you want to allow parallelism
-      test.reducePar(fn (acc: string, i: int): string = ((acc == '') && (i % 2 == 1)) ? i.string : (i % 2 == 1 ? (acc + ', ' + i.string) : acc), fn (acc: string, cur: string): string = ((acc != '') && (cur != '')) ? (acc + ', ' + cur) : (acc != '' ? acc : cur), '').print;
+      test.reducePar(fn (acc: string, i: int) -> string = ((acc == '') && (i % 2 == 1)) ? i.string : (i % 2 == 1 ? (acc + ', ' + i.string) : acc), fn (acc: string, cur: string) -> string = ((acc != '') && (cur != '')) ? (acc + ', ' + cur) : (acc != '' ? acc : cur), '').print;
     }"#;
     stdout r#"reduce test
 20
@@ -1766,12 +1766,12 @@ test_ignore!(array_custom_types => r#"
 
     export fn main {
       const five = [1, 2, 3, 4, 5];
-      five.map(fn (n: int64): Foo {
+      five.map(fn (n: int64) -> Foo {
         return new Foo {
           foo: n.string,
           bar: n % 2 == 0,
         };
-      }).filter(fn (f: Foo): bool = f.bar).map(fn (f: Foo): string = f.foo).join(', ').print;
+      }).filter(fn (f: Foo) -> bool = f.bar).map(fn (f: Foo) -> string = f.foo).join(', ').print;
     }"#;
     stdout "2, 4\n";
 );
@@ -1800,11 +1800,11 @@ test_ignore!(basic_hashmap => r#"
       const test = newHashMap('foo', 1);
       test.set('bar', 2);
       test.set('baz', 99);
-      print(test.keyVal.map(fn (n: KeyVal<string, int64>): string {
+      print(test.keyVal.map(fn (n: KeyVal<string, int64>) -> string {
         return 'key: ' + n.key + \"\\nval: \" + string(n.val);
       }).join(\"\\n\"));
       print(test.keys.join(', '));
-      print(test.vals.map(fn (n: int64): string = n.string).join(', '));
+      print(test.vals.map(fn (n: int64) -> string = n.string).join(', '));
       print(test.length);
       print(test.get('foo'));
     }"#;
@@ -1829,7 +1829,7 @@ test_ignore!(keyval_to_hashmap => r#"
     export fn main {
       const kva = [ kv(1, 'foo'), kv(2, 'bar'), kv(3, 'baz') ];
       const hm = kva.toHashMap;
-      print(hm.keyVal.map(fn (n: KeyVal<int64, string>): string {
+      print(hm.keyVal.map(fn (n: KeyVal<int64, string>) -> string {
         return 'key: ' + string(n.key) + \"\\nval: \" + n.val;
       }).join(\"\\n\"));
       print(hm.get(1));
@@ -1966,7 +1966,7 @@ test_ignore!(invalid_generics => r#"
 
 test_ignore!(basic_interfaces => r#"
     interface Stringifiable {
-      string(Stringifiable): string
+      string(Stringifiable) -> string
     }
 
     fn quoteAndPrint(toQuote: Stringifiable) {
@@ -2024,33 +2024,33 @@ test_ignore!(basic_interfaces => r#"
           timezone: HourMinute
         }
 
-        export fn makeYear(year: int32): Year {
+        export fn makeYear(year: int32) -> Year {
           return new Year {
             year: year
           };
         }
 
-        export fn makeYear(year: int64): Year {
+        export fn makeYear(year: int64) -> Year {
           return new Year {
             year: toInt32(year)
           };
         }
 
-        export fn makeYearMonth(year: int32, month: int8): YearMonth {
+        export fn makeYearMonth(year: int32, month: int8) -> YearMonth {
           return new YearMonth {
             year: year,
             month: month
           };
         }
 
-        export fn makeYearMonth(y: Year, month: int64): YearMonth {
+        export fn makeYearMonth(y: Year, month: int64) -> YearMonth {
           return new YearMonth {
             year: y.year,
             month: toInt8(month),
           };
         }
 
-        export fn makeDate(year: int32, month: int8, day: int8): Date {
+        export fn makeDate(year: int32, month: int8, day: int8) -> Date {
           return new Date {
             year: year,
             month: month,
@@ -2058,7 +2058,7 @@ test_ignore!(basic_interfaces => r#"
           };
         }
 
-        export fn makeDate(ym: YearMonth, day: int64): Date {
+        export fn makeDate(ym: YearMonth, day: int64) -> Date {
           return new Date {
             year: ym.year,
             month: ym.month,
@@ -2066,34 +2066,34 @@ test_ignore!(basic_interfaces => r#"
           };
         }
 
-        export fn makeHour(hour: int8): Hour {
+        export fn makeHour(hour: int8) -> Hour {
           return new Hour {
             hour: hour
           };
         }
 
-        export fn makeHourMinute(hour: int8, minute: int8): HourMinute {
+        export fn makeHourMinute(hour: int8, minute: int8) -> HourMinute {
           return new HourMinute {
             hour: hour,
             minute: minute
           };
         }
 
-        export fn makeHourMinute(hour: int64, minute: int64): HourMinute {
+        export fn makeHourMinute(hour: int64, minute: int64) -> HourMinute {
           return new HourMinute {
             hour: toInt8(hour),
             minute: toInt8(minute)
           };
         }
 
-        export fn makeHourMinute(h: Hour, minute: int8): HourMinute {
+        export fn makeHourMinute(h: Hour, minute: int8) -> HourMinute {
           return new HourMinute {
             hour: h.hour,
             minute: minute
           };
         }
 
-        export fn makeTime(hour: int8, minute: int8, second: float64): Time {
+        export fn makeTime(hour: int8, minute: int8, second: float64) -> Time {
           return new Time {
             hour: hour,
             minute: minute,
@@ -2101,7 +2101,7 @@ test_ignore!(basic_interfaces => r#"
           };
         }
 
-        export fn makeTime(hm: HourMinute, second: float64): Time {
+        export fn makeTime(hm: HourMinute, second: float64) -> Time {
           return new Time {
             hour: hm.hour,
             minute: hm.minute,
@@ -2109,7 +2109,7 @@ test_ignore!(basic_interfaces => r#"
           };
         }
 
-        export fn makeTime(hm: HourMinute, second: int64): Time {
+        export fn makeTime(hm: HourMinute, second: int64) -> Time {
           return new Time {
             hour: hm.hour,
             minute: hm.minute,
@@ -2117,7 +2117,7 @@ test_ignore!(basic_interfaces => r#"
           };
         }
 
-        export fn makeTime(hm: Array<int64>, second: int64): Time {
+        export fn makeTime(hm: Array<int64>, second: int64) -> Time {
           return new Time {
             hour: hm[0].i8,
             minute: hm[1].i8,
@@ -2125,7 +2125,7 @@ test_ignore!(basic_interfaces => r#"
           };
         }
 
-        export fn makeDateTime(date: Date, time: Time, timezone: HourMinute): DateTime {
+        export fn makeDateTime(date: Date, time: Time, timezone: HourMinute) -> DateTime {
           return new DateTime {
             date: date,
             time: time,
@@ -2133,7 +2133,7 @@ test_ignore!(basic_interfaces => r#"
           };
         }
 
-        export fn makeDateTime(date: Date, time: Time): DateTime {
+        export fn makeDateTime(date: Date, time: Time) -> DateTime {
           return new DateTime {
             date: date,
             time: time,
@@ -2141,7 +2141,7 @@ test_ignore!(basic_interfaces => r#"
           };
         }
 
-        export fn makeDateTimeTimezone(dt: DateTime, timezone: HourMinute): DateTime {
+        export fn makeDateTimeTimezone(dt: DateTime, timezone: HourMinute) -> DateTime {
           return new DateTime {
             date: dt.date,
             time: dt.time,
@@ -2149,7 +2149,7 @@ test_ignore!(basic_interfaces => r#"
           };
         }
 
-        export fn makeDateTimeTimezone(dt: DateTime, timezone: Array<int64>): DateTime {
+        export fn makeDateTimeTimezone(dt: DateTime, timezone: Array<int64>) -> DateTime {
           return new DateTime {
             date: dt.date,
             time: dt.time,
@@ -2160,7 +2160,7 @@ test_ignore!(basic_interfaces => r#"
           };
         }
 
-        export fn makeDateTimeTimezoneRev(dt: DateTime, timezone: HourMinute): DateTime {
+        export fn makeDateTimeTimezoneRev(dt: DateTime, timezone: HourMinute) -> DateTime {
           return new DateTime {
             date: dt.date,
             time: dt.time,
@@ -2171,7 +2171,7 @@ test_ignore!(basic_interfaces => r#"
           };
         }
 
-        export fn makeDateTimeTimezoneRev(dt: DateTime, timezone: Array<int64>): DateTime {
+        export fn makeDateTimeTimezoneRev(dt: DateTime, timezone: Array<int64>) -> DateTime {
           return new Datetime {
             date: dt.date,
             time: dt.time,
@@ -2211,7 +2211,7 @@ test_ignore!(basic_interfaces => r#"
           Date @ Time: DateTime,
           DateTime + HourMinute: DateTime,
           DateTime - HourMinute: DateTime,
-          print(DateTime): void,
+          print(DateTime) -> void,
         }
       "
 
@@ -2489,9 +2489,9 @@ test_ignore!(user_types_and_generics => r#"
 // Closures
 
 test_ignore!(closure_creation_and_usage => r#"
-    fn closure(): function {
+    fn closure() -> function {
       let num = 0;
-      return fn (): int64 {
+      return fn () -> int64 {
         num = num + 1 || 0;
         return num;
       };
@@ -2507,7 +2507,7 @@ test_ignore!(closure_creation_and_usage => r#"
     stdout "1\n2\n1\n";
 );
 test_ignore!(closure_by_name => r#"
-    fn double(x: int64): int64 = x * 2 || 0;
+    fn double(x: int64) -> int64 = x * 2 || 0;
 
     export fn main {
       const numbers = [1, 2, 3, 4, 5];
@@ -3196,8 +3196,8 @@ test_ignore!(clone => r#"
       let c = [1, 2, 3];
       let d = c.clone;
       d.set(0, 2);
-      c.map(fn (val: int): string = val.string).join(', ').print;
-      d.map(fn (val: int): string = val.string).join(', ').print;
+      c.map(fn (val: int) -> string = val.string).join(', ').print;
+      d.map(fn (val: int) -> string = val.string).join(', ').print;
     }"#;
     stdout "4\n3\n1, 2, 3\n2, 2, 3\n";
 );
@@ -3302,7 +3302,7 @@ false
 
           // Closure-based remote execution
           let bar = 'bar';
-          const bay = ns.ref('foo').closure(fn (foo: string): int64 {
+          const bay = ns.ref('foo').closure(fn (foo: string) -> int64 {
             bar = 'foobar: ' + foo + bar;
             return foo.length;
           });
@@ -3310,18 +3310,18 @@ false
           print(bar);
 
           // Constrained-closure that only gets the 'with' variable
-          const bax = ns.ref('foo').with(bar).run(fn (foo: string, bar: string): int64 = #foo +. #bar);
+          const bax = ns.ref('foo').with(bar).run(fn (foo: string, bar: string) -> int64 = #foo +. #bar);
           print(bax);
 
           // Mutable closure
-          const baw = ns.mut('foo').run(fn (foo: string): int64 {
+          const baw = ns.mut('foo').run(fn (foo: string) -> int64 {
             foo = foo + 'bar';
             return foo.length;
           });
           print(baw);
 
           // Mutable closure that affects the foo variable
-          const bav = ns.mut('foo').closure(fn (foo: string): int64 {
+          const bav = ns.mut('foo').closure(fn (foo: string) -> int64 {
             foo = foo + 'bar';
             bar = bar * foo.length;
             return bar.length;
@@ -3330,7 +3330,7 @@ false
           print(bar);
 
           // Constrained mutable closure that affects the foo variable
-          const bau = ns.mut('foo').with(bar).run(fn (foo: string, bar: string): int64 {
+          const bau = ns.mut('foo').with(bar).run(fn (foo: string, bar: string) -> int64 {
             foo = foo * #bar;
             return foo.length;
           });
@@ -3426,7 +3426,7 @@ test_ignore!(seq_do_while => r#"
       let s = seq(100);
       let sum = 0;
       // TODO: Get automatic type inference working on anonymous multi-line functions
-      s.doWhile(fn (): bool {
+      s.doWhile(fn () -> bool {
         sum = sum + 1 || 0;
         return sum < 10;
       });
@@ -3438,7 +3438,7 @@ test_ignore!(seq_recurse => r#"
     from @std/seq import seq, Self, recurse
 
     export fn main {
-      print(seq(100).recurse(fn fibonacci(self: Self, i: int64): Result<int64> {
+      print(seq(100).recurse(fn fibonacci(self: Self, i: int64) -> Result<int64> {
         if i < 2 {
           return ok(1);
         } else {
@@ -3507,7 +3507,7 @@ test_ignore!(tree_construction_and_access => r#"
 
       print(myTree.getRootNode || 'wrong');
       print(bayNode.getParent || 'wrong');
-      print(myTree.getChildren.map(fn (c: Node<string>): string = c || 'wrong').join(', '));
+      print(myTree.getChildren.map(fn (c: Node<string>) -> string = c || 'wrong').join(', '));
     }"#;
     stdout "foo\nbar\nbar, baz\n";
 );
@@ -3538,10 +3538,10 @@ test_ignore!(tree_every_find_some_reduce_prune => r#"
       const bazNode = myTree.addChild('baz');
       const bayNode = barNode.addChild('bay');
 
-      print(myTree.every(fn (c: Node<string>): bool = (c || 'wrong').length == 3));
-      print(myTree.some(fn (c: Node<string>): bool = (c || 'wrong').length == 1));
-      print(myTree.find(fn (c: Node<string>): bool = (c || 'wrong') == 'bay').getOr('wrong'));
-      print(myTree.find(fn (c: Node<string>): bool = (c || 'wrong') == 'asf').getOr('wrong'));
+      print(myTree.every(fn (c: Node<string>) -> bool = (c || 'wrong').length == 3));
+      print(myTree.some(fn (c: Node<string>) -> bool = (c || 'wrong').length == 1));
+      print(myTree.find(fn (c: Node<string>) -> bool = (c || 'wrong') == 'bay').getOr('wrong'));
+      print(myTree.find(fn (c: Node<string>) -> bool = (c || 'wrong') == 'asf').getOr('wrong'));
 
       print(myTree.length);
       myTree.getChildren.eachLin(fn (c: Node<string>) {
@@ -3550,10 +3550,10 @@ test_ignore!(tree_every_find_some_reduce_prune => r#"
           c.prune;
         }
       });
-      print(myTree.getChildren.map(fn (c: Node<string>): string = c || 'wrong').join(', '));
+      print(myTree.getChildren.map(fn (c: Node<string>) -> string = c || 'wrong').join(', '));
       print(myTree.length);
 
-      myTree.reduce(fn (acc: int, i: Node<string>): int = (i || 'wrong').length + acc || 0, 0).print;
+      myTree.reduce(fn (acc: int, i: Node<string>) -> int = (i || 'wrong').length + acc || 0, 0).print;
     }"#;
     stdout r#"true
 false

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -348,6 +348,7 @@ build!(
 );
 build!(optwhitespace, zero_or_one!(whitespace));
 build!(colon, token!(":"));
+build!(arrow, token!("->")); // TODO: Temporary to make the syntax closer before being generalized
 build!(under, token!("_"));
 build!(negate, token!("-"));
 build!(dot, token!("."));
@@ -1060,7 +1061,7 @@ named_and!(args: Args =>
     c: String as optwhitespace,
 );
 named_and!(returntype: ReturnType =>
-    colon: String as colon,
+    arrow: String as arrow,
     a: String as optwhitespace,
     fulltypename: FullTypename as fulltypename,
     b: String as optwhitespace,
@@ -1077,7 +1078,7 @@ named_and!(functions: Functions =>
     fullfunctionbody: FullFunctionBody as fullfunctionbody,
 );
 test!(functions =>
-    pass "fn newHashMap(firstKey: Hashable, firstVal: any): HashMap<Hashable, any> { // TODO: Rust-like fn::<typeA, typeB> syntax?\n  let hm = new HashMap<Hashable, any> {\n    keyVal: new Array<KeyVal<Hashable, any>> [],\n    lookup: new Array<Array<int64>> [ new Array<int64> [] ] * 128, // 1KB of space\n  };\n  return hm.set(firstKey, firstVal);\n}" => "";
+    pass "fn newHashMap(firstKey: Hashable, firstVal: any) -> HashMap<Hashable, any> { // TODO: Rust-like fn::<typeA, typeB> syntax?\n  let hm = new HashMap<Hashable, any> {\n    keyVal: new Array<KeyVal<Hashable, any>> [],\n    lookup: new Array<Array<int64>> [ new Array<int64> [] ] * 128, // 1KB of space\n  };\n  return hm.set(firstKey, firstVal);\n}" => "";
     pass "fn foo binds foo;" => "";
     pass "fn print(val: String) binds println!;" => "";
     pass "fn<Test> foo binds foo_test;" => "";
@@ -1345,15 +1346,15 @@ named_and!(functiontype: FunctionType =>
     b: String as optwhitespace,
     closeparen: String as closeparen,
     c: String as optwhitespace,
-    colon: String as colon,
+    arrow: String as arrow,
     d: String as optwhitespace,
     returntype: FullTypename as fulltypename,
 );
 test!(functiontype =>
     fail "()";
-    pass "():void";
-    pass "(Foo): Bar";
-    pass "(Foo, Bar): Baz";
+    pass "() -> void";
+    pass "(Foo) -> Bar";
+    pass "(Foo, Bar) -> Baz";
 );
 named_and!(functiontypeline: FunctionTypeline =>
     variable: String as variable,
@@ -1361,7 +1362,7 @@ named_and!(functiontypeline: FunctionTypeline =>
     functiontype: FunctionType as functiontype,
 );
 test!(functiontypeline =>
-    pass "toString(Stringifiable): string," => ",", super::FunctionTypeline{
+    pass "toString(Stringifiable) -> string," => ",", super::FunctionTypeline{
       variable: "toString".to_string(),
       a: "".to_string(),
       functiontype: super::FunctionType{
@@ -1374,8 +1375,8 @@ test!(functiontypeline =>
         optsep: "".to_string(),
         b: "".to_string(),
         closeparen: ")".to_string(),
-        c: "".to_string(),
-        colon: ":".to_string(),
+        c: " ".to_string(),
+        arrow: "->".to_string(),
         d: " ".to_string(),
         returntype: super::FullTypename{
           typename: "string".to_string(),
@@ -1390,7 +1391,7 @@ named_or!(interfaceline: InterfaceLine =>
     PropertyTypeline: PropertyTypeline as propertytypeline,
 );
 test!(interfaceline =>
-    pass "toString(Stringifiable): string," => ",", super::InterfaceLine::FunctionTypeline(super::FunctionTypeline{
+    pass "toString(Stringifiable) -> string," => ",", super::InterfaceLine::FunctionTypeline(super::FunctionTypeline{
       variable: "toString".to_string(),
       a: "".to_string(),
       functiontype: super::FunctionType{
@@ -1403,8 +1404,8 @@ test!(interfaceline =>
         optsep: "".to_string(),
         b: "".to_string(),
         closeparen: ")".to_string(),
-        c: "".to_string(),
-        colon: ":".to_string(),
+        c: " ".to_string(),
+        arrow: "->".to_string(),
         d: " ".to_string(),
         returntype: super::FullTypename{
           typename: "string".to_string(),
@@ -1415,7 +1416,7 @@ test!(interfaceline =>
 );
 list!(opt interfacelist: InterfaceLine => interfaceline, sep);
 test!(interfacelist =>
-    pass "toString(Stringifiable): string," => ",", vec![super::InterfaceLine::FunctionTypeline(super::FunctionTypeline{
+    pass "toString(Stringifiable) -> string," => ",", vec![super::InterfaceLine::FunctionTypeline(super::FunctionTypeline{
       variable: "toString".to_string(),
       a: "".to_string(),
       functiontype: super::FunctionType{
@@ -1428,8 +1429,8 @@ test!(interfacelist =>
         optsep: "".to_string(),
         b: "".to_string(),
         closeparen: ")".to_string(),
-        c: "".to_string(),
-        colon: ":".to_string(),
+        c: " ".to_string(),
+        arrow: "->".to_string(),
         d: " ".to_string(),
         returntype: super::FullTypename{
           typename: "string".to_string(),
@@ -1467,7 +1468,7 @@ named_and!(interfaces: Interfaces =>
 test!(interfaces =>
     pass "interface any {}";
     pass "interface anythingElse = any";
-    pass "interface Stringifiable {\ntoString(Stringifiable): string,\n}";
+    pass "interface Stringifiable {\ntoString(Stringifiable) -> string,\n}";
 );
 named_or!(exportable: Exportable =>
     Functions: Functions as functions,
@@ -1487,7 +1488,7 @@ named_and!(exports: Exports =>
     exportable: Exportable as exportable,
 );
 test!(exports =>
-    pass "export fn newHashMap(firstKey: Hashable, firstVal: any): HashMap<Hashable, any> { // TODO: Rust-like fn::<typeA, typeB> syntax?\n  let hm = new HashMap<Hashable, any> {\n    keyVal: new Array<KeyVal<Hashable, any>> [],\n    lookup: new Array<Array<int64>> [ new Array<int64> [] ] * 128, // 1KB of space\n  };\n  return hm.set(firstKey, firstVal);\n}" => "";
+    pass "export fn newHashMap(firstKey: Hashable, firstVal: any) -> HashMap<Hashable, any> { // TODO: Rust-like fn::<typeA, typeB> syntax?\n  let hm = new HashMap<Hashable, any> {\n    keyVal: new Array<KeyVal<Hashable, any>> [],\n    lookup: new Array<Array<int64>> [ new Array<int64> [] ] * 128, // 1KB of space\n  };\n  return hm.set(firstKey, firstVal);\n}" => "";
     pass "export<Test> fn main() { let foo = 'bar'; // TODO: Add tests\n }" => "";
 );
 named_or!(rootelements: RootElements =>

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1295,8 +1295,9 @@ named_and!(operatormapping: OperatorMapping =>
 );
 named_and!(typeoperatormapping: TypeOperatorMapping =>
     typen: String as typen,
+    a: String as blank,
     fix: Fix as fix,
-    a: String as optblank,
+    b: String as optblank,
     opttypegenerics: Option<TypeGenerics> as opt(typegenerics),
     blank: String as optblank,
     opmap: OpMap as opmap,

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -24,162 +24,162 @@ export type infix Field as : precedence 3;
 
 export type i8 binds i8;
 export type Result<i8> binds Result_i8;
-export fn ok(i: i8): Result<i8> binds alan_ok;
-export fn getOr(r: Result<i8>, default: i8): i8 binds get_or_i8;
-export fn i8(i: i8): i8 = i;
-export fn i8(i: i16): i8 binds i16toi8;
-export fn i8(i: i32): i8 binds i32toi8;
-export fn i8(i: i64): i8 binds i64toi8;
-export fn add(a: i8, b: i8): Result<i8> binds addi8;
-export fn add(a: Result<i8>, b: Result<i8>): Result<i8> binds addi8_result;
-export fn add(a: i8, b: Result<i8>): Result<i8> = add(a.ok, b);
-export fn add(a: Result<i8>, b: i8): Result<i8> = add(a, b.ok);
-export fn sub(a: i8, b: i8): Result<i8> binds subi8;
-export fn sub(a: Result<i8>, b: Result<i8>): Result<i8> binds subi8_result;
-export fn sub(a: i8, b: Result<i8>): Result<i8> = sub(a.ok, b);
-export fn sub(a: Result<i8>, b: i8): Result<i8> = sub(a, b.ok);
-export fn mul(a: i8, b: i8): Result<i8> binds muli8;
-export fn mul(a: Result<i8>, b: Result<i8>): Result<i8> binds muli8_result;
-export fn mul(a: i8, b: Result<i8>): Result<i8> = mul(a.ok, b);
-export fn mul(a: Result<i8>, b: i8): Result<i8> = mul(a, b.ok);
-export fn div(a: i8, b: i8): Result<i8> binds divi8;
-export fn div(a: Result<i8>, b: Result<i8>): Result<i8> binds divi8_result;
-export fn div(a: i8, b: Result<i8>): Result<i8> = div(a.ok, b);
-export fn div(a: Result<i8>, b: i8): Result<i8> = div(a, b.ok);
-export fn mod(a: i8, b: i8): Result<i8> binds modi8;
-export fn mod(a: Result<i8>, b: Result<i8>): Result<i8> binds modi8_result;
-export fn mod(a: i8, b: Result<i8>): Result<i8> = mod(a.ok, b);
-export fn mod(a: Result<i8>, b: i8): Result<i8> = mod(a, b.ok);
-export fn pow(a: i8, b: i8): Result<i8> binds powi8;
-export fn pow(a: Result<i8>, b: Result<i8>): Result<i8> binds powi8_result;
-export fn pow(a: i8, b: Result<i8>): Result<i8> = pow(a.ok, b);
-export fn pow(a: Result<i8>, b: i8): Result<i8> = pow(a, b.ok);
-export fn min(a: i8, b: i8): i8 binds mini8;
-export fn min(a: Result<i8>, b: Result<i8>): Result<i8> binds mini8_result;
-export fn min(a: i8, b: Result<i8>): Result<i8> = min(a.ok, b);
-export fn min(a: Result<i8>, b: i8): Result<i8> = min(a, b.ok);
-export fn max(a: i8, b: i8): i8 binds maxi8;
-export fn max(a: Result<i8>, b: Result<i8>): Result<i8> binds maxi8_result;
-export fn max(a: i8, b: Result<i8>): Result<i8> = max(a.ok, b);
-export fn max(a: Result<i8>, b: i8): Result<i8> = max(a, b.ok);
+export fn ok(i: i8) -> Result<i8> binds alan_ok;
+export fn getOr(r: Result<i8>, default: i8) -> i8 binds get_or_i8;
+export fn i8(i: i8) -> i8 = i;
+export fn i8(i: i16) -> i8 binds i16toi8;
+export fn i8(i: i32) -> i8 binds i32toi8;
+export fn i8(i: i64) -> i8 binds i64toi8;
+export fn add(a: i8, b: i8) -> Result<i8> binds addi8;
+export fn add(a: Result<i8>, b: Result<i8>) -> Result<i8> binds addi8_result;
+export fn add(a: i8, b: Result<i8>) -> Result<i8> = add(a.ok, b);
+export fn add(a: Result<i8>, b: i8) -> Result<i8> = add(a, b.ok);
+export fn sub(a: i8, b: i8) -> Result<i8> binds subi8;
+export fn sub(a: Result<i8>, b: Result<i8>) -> Result<i8> binds subi8_result;
+export fn sub(a: i8, b: Result<i8>) -> Result<i8> = sub(a.ok, b);
+export fn sub(a: Result<i8>, b: i8) -> Result<i8> = sub(a, b.ok);
+export fn mul(a: i8, b: i8) -> Result<i8> binds muli8;
+export fn mul(a: Result<i8>, b: Result<i8>) -> Result<i8> binds muli8_result;
+export fn mul(a: i8, b: Result<i8>) -> Result<i8> = mul(a.ok, b);
+export fn mul(a: Result<i8>, b: i8) -> Result<i8> = mul(a, b.ok);
+export fn div(a: i8, b: i8) -> Result<i8> binds divi8;
+export fn div(a: Result<i8>, b: Result<i8>) -> Result<i8> binds divi8_result;
+export fn div(a: i8, b: Result<i8>) -> Result<i8> = div(a.ok, b);
+export fn div(a: Result<i8>, b: i8) -> Result<i8> = div(a, b.ok);
+export fn mod(a: i8, b: i8) -> Result<i8> binds modi8;
+export fn mod(a: Result<i8>, b: Result<i8>) -> Result<i8> binds modi8_result;
+export fn mod(a: i8, b: Result<i8>) -> Result<i8> = mod(a.ok, b);
+export fn mod(a: Result<i8>, b: i8) -> Result<i8> = mod(a, b.ok);
+export fn pow(a: i8, b: i8) -> Result<i8> binds powi8;
+export fn pow(a: Result<i8>, b: Result<i8>) -> Result<i8> binds powi8_result;
+export fn pow(a: i8, b: Result<i8>) -> Result<i8> = pow(a.ok, b);
+export fn pow(a: Result<i8>, b: i8) -> Result<i8> = pow(a, b.ok);
+export fn min(a: i8, b: i8) -> i8 binds mini8;
+export fn min(a: Result<i8>, b: Result<i8>) -> Result<i8> binds mini8_result;
+export fn min(a: i8, b: Result<i8>) -> Result<i8> = min(a.ok, b);
+export fn min(a: Result<i8>, b: i8) -> Result<i8> = min(a, b.ok);
+export fn max(a: i8, b: i8) -> i8 binds maxi8;
+export fn max(a: Result<i8>, b: Result<i8>) -> Result<i8> binds maxi8_result;
+export fn max(a: i8, b: Result<i8>) -> Result<i8> = max(a.ok, b);
+export fn max(a: Result<i8>, b: i8) -> Result<i8> = max(a, b.ok);
 
 export type i16 binds i16;
-export fn i16(i: i8): i16 binds i8toi16;
-export fn i16(i: i16): i16 = i;
-export fn i16(i: i32): i32 binds i32toi16;
-export fn i16(i: i64): i16 binds i64toi16;
-export fn add(a: i16, b: i16): Result<i16> binds addi16;
-export fn add(a: Result<i16>, b: Result<i16>): Result<i16> binds addi16_result;
-export fn add(a: i16, b: Result<i16>): Result<i16> = add(a.ok, b);
-export fn add(a: Result<i16>, b: i16): Result<i16> = add(a, b.ok);
-export fn sub(a: i16, b: i16): Result<i16> binds subi16;
-export fn sub(a: Result<i16>, b: Result<i16>): Result<i16> binds subi16_result;
-export fn sub(a: i16, b: Result<i16>): Result<i16> = sub(a.ok, b);
-export fn sub(a: Result<i16>, b: i16): Result<i16> = sub(a, b.ok);
-export fn mul(a: i16, b: i16): Result<i16> binds muli16;
-export fn mul(a: Result<i16>, b: Result<i16>): Result<i16> binds muli16_result;
-export fn mul(a: i16, b: Result<i16>): Result<i16> = mul(a.ok, b);
-export fn mul(a: Result<i16>, b: i16): Result<i16> = mul(a, b.ok);
-export fn div(a: i16, b: i16): Result<i16> binds divi16;
-export fn div(a: Result<i16>, b: Result<i16>): Result<i16> binds divi16_result;
-export fn div(a: i16, b: Result<i16>): Result<i16> = div(a.ok, b);
-export fn div(a: Result<i16>, b: i16): Result<i16> = div(a, b.ok);
-export fn mod(a: i16, b: i16): Result<i16> binds modi16;
-export fn mod(a: Result<i16>, b: Result<i16>): Result<i16> binds modi16_result;
-export fn mod(a: i16, b: Result<i16>): Result<i16> = mod(a.ok, b);
-export fn mod(a: Result<i16>, b: i16): Result<i16> = mod(a, b.ok);
-export fn pow(a: i16, b: i16): Result<i16> binds powi16;
-export fn pow(a: Result<i16>, b: Result<i16>): Result<i16> binds powi16_result;
-export fn pow(a: i16, b: Result<i16>): Result<i16> = pow(a.ok, b);
-export fn pow(a: Result<i16>, b: i16): Result<i16> = pow(a, b.ok);
-export fn min(a: i16, b: i16): i16 binds mini16;
-export fn min(a: Result<i16>, b: Result<i16>): Result<i16> binds mini16_result;
-export fn min(a: i16, b: Result<i16>): Result<i16> = min(a.ok, b);
-export fn min(a: Result<i16>, b: i16): Result<i16> = min(a, b.ok);
-export fn max(a: i16, b: i16): i16 binds maxi16;
-export fn max(a: Result<i16>, b: Result<i16>): Result<i16> binds maxi16_result;
-export fn max(a: i16, b: Result<i16>): Result<i16> = max(a.ok, b);
-export fn max(a: Result<i16>, b: i16): Result<i16> = max(a, b.ok);
+export fn i16(i: i8) -> i16 binds i8toi16;
+export fn i16(i: i16) -> i16 = i;
+export fn i16(i: i32) -> i32 binds i32toi16;
+export fn i16(i: i64) -> i16 binds i64toi16;
+export fn add(a: i16, b: i16) -> Result<i16> binds addi16;
+export fn add(a: Result<i16>, b: Result<i16>) -> Result<i16> binds addi16_result;
+export fn add(a: i16, b: Result<i16>) -> Result<i16> = add(a.ok, b);
+export fn add(a: Result<i16>, b: i16) -> Result<i16> = add(a, b.ok);
+export fn sub(a: i16, b: i16) -> Result<i16> binds subi16;
+export fn sub(a: Result<i16>, b: Result<i16>) -> Result<i16> binds subi16_result;
+export fn sub(a: i16, b: Result<i16>) -> Result<i16> = sub(a.ok, b);
+export fn sub(a: Result<i16>, b: i16) -> Result<i16> = sub(a, b.ok);
+export fn mul(a: i16, b: i16) -> Result<i16> binds muli16;
+export fn mul(a: Result<i16>, b: Result<i16>) -> Result<i16> binds muli16_result;
+export fn mul(a: i16, b: Result<i16>) -> Result<i16> = mul(a.ok, b);
+export fn mul(a: Result<i16>, b: i16) -> Result<i16> = mul(a, b.ok);
+export fn div(a: i16, b: i16) -> Result<i16> binds divi16;
+export fn div(a: Result<i16>, b: Result<i16>) -> Result<i16> binds divi16_result;
+export fn div(a: i16, b: Result<i16>) -> Result<i16> = div(a.ok, b);
+export fn div(a: Result<i16>, b: i16) -> Result<i16> = div(a, b.ok);
+export fn mod(a: i16, b: i16) -> Result<i16> binds modi16;
+export fn mod(a: Result<i16>, b: Result<i16>) -> Result<i16> binds modi16_result;
+export fn mod(a: i16, b: Result<i16>) -> Result<i16> = mod(a.ok, b);
+export fn mod(a: Result<i16>, b: i16) -> Result<i16> = mod(a, b.ok);
+export fn pow(a: i16, b: i16) -> Result<i16> binds powi16;
+export fn pow(a: Result<i16>, b: Result<i16>) -> Result<i16> binds powi16_result;
+export fn pow(a: i16, b: Result<i16>) -> Result<i16> = pow(a.ok, b);
+export fn pow(a: Result<i16>, b: i16) -> Result<i16> = pow(a, b.ok);
+export fn min(a: i16, b: i16) -> i16 binds mini16;
+export fn min(a: Result<i16>, b: Result<i16>) -> Result<i16> binds mini16_result;
+export fn min(a: i16, b: Result<i16>) -> Result<i16> = min(a.ok, b);
+export fn min(a: Result<i16>, b: i16) -> Result<i16> = min(a, b.ok);
+export fn max(a: i16, b: i16) -> i16 binds maxi16;
+export fn max(a: Result<i16>, b: Result<i16>) -> Result<i16> binds maxi16_result;
+export fn max(a: i16, b: Result<i16>) -> Result<i16> = max(a.ok, b);
+export fn max(a: Result<i16>, b: i16) -> Result<i16> = max(a, b.ok);
 
 export type i32 binds i32;
 export type Result<i32> binds Result_i32;
-export fn i32(i: i8): i32 binds i8toi32;
-export fn i32(i: i16): i32 binds i16toi32;
-export fn i32(i: i32): i32 = i;
-export fn i32(i: i64): i32 binds i64toi32;
-export fn add(a: i32, b: i32): Result<i32> binds addi32;
-export fn add(a: Result<i32>, b: Result<i32>): Result<i32> binds addi32_result;
-export fn add(a: i32, b: Result<i32>): Result<i32> = add(a.ok, b);
-export fn add(a: Result<i32>, b: i32): Result<i32> = add(a, b.ok);
-export fn sub(a: i32, b: i32): Result<i32> binds subi32;
-export fn sub(a: Result<i32>, b: Result<i32>): Result<i32> binds subi32_result;
-export fn sub(a: i32, b: Result<i32>): Result<i32> = sub(a.ok, b);
-export fn sub(a: Result<i32>, b: i32): Result<i32> = sub(a, b.ok);
-export fn mul(a: i32, b: i32): Result<i32> binds muli32;
-export fn mul(a: Result<i32>, b: Result<i32>): Result<i32> binds muli32_result;
-export fn mul(a: i32, b: Result<i32>): Result<i32> = mul(a.ok, b);
-export fn mul(a: Result<i32>, b: i32): Result<i32> = mul(a, b.ok);
-export fn div(a: i32, b: i32): Result<i32> binds divi32;
-export fn div(a: Result<i32>, b: Result<i32>): Result<i32> binds divi32_result;
-export fn div(a: i32, b: Result<i32>): Result<i32> = div(a.ok, b);
-export fn div(a: Result<i32>, b: i32): Result<i32> = div(a, b.ok);
-export fn mod(a: i32, b: i32): Result<i32> binds modi32;
-export fn mod(a: Result<i32>, b: Result<i32>): Result<i32> binds modi32_result;
-export fn mod(a: i32, b: Result<i32>): Result<i32> = mod(a.ok, b);
-export fn mod(a: Result<i32>, b: i32): Result<i32> = mod(a, b.ok);
-export fn pow(a: i32, b: i32): Result<i32> binds powi32;
-export fn pow(a: Result<i32>, b: Result<i32>): Result<i32> binds powi32_result;
-export fn pow(a: i32, b: Result<i32>): Result<i32> = pow(a.ok, b);
-export fn pow(a: Result<i32>, b: i32): Result<i32> = pow(a, b.ok);
-export fn min(a: i32, b: i32): i32 binds mini32;
-export fn min(a: Result<i32>, b: Result<i32>): Result<i32> binds mini32_result;
-export fn min(a: i32, b: Result<i32>): Result<i32> = min(a.ok, b);
-export fn min(a: Result<i32>, b: i32): Result<i32> = min(a, b.ok);
-export fn max(a: i32, b: i32): i32 binds maxi32;
-export fn max(a: Result<i32>, b: Result<i32>): Result<i32> binds maxi32_result;
-export fn max(a: i32, b: Result<i32>): Result<i32> = max(a.ok, b);
-export fn max(a: Result<i32>, b: i32): Result<i32> = max(a, b.ok);
+export fn i32(i: i8) -> i32 binds i8toi32;
+export fn i32(i: i16) -> i32 binds i16toi32;
+export fn i32(i: i32) -> i32 = i;
+export fn i32(i: i64) -> i32 binds i64toi32;
+export fn add(a: i32, b: i32) -> Result<i32> binds addi32;
+export fn add(a: Result<i32>, b: Result<i32>) -> Result<i32> binds addi32_result;
+export fn add(a: i32, b: Result<i32>) -> Result<i32> = add(a.ok, b);
+export fn add(a: Result<i32>, b: i32) -> Result<i32> = add(a, b.ok);
+export fn sub(a: i32, b: i32) -> Result<i32> binds subi32;
+export fn sub(a: Result<i32>, b: Result<i32>) -> Result<i32> binds subi32_result;
+export fn sub(a: i32, b: Result<i32>) -> Result<i32> = sub(a.ok, b);
+export fn sub(a: Result<i32>, b: i32) -> Result<i32> = sub(a, b.ok);
+export fn mul(a: i32, b: i32) -> Result<i32> binds muli32;
+export fn mul(a: Result<i32>, b: Result<i32>) -> Result<i32> binds muli32_result;
+export fn mul(a: i32, b: Result<i32>) -> Result<i32> = mul(a.ok, b);
+export fn mul(a: Result<i32>, b: i32) -> Result<i32> = mul(a, b.ok);
+export fn div(a: i32, b: i32) -> Result<i32> binds divi32;
+export fn div(a: Result<i32>, b: Result<i32>) -> Result<i32> binds divi32_result;
+export fn div(a: i32, b: Result<i32>) -> Result<i32> = div(a.ok, b);
+export fn div(a: Result<i32>, b: i32) -> Result<i32> = div(a, b.ok);
+export fn mod(a: i32, b: i32) -> Result<i32> binds modi32;
+export fn mod(a: Result<i32>, b: Result<i32>) -> Result<i32> binds modi32_result;
+export fn mod(a: i32, b: Result<i32>) -> Result<i32> = mod(a.ok, b);
+export fn mod(a: Result<i32>, b: i32) -> Result<i32> = mod(a, b.ok);
+export fn pow(a: i32, b: i32) -> Result<i32> binds powi32;
+export fn pow(a: Result<i32>, b: Result<i32>) -> Result<i32> binds powi32_result;
+export fn pow(a: i32, b: Result<i32>) -> Result<i32> = pow(a.ok, b);
+export fn pow(a: Result<i32>, b: i32) -> Result<i32> = pow(a, b.ok);
+export fn min(a: i32, b: i32) -> i32 binds mini32;
+export fn min(a: Result<i32>, b: Result<i32>) -> Result<i32> binds mini32_result;
+export fn min(a: i32, b: Result<i32>) -> Result<i32> = min(a.ok, b);
+export fn min(a: Result<i32>, b: i32) -> Result<i32> = min(a, b.ok);
+export fn max(a: i32, b: i32) -> i32 binds maxi32;
+export fn max(a: Result<i32>, b: Result<i32>) -> Result<i32> binds maxi32_result;
+export fn max(a: i32, b: Result<i32>) -> Result<i32> = max(a.ok, b);
+export fn max(a: Result<i32>, b: i32) -> Result<i32> = max(a, b.ok);
 
 export type i64 binds i64;
 export type Result<i64> binds Result_i64;
-export fn ok(i: i64): Result<i64> binds alan_ok;
-export fn getOr(r: Result<i64>, default: i64): i64 binds get_or_i64;
-export fn i64(i: i8): i64 binds i8toi64;
-export fn i64(i: i16): i64 binds i16toi64;
-export fn i64(i: i32): i64 binds i32toi64;
-export fn i64(i: i64): i64 = i;
-export fn add(a: i64, b: i64): Result<i64> binds addi64;
-export fn add(a: Result<i64>, b: Result<i64>): Result<i64> binds addi64_result;
-export fn add(a: i64, b: Result<i64>): Result<i64> = add(a.ok, b);
-export fn add(a: Result<i64>, b: i64): Result<i64> = add(a, b.ok);
-export fn sub(a: i64, b: i64): Result<i64> binds subi64;
-export fn sub(a: Result<i64>, b: Result<i64>): Result<i64> binds subi64_result;
-export fn sub(a: i64, b: Result<i64>): Result<i64> = sub(a.ok, b);
-export fn sub(a: Result<i64>, b: i64): Result<i64> = sub(a, b.ok);
-export fn mul(a: i64, b: i64): Result<i64> binds muli64;
-export fn mul(a: Result<i64>, b: Result<i64>): Result<i64> binds muli64_result;
-export fn mul(a: i64, b: Result<i64>): Result<i64> = mul(a.ok, b);
-export fn mul(a: Result<i64>, b: i64): Result<i64> = mul(a, b.ok);
-export fn div(a: i64, b: i64): Result<i64> binds divi64;
-export fn div(a: Result<i64>, b: Result<i64>): Result<i64> binds divi64_result;
-export fn div(a: i64, b: Result<i64>): Result<i64> = div(a.ok, b);
-export fn div(a: Result<i64>, b: i64): Result<i64> = div(a, b.ok);
-export fn mod(a: i64, b: i64): Result<i64> binds modi64;
-export fn mod(a: Result<i64>, b: Result<i64>): Result<i64> binds modi64_result;
-export fn mod(a: i64, b: Result<i64>): Result<i64> = mod(a.ok, b);
-export fn mod(a: Result<i64>, b: i64): Result<i64> = mod(a, b.ok);
-export fn pow(a: i64, b: i64): Result<i64> binds powi64;
-export fn pow(a: Result<i64>, b: Result<i64>): Result<i64> binds powi64_result;
-export fn pow(a: i64, b: Result<i64>): Result<i64> = pow(a.ok, b);
-export fn pow(a: Result<i64>, b: i64): Result<i64> = pow(a, b.ok);
-export fn min(a: i64, b: i64): i64 binds mini64;
-export fn min(a: Result<i64>, b: Result<i64>): Result<i64> binds mini64_result;
-export fn min(a: i64, b: Result<i64>): Result<i64> = min(a.ok, b);
-export fn min(a: Result<i64>, b: i64): Result<i64> = min(a, b.ok);
-export fn max(a: i64, b: i64): i64 binds maxi64;
-export fn max(a: Result<i64>, b: Result<i64>): Result<i64> binds maxi64_result;
-export fn max(a: i64, b: Result<i64>): Result<i64> = max(a.ok, b);
-export fn max(a: Result<i64>, b: i64): Result<i64> = max(a, b.ok);
+export fn ok(i: i64) -> Result<i64> binds alan_ok;
+export fn getOr(r: Result<i64>, default: i64) -> i64 binds get_or_i64;
+export fn i64(i: i8) -> i64 binds i8toi64;
+export fn i64(i: i16) -> i64 binds i16toi64;
+export fn i64(i: i32) -> i64 binds i32toi64;
+export fn i64(i: i64) -> i64 = i;
+export fn add(a: i64, b: i64) -> Result<i64> binds addi64;
+export fn add(a: Result<i64>, b: Result<i64>) -> Result<i64> binds addi64_result;
+export fn add(a: i64, b: Result<i64>) -> Result<i64> = add(a.ok, b);
+export fn add(a: Result<i64>, b: i64) -> Result<i64> = add(a, b.ok);
+export fn sub(a: i64, b: i64) -> Result<i64> binds subi64;
+export fn sub(a: Result<i64>, b: Result<i64>) -> Result<i64> binds subi64_result;
+export fn sub(a: i64, b: Result<i64>) -> Result<i64> = sub(a.ok, b);
+export fn sub(a: Result<i64>, b: i64) -> Result<i64> = sub(a, b.ok);
+export fn mul(a: i64, b: i64) -> Result<i64> binds muli64;
+export fn mul(a: Result<i64>, b: Result<i64>) -> Result<i64> binds muli64_result;
+export fn mul(a: i64, b: Result<i64>) -> Result<i64> = mul(a.ok, b);
+export fn mul(a: Result<i64>, b: i64) -> Result<i64> = mul(a, b.ok);
+export fn div(a: i64, b: i64) -> Result<i64> binds divi64;
+export fn div(a: Result<i64>, b: Result<i64>) -> Result<i64> binds divi64_result;
+export fn div(a: i64, b: Result<i64>) -> Result<i64> = div(a.ok, b);
+export fn div(a: Result<i64>, b: i64) -> Result<i64> = div(a, b.ok);
+export fn mod(a: i64, b: i64) -> Result<i64> binds modi64;
+export fn mod(a: Result<i64>, b: Result<i64>) -> Result<i64> binds modi64_result;
+export fn mod(a: i64, b: Result<i64>) -> Result<i64> = mod(a.ok, b);
+export fn mod(a: Result<i64>, b: i64) -> Result<i64> = mod(a, b.ok);
+export fn pow(a: i64, b: i64) -> Result<i64> binds powi64;
+export fn pow(a: Result<i64>, b: Result<i64>) -> Result<i64> binds powi64_result;
+export fn pow(a: i64, b: Result<i64>) -> Result<i64> = pow(a.ok, b);
+export fn pow(a: Result<i64>, b: i64) -> Result<i64> = pow(a, b.ok);
+export fn min(a: i64, b: i64) -> i64 binds mini64;
+export fn min(a: Result<i64>, b: Result<i64>) -> Result<i64> binds mini64_result;
+export fn min(a: i64, b: Result<i64>) -> Result<i64> = min(a.ok, b);
+export fn min(a: Result<i64>, b: i64) -> Result<i64> = min(a, b.ok);
+export fn max(a: i64, b: i64) -> i64 binds maxi64;
+export fn max(a: Result<i64>, b: Result<i64>) -> Result<i64> binds maxi64_result;
+export fn max(a: i64, b: Result<i64>) -> Result<i64> = max(a.ok, b);
+export fn max(a: Result<i64>, b: i64) -> Result<i64> = max(a, b.ok);
 
 /// Boolean related bindings
 
@@ -188,19 +188,19 @@ type bool binds bool;
 /// Process exit-related bindings
 
 export type ExitCode binds std::process::ExitCode;
-export fn ExitCode(e: i8): ExitCode binds to_exit_code_i8;
-export fn ExitCode(e: i16): ExitCode = ExitCode(e.i8);
-export fn ExitCode(e: i32): ExitCode = ExitCode(e.i8);
-export fn ExitCode(e: i64): ExitCode = ExitCode(e.i8);
-export fn getOrExit(a: Result<i8>): i8 binds get_or_exit; // TODO: Support real generics
-export fn getOrExit(a: Result<i16>): i16 binds get_or_exit; // TODO: Support real generics
-export fn getOrExit(a: Result<i32>): i32 binds get_or_exit; // TODO: Support real generics
-export fn getOrExit(a: Result<i64>): i64 binds get_or_exit; // TODO: Support real generics
+export fn ExitCode(e: i8) -> ExitCode binds to_exit_code_i8;
+export fn ExitCode(e: i16) -> ExitCode = ExitCode(e.i8);
+export fn ExitCode(e: i32) -> ExitCode = ExitCode(e.i8);
+export fn ExitCode(e: i64) -> ExitCode = ExitCode(e.i8);
+export fn getOrExit(a: Result<i8>) -> i8 binds get_or_exit; // TODO: Support real generics
+export fn getOrExit(a: Result<i16>) -> i16 binds get_or_exit; // TODO: Support real generics
+export fn getOrExit(a: Result<i32>) -> i32 binds get_or_exit; // TODO: Support real generics
+export fn getOrExit(a: Result<i64>) -> i64 binds get_or_exit; // TODO: Support real generics
 
 /// Stdout/stderr-related bindings
 
 export type string binds String;
-export fn concat(a: string, b: string): string binds string_concat;
+export fn concat(a: string, b: string) -> string binds string_concat;
 export fn print(str: string) binds println;
 export fn print(b: bool) binds println;
 export fn print(i: i8) binds println;
@@ -218,51 +218,51 @@ export fn wait(t: i64) binds wait;
 /// Time-related bindings
 
 export type Instant binds std::time::Instant;
-export fn now(): Instant binds now;
+export fn now() -> Instant binds now;
 export type Duration binds std::time::Duration;
-export fn elapsed(i: Instant): Duration binds elapsed;
+export fn elapsed(i: Instant) -> Duration binds elapsed;
 export fn print(d: Duration) binds print_duration;
 
 /// Vector-related bindings
 
 export type Vec<i64> binds Vec<i64>;
 export type Vec<Result<i64>> binds Vec<Result_i64>;
-export fn filled(i: i64, l: i64): Vec<i64> binds filled;
-export fn filled(r: Result<i64>, l: i64): Vec<Result<i64>> binds filled;
+export fn filled(i: i64, l: i64) -> Vec<i64> binds filled;
+export fn filled(r: Result<i64>, l: i64) -> Vec<Result<i64>> binds filled;
 export fn print(v: Vec<i64>) binds print_vec;
 export fn print(v: Vec<Result<i64>>) binds print_vec_result;
-export fn map(v: Vec<i64>, m: function): Vec<Result<i64>> binds map_onearg; // TODO: This is terrible
-export fn parmap(v: Vec<i64>, m: function): Vec<Result<i64>> binds parmap_onearg; // TODO: This is terrible
-export fn map(v: Vec<i32>, m: function): Vec<Result<i32>> binds map_onearg; // TODO: This is terrible
-export fn parmap(v: Vec<i32>, m: function): Vec<Result<i32>> binds parmap_onearg; // TODO: This is terrible
+export fn map(v: Vec<i64>, m: function) -> Vec<Result<i64>> binds map_onearg; // TODO: This is terrible
+export fn parmap(v: Vec<i64>, m: function) -> Vec<Result<i64>> binds parmap_onearg; // TODO: This is terrible
+export fn map(v: Vec<i32>, m: function) -> Vec<Result<i32>> binds map_onearg; // TODO: This is terrible
+export fn parmap(v: Vec<i32>, m: function) -> Vec<Result<i32>> binds parmap_onearg; // TODO: This is terrible
 export fn push(v: Vec<i64>, a: i64) binds push;
-export fn length(v: Vec<i64>): i64 binds vec_len;
-export fn length(v: Vec<i32>): i64 binds vec_len;
+export fn length(v: Vec<i64>) -> i64 binds vec_len;
+export fn length(v: Vec<i32>) -> i64 binds vec_len;
 
 /// GPU-related bindings
 
 export type GPU binds GPU;
-export fn GPU(): GPU binds GPU_new;
+export fn GPU() -> GPU binds GPU_new;
 export type BufferUsages binds wgpu::BufferUsages;
 export type Vec<i32> binds Vec<i32>;
 export type Buffer binds wgpu::Buffer;
 export type Vec<Buffer> binds Vec_Buffer;
 export type Vec<Vec<Buffer>> binds Vec_Vec_Buffer;
-export fn newVecBuffer(): Vec<Buffer> binds Vec_Buffer_new;
-export fn newVecVecBuffer(): Vec<Vec<Buffer>> binds Vec_Vec_Buffer_new;
+export fn newVecBuffer() -> Vec<Buffer> binds Vec_Buffer_new;
+export fn newVecVecBuffer() -> Vec<Vec<Buffer>> binds Vec_Vec_Buffer_new;
 export fn push(v: Vec<Buffer>, a: Buffer) binds push;
 export fn push(v: Vec<Vec<Buffer>>, a: Vec<Buffer>) binds push;
-export fn filled(i: i32, l: i64): Vec<i32> binds filled;
+export fn filled(i: i32, l: i64) -> Vec<i32> binds filled;
 export fn print(v: Vec<i32>) binds print_vec;
-export fn createBuffer(g: GPU, usage: BufferUsages, vals: Vec<i32>): Buffer binds create_buffer_init;
-export fn createBuffer(g: GPU, usage: BufferUsages, size: i64): Buffer binds create_empty_buffer;
-export fn mapReadBuffer(): BufferUsages binds map_read_buffer_type;
-export fn storageBuffer(): BufferUsages binds storage_buffer_type;
+export fn createBuffer(g: GPU, usage: BufferUsages, vals: Vec<i32>) -> Buffer binds create_buffer_init;
+export fn createBuffer(g: GPU, usage: BufferUsages, size: i64) -> Buffer binds create_empty_buffer;
+export fn mapReadBuffer() -> BufferUsages binds map_read_buffer_type;
+export fn storageBuffer() -> BufferUsages binds storage_buffer_type;
 export type GPGPU binds GPGPU;
-export fn GPGPU(source: string, buffers: Vec<Vec<Buffer>>): GPGPU binds GPGPU_new;
-export fn GPGPU(source: string, buffer: Buffer): GPGPU binds GPGPU_new_easy;
+export fn GPGPU(source: string, buffers: Vec<Vec<Buffer>>) -> GPGPU binds GPGPU_new;
+export fn GPGPU(source: string, buffer: Buffer) -> GPGPU binds GPGPU_new_easy;
 export fn run(g: GPU, gg: GPGPU) binds gpu_run;
-export fn read(g: GPU, b: Buffer): Vec<i32> binds read_buffer; // TODO: Support other output types
+export fn read(g: GPU, b: Buffer) -> Vec<i32> binds read_buffer; // TODO: Support other output types
 
 /// Built-in operator definitions
 


### PR DESCRIPTION
This doesn't refactor how the source code parsing is done, but just changes the current parsing to use an arrow (`->`) for the return type to match what the future syntax will look like.

In the future, instead of having special logic in the parser for not including a return type, it will just be a type provided to the next stage of the compiler and if it isn't a `Function` type, then it'll be assumed that the type is the argument(s) and it needs to infer the return type. Anyways, just part of the refactoring work to get from here to the plan in the RFC.
