### PR TITLE
Small PR to add the Either type as a built-in type

### DIFF
--- a/src/program.rs
+++ b/src/program.rs
@@ -242,7 +242,7 @@ impl Scope {
                         if path == "@root" {
                             match c.name.as_str() {
                                 "Type" | "Int" | "Float" | "Bool" | "String" | "Function"
-                                | "Tuple" | "Label" | "Field" => { /* Do nothing */ }
+                                | "Tuple" | "Label" | "Field" | "Either" => { /* Do nothing */ }
                                 unknown => {
                                     return Err(format!("Unknown ctype {} defined in root scope. There's something wrong with the compiler.", unknown).into());
                                 }

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -15,10 +15,12 @@ export ctype Function<I, O>;
 export ctype Tuple<A, B>;
 export ctype Label;
 export ctype Field<Label, V>; // TODO: Add constraint logic to typegenerics so I can call this `L: Label` instead
+export ctype Either<A, B>;
 
 export type infix Function as -> precedence 1;
 export type infix Tuple as , precedence 2;
 export type infix Field as : precedence 3;
+export type infix Either as | precedence 1;
 
 /// Integer-related bindings
 


### PR DESCRIPTION
I do need to actually implement the `ctype`s in the compiler, but I'm a bit fried right now, so just putting up a missing integral type.

I'm also thinking that in that implementation I might eliminate the `binds` feature for types and port them all to `ctype`s for a stronger foundation for the type system, but I'm not entirely sure. It could still be useful to bind in native Rust types for third party libraries.
