### PR TITLE
Implement the void type

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -413,7 +413,7 @@ macro_rules! status {
 
 // The gold standard test. If you can't do this, are you even a language at all? :P
 test!(hello_world => r#"
-    export fn main {
+    export fn main() -> () {
         print('Hello, World!');
     }"#;
     stdout "Hello, World!\n";
@@ -472,7 +472,7 @@ test!(print_function => r#"
     status 0;
 );
 test!(duration_print => r#"
-    export fn main() {
+    export fn main() -> void {
         const i = now();
         wait(10);
         const d = i.elapsed;

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -10,6 +10,7 @@ fn ctype_to_rtype(
     in_function_type: bool,
 ) -> Result<String, Box<dyn std::error::Error>> {
     match ctype {
+        CType::Void => Ok("()".to_string()),
         CType::Type(name, _) => Ok(name.clone()), // TODO: Do we need to handle this recursively,
         // or will the syntax ordering save us here?
         CType::Generic(name, ..) => Ok(name.clone()),

--- a/src/program.rs
+++ b/src/program.rs
@@ -299,6 +299,7 @@ impl Scope {
 
 #[derive(Clone, Debug)]
 pub enum CType {
+    Void,
     Type(String, Box<CType>),
     Generic(String, Vec<String>, Vec<parse::WithTypeOperators>),
     Bound(String, String),
@@ -2033,12 +2034,17 @@ fn typebaselist_to_ctype(
             }
             parse::TypeBase::GnCall(_) => { /* We always process GnCall in the Variable path */ }
             parse::TypeBase::TypeGroup(g) => {
-                // Simply wrap the returned type in a `CType::Group`
-                prior_value = Some(CType::Group(Box::new(withtypeoperatorslist_to_ctype(
-                    &g.typeassignables,
-                    scope,
-                    program,
-                )?)));
+                if g.typeassignables.len() == 0 {
+                    // It's a void type!
+                    prior_value = Some(CType::Group(Box::new(CType::Void)));
+                } else {
+                    // Simply wrap the returned type in a `CType::Group`
+                    prior_value = Some(CType::Group(Box::new(withtypeoperatorslist_to_ctype(
+                        &g.typeassignables,
+                        scope,
+                        program,
+                    )?)));
+                }
             }
         };
         i = i + 1;

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -81,6 +81,8 @@ export type infix Lte as <= precedence 1;
 export type infix Gt as > precedence 1;
 export type infix Gte as >= precedence 1;
 
+export type void = ();
+
 // Binding the integer types
 export type i8 binds i8;
 export type Result{i8} binds Result<i8, AlanError>; // TODO: Just define `export type Result{T} binds Result{T, AlanError};` and have that work instead of this redundant definition


### PR DESCRIPTION
Something something neitzsche something void something something.

An empty group `()` is the `void` type, with `void` being an alias for it, which is represented as the `CType::Void` enum internally and then translated back into `()` on the Rust side.
