### PR TITLE
Fix array constructor function syntax

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1591,10 +1591,10 @@ test_ignore!(array_accessor_and_length => r#"
 "#;
 );
 
-test_ignore!(array_literal_syntax => r#"
+test!(array_literal_syntax => r#"
     export fn main {
       print('Testing...');
-      const test = new Array{int64} [ 1, 2, 3 ];
+      const test = Array{i64}(1, 2, 3);
       print(test[0]);
       print(test[1]);
       print(test[2]);

--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -244,21 +244,30 @@ pub fn from_microstatement(
                             let first_type = &f.args[0].1;
                             let second_type = &f.args[1].1;
                             match (first_type, second_type, &f.rettype) {
-                                (CType::Type(_, a), CType::Bound(i, _), CType::Type(_, r)) if i == "i64" => {
+                                (CType::Type(_, a), CType::Bound(i, _), CType::Type(_, r))
+                                    if i == "i64" =>
+                                {
                                     match (*a.clone(), *r.clone()) {
                                         (CType::Array(_), CType::Either(ts)) if ts.len() == 2 => {
-                                            return Ok((format!("{}.get({})", argstrs[0], match argstrs[1].strip_prefix("&mut ") {
-                                                Some(s) => s,
-                                                None => &argstrs[1],
-                                            }), out))
+                                            return Ok((
+                                                format!(
+                                                    "{}.get({})",
+                                                    argstrs[0],
+                                                    match argstrs[1].strip_prefix("&mut ") {
+                                                        Some(s) => s,
+                                                        None => &argstrs[1],
+                                                    }
+                                                ),
+                                                out,
+                                            ));
                                             // TODO: Someday revive something like this, but for
                                             // now we are using Option, so it's much simpler
                                             // return Ok((format!("match {}.get({}) {{ Some(v) => {}::{}(v), None => {}::void }}", argstrs[0], argstrs[1], n, ts[0].to_string(), n), out));
                                         }
-                                        _ => {}, // Just fall through
+                                        _ => {} // Just fall through
                                     }
                                 }
-                                _ => {}, // Just fall through
+                                _ => {} // Just fall through
                             }
                         }
                         if f.args.len() == 1 {
@@ -373,10 +382,20 @@ pub fn from_microstatement(
                                     }
                                 }
                                 CType::Array(_) => {
-                                    return Ok((format!("vec![{}]", argstrs.iter().map(|a| match a.strip_prefix("&mut ") {
-                                        Some(v) => v.to_string(),
-                                        None => a.clone(),
-                                    }).collect::<Vec<String>>().join(", ")), out));
+                                    return Ok((
+                                        format!(
+                                            "vec![{}]",
+                                            argstrs
+                                                .iter()
+                                                .map(|a| match a.strip_prefix("&mut ") {
+                                                    Some(v) => v.to_string(),
+                                                    None => a.clone(),
+                                                })
+                                                .collect::<Vec<String>>()
+                                                .join(", ")
+                                        ),
+                                        out,
+                                    ));
                                 }
                                 CType::Either(ts) => {
                                     if argstrs.len() != 1 {
@@ -537,7 +556,7 @@ pub fn generate(
                 out = o;
                 Some(t_str)
             }
-        }
+        },
         otherwise => {
             let (t_str, o) = typen::generate(otherwise, scope, program, out)?;
             out = o;

--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -236,6 +236,31 @@ pub fn from_microstatement(
                         // 3) If the input type is an either and the name of the function matches
                         //    the name of a sub-type, it returns a Maybe{T} for the type in
                         //    question. (This conflicts with (1) so it's checked first.)
+                        // 4) If the name of the function is `get` write a getter function for the
+                        //    first argument type in question.
+                        // 5) If the name of the function is `set` write a setter function for the
+                        //    first argument type in question. TODO: Do this path.
+                        if &f.name == "get" && f.args.len() == 2 {
+                            let first_type = &f.args[0].1;
+                            let second_type = &f.args[1].1;
+                            match (first_type, second_type, &f.rettype) {
+                                (CType::Type(_, a), CType::Bound(i, _), CType::Type(_, r)) if i == "i64" => {
+                                    match (*a.clone(), *r.clone()) {
+                                        (CType::Array(_), CType::Either(ts)) if ts.len() == 2 => {
+                                            return Ok((format!("{}.get({})", argstrs[0], match argstrs[1].strip_prefix("&mut ") {
+                                                Some(s) => s,
+                                                None => &argstrs[1],
+                                            }), out))
+                                            // TODO: Someday revive something like this, but for
+                                            // now we are using Option, so it's much simpler
+                                            // return Ok((format!("match {}.get({}) {{ Some(v) => {}::{}(v), None => {}::void }}", argstrs[0], argstrs[1], n, ts[0].to_string(), n), out));
+                                        }
+                                        _ => {}, // Just fall through
+                                    }
+                                }
+                                _ => {}, // Just fall through
+                            }
+                        }
                         if f.args.len() == 1 {
                             // This is a wacky unwrapping logic...
                             let mut input_type = &f.args[0].1;
@@ -348,7 +373,10 @@ pub fn from_microstatement(
                                     }
                                 }
                                 CType::Array(_) => {
-                                    return Ok((format!("vec![{}]", argstrs.join(", ")), out));
+                                    return Ok((format!("vec![{}]", argstrs.iter().map(|a| match a.strip_prefix("&mut ") {
+                                        Some(v) => v.to_string(),
+                                        None => a.clone(),
+                                    }).collect::<Vec<String>>().join(", ")), out));
                                 }
                                 CType::Either(ts) => {
                                     if argstrs.len() != 1 {
@@ -501,6 +529,15 @@ pub fn generate(
     let opt_ret_str = match &function.rettype {
         CType::Void => None,
         CType::Type(n, _) if n == "void" => None,
+        CType::Group(g) => match &**g {
+            CType::Void => None,
+            CType::Type(n, _) if n == "void" => None,
+            otherwise => {
+                let (t_str, o) = typen::generate(otherwise, scope, program, out)?;
+                out = o;
+                Some(t_str)
+            }
+        }
         otherwise => {
             let (t_str, o) = typen::generate(otherwise, scope, program, out)?;
             out = o;

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -31,7 +31,12 @@ pub fn ctype_to_rtype(
                                 enum_type_strs.push(format!("{}({})", n, r));
                             }
                             CType::Group(g) => {
-                                enum_type_strs.push(ctype_to_rtype(g, scope, program, in_function_type)?);
+                                enum_type_strs.push(ctype_to_rtype(
+                                    g,
+                                    scope,
+                                    program,
+                                    in_function_type,
+                                )?);
                             }
                             otherwise => {
                                 return Err(format!("TODO: What is this? {:?}", otherwise).into());

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -10,7 +10,7 @@ pub fn ctype_to_rtype(
     in_function_type: bool,
 ) -> Result<String, Box<dyn std::error::Error>> {
     match ctype {
-        CType::Void => Ok("()".to_string()),
+        CType::Void => Ok("void".to_string()),
         CType::Type(name, t) => {
             match &**t {
                 CType::Either(ts) => {
@@ -29,6 +29,9 @@ pub fn ctype_to_rtype(
                             }
                             CType::Bound(n, r) => {
                                 enum_type_strs.push(format!("{}({})", n, r));
+                            }
+                            CType::Group(g) => {
+                                enum_type_strs.push(ctype_to_rtype(g, scope, program, in_function_type)?);
                             }
                             otherwise => {
                                 return Err(format!("TODO: What is this? {:?}", otherwise).into());
@@ -113,7 +116,9 @@ pub fn generate(
         // output, while the `Structlike` type requires a new struct to be created and inserted
         // into the source definition, potentially inserting inner types as needed
         CType::Bound(_name, rtype) => Ok((rtype.clone(), out)),
-        CType::Type(name, _) => {
+        CType::Type(name, t) => {
+            let res = generate(t, scope, program, out)?;
+            out = res.1;
             out.insert(name.clone(), ctype_to_rtype(typen, scope, program, false)?);
             Ok((name.clone(), out))
         }
@@ -129,6 +134,11 @@ pub fn generate(
             }
             let out_str = ctype_to_rtype(&typen, scope, program, false)?;
             Ok((out_str, out)) // TODO: Put something into out?
+        }
+        CType::Group(g) => {
+            let res = generate(g, scope, program, out)?;
+            out = res.1;
+            Ok(("".to_string(), out))
         }
         otherwise => {
             let out_str = ctype_to_rtype(&otherwise, scope, program, false)?;

--- a/src/program.rs
+++ b/src/program.rs
@@ -353,7 +353,7 @@ impl CType {
             CType::Type(n, t) => match strict {
                 true => format!("{}", n),
                 false => t.to_strict_string(strict),
-            }
+            },
             CType::Generic(n, a, _) => format!("{}{{{}}}", n, a.join(", ")),
             CType::Bound(s, _) => format!("{}", s),
             CType::BoundGeneric(s, a, _) => format!("{}{{{}}}", s, a.join(", ")),
@@ -598,13 +598,19 @@ impl CType {
                                     name: "get".to_string(),
                                     args: vec![
                                         ("arg0".to_string(), t.clone()),
-                                        ("arg1".to_string(), CType::Bound("i64".to_string(), "i64".to_string())),
+                                        (
+                                            "arg1".to_string(),
+                                            CType::Bound("i64".to_string(), "i64".to_string()),
+                                        ),
                                     ],
-                                    rettype: CType::Type(format!("Maybe_{}_", a.to_string()), Box::new(CType::Either(vec![
-                                        *a.clone(),
-                                        CType::Group(Box::new(CType::Void)), // TODO: Do I need
-                                                                             // this?
-                                    ]))),
+                                    rettype: CType::Type(
+                                        format!("Maybe_{}_", a.to_string()),
+                                        Box::new(CType::Either(vec![
+                                            *a.clone(),
+                                            CType::Group(Box::new(CType::Void)), // TODO: Do I need
+                                                                                 // this?
+                                        ])),
+                                    ),
                                     microstatements: Vec::new(),
                                     kind: FnKind::Derived,
                                 });

--- a/src/program.rs
+++ b/src/program.rs
@@ -149,17 +149,30 @@ impl Program {
         match scope.functions.get(function) {
             Some(fs) => {
                 for f in fs {
-                    if args.len() != f.args.len() {
-                        continue;
-                    }
+                    // TODO: Handle this more generically, and in a way that allows users to write
+                    // variadic functions
                     let mut args_match = true;
-                    for (i, arg) in args.iter().enumerate() {
-                        // This is pretty cheap, but for now, a "non-strict" string representation
-                        // of the CTypes is how we'll match the args against each other. TODO: Do
-                        // this without constructing a string to compare against each other.
-                        if f.args[i].1.to_strict_string(false) != arg.to_strict_string(false) {
-                            args_match = false;
-                            break;
+                    if let FnKind::DerivedVariadic = f.kind {
+                        // The special path where the length doesn't matter as long as all of the
+                        // actual args are the same type as the function's arg.
+                        for arg in args.iter() {
+                            if f.args[0].1.to_strict_string(false) != arg.to_strict_string(false) {
+                                args_match = false;
+                                break;
+                            }
+                        }
+                    } else {
+                        if args.len() != f.args.len() {
+                            continue;
+                        }
+                        for (i, arg) in args.iter().enumerate() {
+                            // This is pretty cheap, but for now, a "non-strict" string representation
+                            // of the CTypes is how we'll match the args against each other. TODO: Do
+                            // this without constructing a string to compare against each other.
+                            if f.args[i].1.to_strict_string(false) != arg.to_strict_string(false) {
+                                args_match = false;
+                                break;
+                            }
                         }
                     }
                     if args_match {
@@ -337,7 +350,10 @@ impl CType {
     pub fn to_strict_string(&self, strict: bool) -> String {
         match self {
             CType::Void => "()".to_string(),
-            CType::Type(s, _) => format!("{}", s),
+            CType::Type(n, t) => match strict {
+                true => format!("{}", n),
+                false => t.to_strict_string(strict),
+            }
             CType::Generic(n, a, _) => format!("{}{{{}}}", n, a.join(", ")),
             CType::Bound(s, _) => format!("{}", s),
             CType::BoundGeneric(s, a, _) => format!("{}{{{}}}", s, a.join(", ")),
@@ -568,7 +584,9 @@ impl CType {
                                 // number of the input type. Until there's better support in the
                                 // language for variadic functions, this is faked with a special
                                 // DerivedVariadic function type that repeats the first and only
-                                // arg for all input arguments
+                                // arg for all input arguments. We also need to create `get` and
+                                // `set` functions for this type (TODO: This is probably true for
+                                // other types, too.
                                 fs.push(Function {
                                     name: constructor_fn_name.clone(),
                                     args: vec![("arg0".to_string(), *a.clone())],
@@ -576,6 +594,21 @@ impl CType {
                                     microstatements: Vec::new(),
                                     kind: FnKind::DerivedVariadic,
                                 });
+                                fs.push(Function {
+                                    name: "get".to_string(),
+                                    args: vec![
+                                        ("arg0".to_string(), t.clone()),
+                                        ("arg1".to_string(), CType::Bound("i64".to_string(), "i64".to_string())),
+                                    ],
+                                    rettype: CType::Type(format!("Maybe_{}_", a.to_string()), Box::new(CType::Either(vec![
+                                        *a.clone(),
+                                        CType::Group(Box::new(CType::Void)), // TODO: Do I need
+                                                                             // this?
+                                    ]))),
+                                    microstatements: Vec::new(),
+                                    kind: FnKind::Derived,
+                                });
+                                // TODO: Add 'set' function
                             }
                             _ => {} // Don't do anything for other types
                         }


### PR DESCRIPTION
This syntax technically is only necessary for constructing an empty array, but it should work for any number of arguments passed to it.

Fixing this revealed several bugs in different parts of the codebase, which I fixed along the way.
