### PR TITLE
Simplify type definition to just type assignment, no 'structlike' syntax

### DIFF
--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -7,7 +7,7 @@ pub fn generate(
     typen: &Type,
     _scope: &Scope,
     _program: &Program,
-    mut out: OrderedHashMap<String, String>,
+    out: OrderedHashMap<String, String>,
 ) -> Result<(String, OrderedHashMap<String, String>), Box<dyn std::error::Error>> {
     match &typen.typetype {
         // The first value is the identifier, and the second is the generated source. For the
@@ -16,37 +16,8 @@ pub fn generate(
         // output, while the `Structlike` type requires a new struct to be created and inserted
         // into the source definition, potentially inserting inner types as needed
         TypeType::Bind(s) => Ok((s.clone(), out)),
-        TypeType::Alias(a) => Ok((a.to_string(), out)),
-        TypeType::Structlike(_s) => {
-            let mut typestring = format!(
-                r#"#[derive(Debug)]
-struct {} {{
-"#,
-                typen.typename.to_string()
-            );
-            // TODO: Redo all of this to use the built-in function types concept
-            /*for typeline in &s.typelist {
-                        let typename = typeline.fulltypename.to_string();
-                        let (subtypen, subtypescope) = match program.resolve_type(scope, &typename) {
-                            None => Err(format!("Type {} not found", typename)),
-                            Some((t, s)) => Ok((t, s)),
-                        }?;
-                        let res = generate(subtypen, subtypescope, program, out)?;
-                        let subtypename = res.0;
-                        out = res.1;
-                        typestring = format!(
-                            r#"{}
-            pub {}: {},"#,
-                            typestring, typeline.variable, subtypename
-                        );
-                    }*/
-            typestring = format!(
-                r#"{}
-}}"#,
-                typestring
-            );
-            out.insert(typen.typename.to_string(), typestring.to_string());
-            Ok((typen.typename.to_string(), out))
-        }
+        // TODO: The "alias" type is just the normal type assignment path, now, no distinction so
+        // this needs to be more capable going forward
+        TypeType::Create(a) => Ok((a.to_string(), out)),
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -816,12 +816,6 @@ test!(typeassignables =>
     pass "(firstKey: Hashable, firstVal: any) -> HashMap<Hashable, any>";
     pass "() -> void";
 );
-list!(typecalllist: Vec<WithTypeOperators> => typeassignables, sep);
-test!(typecalllist =>
-    pass "(foo: Foo) -> Bar";
-    pass "T";
-    pass "T, U";
-);
 named_and!(gncall: GnCall =>
     opencaret: String as opencaret,
     a: String as optwhitespace,
@@ -904,20 +898,10 @@ test!(typebaselist =>
         }),
     ];
 );
-named_and!(typebody: TypeBody =>
-    a: String as opencurly,
-    b: String as optwhitespace,
-    typecalllist: Vec<Vec<WithTypeOperators>> as typecalllist,
-    d: String as optwhitespace,
-    e: String as closecurly,
-);
-test!(typebody =>
-    pass "{\n  arr: Array<T>,\n  initial: U,\n}";
-);
-named_and!(typealias: TypeAlias =>
+named_and!(typecreate: TypeCreate =>
     a: String as eq,
     b: String as blank,
-    fulltypename: FullTypename as fulltypename,
+    typeassignables: Vec<WithTypeOperators> as typeassignables,
 );
 list!(rustpath: String => variable, token!("::"));
 named_and!(typebind: TypeBind =>
@@ -927,8 +911,7 @@ named_and!(typebind: TypeBind =>
     opttypegenerics: Option<TypeGenerics> as opt(typegenerics)
 );
 named_or!(typedef: TypeDef =>
-    TypeBody: TypeBody as typebody,
-    TypeAlias: TypeAlias as typealias,
+    TypeCreate: TypeCreate as typecreate,
     TypeBind: TypeBind as typebind,
 );
 named_and!(types: Types =>
@@ -942,11 +925,11 @@ named_and!(types: Types =>
     optsemicolon: String as optsemicolon,
 );
 test!(types =>
-    pass "type Foo {\n  bar: string,\n}";
+    pass "type Foo = bar: string;";
     pass "type Foo = Bar";
     pass "type Result<T, Error> binds Result<T, Error>";
     pass "type ExitCode binds std::process::ExitCode;";
-    pass "type<Windows> Path {\n driveLetter: string, pathsegments: Array<string>, \n}";
+    pass "type<Windows> Path = driveLetter: string, pathsegments: Array<string>;";
 );
 named_and!(ctypes: CTypes =>
     ctype: String as ctype,

--- a/src/program.rs
+++ b/src/program.rs
@@ -367,7 +367,14 @@ impl Type {
         let t = Type {
             typename: type_ast.fulltypename.clone(),
             typetype: match &type_ast.typedef {
-                parse::TypeDef::TypeCreate(create) => TypeType::Create(create.typeassignables.iter().map(|ta| ta.to_string()).collect::<Vec<String>>().join("")), // TODO: Redo this
+                parse::TypeDef::TypeCreate(create) => TypeType::Create(
+                    create
+                        .typeassignables
+                        .iter()
+                        .map(|ta| ta.to_string())
+                        .collect::<Vec<String>>()
+                        .join(""),
+                ), // TODO: Redo this
                 parse::TypeDef::TypeBind(bind) => TypeType::Bind(
                     format!(
                         "{}{}",

--- a/src/program.rs
+++ b/src/program.rs
@@ -347,8 +347,7 @@ impl Import {
 
 #[derive(Debug)]
 pub enum TypeType {
-    Structlike(parse::TypeBody),
-    Alias(parse::FullTypename),
+    Create(String), // TODO: Redo this entirely
     Bind(String),
 }
 
@@ -368,8 +367,7 @@ impl Type {
         let t = Type {
             typename: type_ast.fulltypename.clone(),
             typetype: match &type_ast.typedef {
-                parse::TypeDef::TypeBody(body) => TypeType::Structlike(body.clone()),
-                parse::TypeDef::TypeAlias(alias) => TypeType::Alias(alias.fulltypename.clone()),
+                parse::TypeDef::TypeCreate(create) => TypeType::Create(create.typeassignables.iter().map(|ta| ta.to_string()).collect::<Vec<String>>().join("")), // TODO: Redo this
                 parse::TypeDef::TypeBind(bind) => TypeType::Bind(
                     format!(
                         "{}{}",


### PR DESCRIPTION
This simplification may or may not be long-term (adding `{}` could simply be a substitution with `=;`), but the extra focus will help with keeping the sprawl in the first stage of the compiler less large, at least in my head.
