### PR TITLE
Fully working generic types, postfix type operators, and better chunking logic

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1915,34 +1915,24 @@ length test
 
 // Generics
 
-test_ignore!(generics => r#"
-    type box{V} {
-      set: bool,
-      val: V
-    }
+test!(generics => r#"
+    type box{V} =
+      val: V,
+      set: bool;
 
     export fn main {
-      let int8Box = new box{int8} {
-        val: 8.i8,
-        set: true
-      };
+      let int8Box = box{i8}(8.i8, true);
       print(int8Box.val);
       print(int8Box.set);
 
-      let stringBox = new box{string} {
-        val: 'hello, generics!',
-        set: true
-      };
+      let stringBox = box{string}('hello, generics!', true);
       print(stringBox.val);
       print(stringBox.set);
 
-      const stringBoxBox = new box{box{string}} {
-        val: new box{string} {
-          val: 'hello, nested generics!',
-          set: true
-        },
-        set: true
-      };
+      const stringBoxBox = box{box{string}}(
+        box{string}('hello, nested generics!', true),
+        true
+      );
       stringBoxBox.set.print;
       stringBoxBox.val.set.print;
       print(stringBoxBox.val.val);
@@ -2389,7 +2379,7 @@ test!(user_types_and_generics => r#"
       let b = foo{i64, bool}(0, true);
       let c = foo2(0, 1.23);
       let d = foo{i64, f64}(1, 3.14);
-      let e = {i64 | void}(2); // TODO: Implement postfix operators to change this to {i64?}
+      let e = {i64?}(2);
       print(a.bar);
       print(b.bar);
       print(c.bar);

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -38,6 +38,7 @@ pub fn ctype_to_rtype(
                                     in_function_type,
                                 )?);
                             }
+                            CType::Void => enum_type_strs.push("void".to_string()),
                             otherwise => {
                                 return Err(format!("TODO: What is this? {:?}", otherwise).into());
                             }

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -478,10 +478,10 @@ export fn getOrExit(a: Result{i8}) -> i8 binds get_or_exit; // TODO: Support rea
 export fn getOrExit(a: Result{i16}) -> i16 binds get_or_exit; // TODO: Support real generics
 export fn getOrExit(a: Result{i32}) -> i32 binds get_or_exit; // TODO: Support real generics
 export fn getOrExit(a: Result{i64}) -> i64 binds get_or_exit; // TODO: Support real generics
-export fn getOrExit(a: i8 | void) -> i8 binds get_or_maybe_exit; // TODO: Support real generics
-export fn getOrExit(a: i16 | void) -> i16 binds get_or_maybe_exit; // TODO: Support real generics
-export fn getOrExit(a: i32 | void) -> i32 binds get_or_maybe_exit; // TODO: Support real generics
-export fn getOrExit(a: i64 | void) -> i64 binds get_or_maybe_exit; // TODO: Support real generics
+export fn getOrExit(a: i8?) -> i8 binds get_or_maybe_exit; // TODO: Support real generics
+export fn getOrExit(a: i16?) -> i16 binds get_or_maybe_exit; // TODO: Support real generics
+export fn getOrExit(a: i32?) -> i32 binds get_or_maybe_exit; // TODO: Support real generics
+export fn getOrExit(a: i64?) -> i64 binds get_or_maybe_exit; // TODO: Support real generics
 
 /// Stdout/stderr-related bindings
 export fn print(str: string) binds println;


### PR DESCRIPTION
This PR got a bit scattershot on what it's doing, so I decided to cap it off here.

* It has working postfix type operator logic, so `i64?` is equivalent to `Maybe{i64}` which itself is `Either{i64, ()}`.
* There's a fix with how types with `()` are turned into constructor function names that fixed full generic types, unlocking that test (after changing the syntax versus Alan v0.1).
* The statement "chunking" logic is simplified and shortened in this PR, shoving it all into one giant match statement, which also allowed the chunk to avoid being wrapped (at the expensive the array values being wrapped, which means slightly more wrapping than before, but the code clarity is worth it).
