### PR TITLE
Implement type statement parsing

### DIFF
--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -1,13 +1,70 @@
 // TODO: Generics/Interfaces resolution
 use ordered_hash_map::OrderedHashMap;
 
-use crate::program::{Program, Scope, Type, TypeType};
+use crate::program::{CType, Program, Scope, Type, TypeType};
+
+fn ctype_to_rtype(
+    ctype: &CType,
+    scope: &Scope,
+    program: &Program,
+    in_function_type: bool,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match ctype {
+        CType::Type(name, _) => Ok(name.clone()), // TODO: Do we need to handle this recursively,
+        // or will the syntax ordering save us here?
+        CType::Generic(name, ..) => Ok(name.clone()),
+        CType::Bound(name, _) => Ok(name.clone()),
+        CType::BoundGeneric(name, ..) => Ok(name.clone()),
+        CType::IntrinsicGeneric(name, _) => Ok(name.clone()), // How would this even be reached?
+        CType::Int(i) => Ok(i.to_string()),
+        CType::Float(f) => Ok(f.to_string()),
+        CType::Bool(b) => Ok(b.to_string()),
+        CType::TString(s) => Ok(s.clone()),
+        CType::Group(g) => Ok(format!(
+            "({})",
+            ctype_to_rtype(g, scope, program, in_function_type)?
+        )),
+        CType::Function(i, o) => Ok(format!(
+            "fn({}) -> {}",
+            ctype_to_rtype(i, scope, program, true)?,
+            ctype_to_rtype(o, scope, program, true)?
+        )),
+        CType::Tuple(ts) => {
+            let mut out = Vec::new();
+            for t in ts {
+                out.push(ctype_to_rtype(t, scope, program, in_function_type)?);
+            }
+            Ok(format!("({})", out.join(", ")))
+        }
+        CType::Field(k, v) => {
+            if in_function_type {
+                Ok(ctype_to_rtype(v, scope, program, in_function_type)?)
+            } else {
+                Ok(format!(
+                    "{}: {}",
+                    k,
+                    ctype_to_rtype(v, scope, program, in_function_type)?
+                ))
+            }
+        }
+        CType::Either(_ts) => Err("TODO: Implement either-to-enum logic".into()),
+        CType::Buffer(t, s) => Ok(format!(
+            "[{};{}]",
+            ctype_to_rtype(t, scope, program, in_function_type)?,
+            s
+        )),
+        CType::Array(t) => Ok(format!(
+            "Vec<{}>",
+            ctype_to_rtype(t, scope, program, in_function_type)?
+        )),
+    }
+}
 
 pub fn generate(
     typen: &Type,
-    _scope: &Scope,
-    _program: &Program,
-    out: OrderedHashMap<String, String>,
+    scope: &Scope,
+    program: &Program,
+    mut out: OrderedHashMap<String, String>,
 ) -> Result<(String, OrderedHashMap<String, String>), Box<dyn std::error::Error>> {
     match &typen.typetype {
         // The first value is the identifier, and the second is the generated source. For the
@@ -18,6 +75,19 @@ pub fn generate(
         TypeType::Bind(s) => Ok((s.clone(), out)),
         // TODO: The "alias" type is just the normal type assignment path, now, no distinction so
         // this needs to be more capable going forward
-        TypeType::Create(a) => Ok((a.to_string(), out)),
+        TypeType::Create(a) => match a {
+            CType::Type(name, ctype) => {
+                out.insert(
+                    name.clone(),
+                    format!(
+                        "type {} = {};\n",
+                        name.clone(),
+                        ctype_to_rtype(ctype, scope, program, false)?
+                    ),
+                );
+                Ok((name.clone(), out))
+            }
+            _ => Ok(("".to_string(), out)), // Ignore all other types at the top-level for now?
+        },
     }
 }


### PR DESCRIPTION
This implements type statement parsing into a `CType` tree on the `withoperatorslist` syntax group. It's not really used, yet, so there's probably parts that aren't implemented correctly, but this is a significant step along the way of having the new type system implemented.
