### PR TITLE
'get_or_exit' working

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -3178,16 +3178,16 @@ test_ignore!(clone => r#"
       print(b);
       let c = [1, 2, 3];
       let d = c.clone;
-      d.set(0, 2);
-      c.map(fn (val: int) -> string = val.string).join(', ').print;
-      d.map(fn (val: int) -> string = val.string).join(', ').print;
+      d[0] = 2;
+      c.map(string).join(', ').print;
+      d.map(string).join(', ').print;
     }"#;
     stdout "4\n3\n1, 2, 3\n2, 2, 3\n";
 );
 
 // Runtime Error
 
-test_ignore!(get_or_exit => r#"
+test!(get_or_exit => r#"
     export fn main {
       const xs = [0, 1, 2, 5];
       const x1 = xs[1].getOrExit;
@@ -3197,7 +3197,7 @@ test_ignore!(get_or_exit => r#"
       const x5 = xs[5].getOrExit;
       print(x5);
     }"#;
-    status 1;
+    status 101;
 );
 
 /* It's not known *if* @std/datastore will be restored or what changes there will be needed with

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -478,6 +478,10 @@ export fn getOrExit(a: Result{i8}) -> i8 binds get_or_exit; // TODO: Support rea
 export fn getOrExit(a: Result{i16}) -> i16 binds get_or_exit; // TODO: Support real generics
 export fn getOrExit(a: Result{i32}) -> i32 binds get_or_exit; // TODO: Support real generics
 export fn getOrExit(a: Result{i64}) -> i64 binds get_or_exit; // TODO: Support real generics
+export fn getOrExit(a: i8 | void) -> i8 binds get_or_maybe_exit; // TODO: Support real generics
+export fn getOrExit(a: i16 | void) -> i16 binds get_or_maybe_exit; // TODO: Support real generics
+export fn getOrExit(a: i32 | void) -> i32 binds get_or_maybe_exit; // TODO: Support real generics
+export fn getOrExit(a: i64 | void) -> i64 binds get_or_maybe_exit; // TODO: Support real generics
 
 /// Stdout/stderr-related bindings
 export fn print(str: string) binds println;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -1897,6 +1897,16 @@ fn get_or_exit<A: Clone>(a: &Result<A, AlanError>) -> A {
     }
 }
 
+/// `get_or_maybe_exit` is basically an alias to `unwrap`, but as a function instead of a method
+/// and for `Option` instead of `Result`
+#[inline(always)]
+fn get_or_maybe_exit<A: Clone>(a: &Option<A>) -> A {
+    match a {
+        Some(v) => v.clone(),
+        None => panic!("Expected value did not exist"), // TODO: Better error message somehow?
+    }
+}
+
 /// `i8tostring` converts an i8 into a simple string representation
 #[inline(always)]
 fn i8tostring(a: &i8) -> String {


### PR DESCRIPTION
Simple change that gets `get_or_exit` working with the new Either type. The old Result-based approach will be deleted eventually.
