### PR TITLE
Implement most of the string operators and partially implement negation

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -448,7 +448,7 @@ test!(non_global_memory_exit_code => r#"
     }"#;
     status 0;
 );
-test_ignore!(passing_ints_from_global_memory => r#"
+test!(passing_ints_from_global_memory => r#"
     fn aNumber(num: i64) {
       print('I got a number! ' + num.string);
     }
@@ -519,6 +519,10 @@ test!(int8_max => r#"
     }"#;
     stdout "5\n";
 );
+test!(int8_neg => r#"
+    export fn main = print(neg(i8(3)));"#;
+    stdout "-3\n";
+);
 
 test!(int16_add => r#"
     export fn main {
@@ -567,6 +571,10 @@ test!(int16_max => r#"
       max(3.i16, 5.i16).print;
     }"#;
     stdout "5\n";
+);
+test_ignore!(int16_neg => r#"
+    export fn main = print(-i16(3));"#;
+    stdout "-3\n";
 );
 
 test!(int32_add => r#"
@@ -617,6 +625,10 @@ test!(int32_max => r#"
     }"#;
     stdout "5\n";
 );
+test_ignore!(int32_neg => r#"
+    export fn main = print(- 3.i32);"#; // You wouldn't naturally write this, but should still work
+    stdout "-3\n";
+);
 
 test!(int64_add => r#"
     export fn main = print(1 + 2);"#;
@@ -649,6 +661,10 @@ test!(int64_min => r#"
 test!(int64_max => r#"
     export fn main = max(3.i64, 5.i64).print;"#;
     stdout "5\n";
+);
+test_ignore!(int64_neg => r#"
+    export fn main = print(- 3);"#; // You wouldn't naturally write this, but should still work
+    stdout "-3\n";
 );
 
 test!(float32_add => r#"
@@ -699,6 +715,10 @@ test!(float32_max => r#"
     }"#;
     stdout "5\n";
 );
+test_ignore!(float32_neg => r#"
+    export fn main = print(- 3.f32);"#; // You wouldn't naturally write this, but should still work
+    stdout "-3\n";
+);
 
 test!(float64_add => r#"
     export fn main {
@@ -747,6 +767,10 @@ test!(float64_max => r#"
       max(3.f64, 5.f64).print;
     }"#;
     stdout "5\n";
+);
+test_ignore!(float64_neg => r#"
+    export fn main = print(- 3.f64);"#; // You wouldn't naturally write this, but should still work
+    stdout "-3\n";
 );
 
 test!(grouping => r#"
@@ -939,7 +963,7 @@ true
 
 // String Manipulation
 
-test_ignore!(string_ops => r#"
+test!(string_ops => r#"
     export fn main {
       concat('Hello, ', 'World!').print;
       print('Hello, ' + 'World!');
@@ -947,17 +971,19 @@ test_ignore!(string_ops => r#"
       repeat('hi ', 5).print;
       print('hi ' * 5);
 
-      matches('foobar', 'fo.*').print;
-      print('foobar' ~ 'fo.*');
+      // TODO: Add regex support
+      //matches('foobar', 'fo.*').print;
+      //print('foobar' ~ 'fo.*');
 
       index('foobar', 'ba').print;
       print('foobar' @ 'ba');
 
-      length('foobar').print;
+      len('foobar').print;
       print(#'foobar');
 
       trim('   hi   ').print;
-      print(\`'   hi   ');
+      // TODO: Do we really want this operator?
+      // print(\`'   hi   ');
 
       split('Hello, World!', ', ')[0].print;
       print(('Hello, World!' / ', ')[1]);
@@ -972,13 +998,10 @@ test_ignore!(string_ops => r#"
 Hello, World!
 hi hi hi hi hi 
 hi hi hi hi hi 
-true
-true
 3
 3
 6
 6
-hi
 hi
 Hello
 World!
@@ -2464,7 +2487,7 @@ test!(user_types_and_generics => r#"
 test_ignore!(closure_creation_and_usage => r#"
     fn closure() -> function {
       let num = 0;
-      return fn () -> int64 {
+      return fn () -> i64 {
         num = num + 1 || 0;
         return num;
       };
@@ -2480,7 +2503,7 @@ test_ignore!(closure_creation_and_usage => r#"
     stdout "1\n2\n1\n";
 );
 test_ignore!(closure_by_name => r#"
-    fn double(x: int64) -> int64 = x * 2 || 0;
+    fn double(x: i64) -> i64 = x * 2 || 0;
 
     export fn main {
       const numbers = [1, 2, 3, 4, 5];

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -25,6 +25,9 @@ pub fn ctype_to_rtype(
                                 ));
                             }
                             CType::Type(n, _) | CType::ResolvedBoundGeneric(n, ..) => {
+                                if n == "string" {
+                                    println!("wtf {:?}", t);
+                                }
                                 enum_type_strs.push(format!("{}({})", n, n));
                             }
                             CType::Bound(n, r) => {

--- a/src/program.rs
+++ b/src/program.rs
@@ -1228,7 +1228,16 @@ impl Microstatement {
                 }
                 match program.resolve_function(scope, function, &arg_types) {
                     Some((function_object, _s)) => Ok(function_object.rettype.clone()),
-                    None => Err(format!("Could not find function {}({})", function, arg_types.iter().map(|t| t.to_string()).collect::<Vec<String>>().join(", ")).into()),
+                    None => Err(format!(
+                        "Could not find function {}({})",
+                        function,
+                        arg_types
+                            .iter()
+                            .map(|t| t.to_string())
+                            .collect::<Vec<String>>()
+                            .join(", ")
+                    )
+                    .into()),
                 }
             }
         }
@@ -2851,7 +2860,8 @@ impl Function {
                         }
                     }
                     if let Some(lastfnop) = lastfnop {
-                        let returntypeassignables = typeassignable[lastfnop+1..typeassignable.len()].to_vec();
+                        let returntypeassignables =
+                            typeassignable[lastfnop + 1..typeassignable.len()].to_vec();
                         // TODO: Be more complete here
                         let name = output_type
                             .to_strict_string(false)

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -30,6 +30,9 @@ export ctype Mul{A, B}; // Multiplication
 export ctype Div{A, B}; // Division
 export ctype Mod{A, B}; // Modulus (remainder)
 export ctype Pow{A, B}; // Exponentiation/Power
+export ctype Min{A, B}; // Minimum value of the two
+export ctype Max{A, B}; // Maximum value of the two
+export ctype Neg{A}; // Negate the value
 export ctype Len{A}; // Returns the length of the input type in terms of the number of elements it contains, which is most useful for Buffers, Tuples, and Either, causes a compiler failure for Arrays, and returns 1 for everything else
 export ctype Size{T}; // Returns the size in bytes of the type in question, if possible, causing a compiler failure otherwise.
 export ctype FileStr{F}; // Read a file and return a string constant, useful for including large strings from a separate, nearby file, or fails if it doesn't exist
@@ -156,6 +159,8 @@ export fn max(a: i8, b: i8) -> i8 binds maxi8;
 export fn max(a: Result{i8}, b: Result{i8}) -> Result{i8} binds maxi8_result;
 export fn max(a: i8, b: Result{i8}) -> Result{i8} = max(a.ok, b);
 export fn max(a: Result{i8}, b: i8) -> Result{i8} = max(a, b.ok);
+export fn neg(a: i8) -> i8 binds negi8;
+export fn neg(a: Result{i8}) -> Result{i8} binds negi8_result;
 export fn and(a: i8, b: i8) -> i8 binds andi8;
 export fn or(a: i8, b: i8) -> i8 binds ori8;
 export fn xor(a: i8, b: i8) -> i8 binds xori8;
@@ -211,6 +216,8 @@ export fn max(a: i16, b: i16) -> i16 binds maxi16;
 export fn max(a: Result{i16}, b: Result{i16}) -> Result{i16} binds maxi16_result;
 export fn max(a: i16, b: Result{i16}) -> Result{i16} = max(a.ok, b);
 export fn max(a: Result{i16}, b: i16) -> Result{i16} = max(a, b.ok);
+export fn neg(a: i16) -> i16 binds negi16;
+export fn neg(a: Result{i16}) -> Result{i16} binds negi16_result;
 export fn and(a: i16, b: i16) -> i16 binds andi16;
 export fn or(a: i16, b: i16) -> i16 binds ori16;
 export fn xor(a: i16, b: i16) -> i16 binds xori16;
@@ -266,6 +273,8 @@ export fn max(a: i32, b: i32) -> i32 binds maxi32;
 export fn max(a: Result{i32}, b: Result{i32}) -> Result{i32} binds maxi32_result;
 export fn max(a: i32, b: Result{i32}) -> Result{i32} = max(a.ok, b);
 export fn max(a: Result{i32}, b: i32) -> Result{i32} = max(a, b.ok);
+export fn neg(a: i32) -> i32 binds negi32;
+export fn neg(a: Result{i32}) -> Result{i32} binds negi32_result;
 export fn and(a: i32, b: i32) -> i32 binds andi32;
 export fn or(a: i32, b: i32) -> i32 binds ori32;
 export fn xor(a: i32, b: i32) -> i32 binds xori32;
@@ -321,6 +330,8 @@ export fn max(a: i64, b: i64) -> i64 binds maxi64;
 export fn max(a: Result{i64}, b: Result{i64}) -> Result{i64} binds maxi64_result;
 export fn max(a: i64, b: Result{i64}) -> Result{i64} = max(a.ok, b);
 export fn max(a: Result{i64}, b: i64) -> Result{i64} = max(a, b.ok);
+export fn neg(a: i64) -> i64 binds negi64;
+export fn neg(a: Result{i64}) -> Result{i64} binds negi64_result;
 export fn and(a: i64, b: i64) -> i64 binds andi64;
 export fn or(a: i64, b: i64) -> i64 binds ori64;
 export fn xor(a: i64, b: i64) -> i64 binds xori64;
@@ -375,6 +386,8 @@ export fn max(a: f32, b: f32) -> f32 binds maxf32;
 export fn max(a: Result{f32}, b: Result{f32}) -> Result{f32} binds maxf32_result;
 export fn max(a: f32, b: Result{f32}) -> Result{f32} = max(a.ok, b);
 export fn max(a: Result{f32}, b: f32) -> Result{f32} = max(a, b.ok);
+export fn neg(a: f32) -> f32 binds negf32;
+export fn neg(a: Result{f32}) -> Result{f32} binds negf32_result;
 export fn eq(a: f32, b: f32) -> bool binds eqf32;
 export fn neq(a: f32, b: f32) -> bool binds neqf32;
 export fn lt(a: f32, b: f32) -> bool binds ltf32;
@@ -421,6 +434,8 @@ export fn max(a: f64, b: f64) -> f64 binds maxf64;
 export fn max(a: Result{f64}, b: Result{f64}) -> Result{f64} binds maxf64_result;
 export fn max(a: f64, b: Result{f64}) -> Result{f64} = max(a.ok, b);
 export fn max(a: Result{f64}, b: f64) -> Result{f64} = max(a, b.ok);
+export fn neg(a: f64) -> f64 binds negf64;
+export fn neg(a: Result{f64}) -> Result{f64} binds negf64_result;
 export fn eq(a: f64, b: f64) -> bool binds eqf64;
 export fn neq(a: f64, b: f64) -> bool binds neqf64;
 export fn lt(a: f64, b: f64) -> bool binds ltf64;
@@ -438,6 +453,14 @@ export fn string(f: f64) -> string binds f64tostring;
 export fn string(b: bool) -> string binds booltostring;
 export fn string(s: string) -> string = s;
 export fn concat(a: string, b: string) -> string binds concatstring;
+export fn add(a: string, b: string) -> string binds concatstring; // To use the '+' operator
+export fn repeat(a: string, n: i64) -> string binds repeatstring;
+export fn mul(a: string, n: i64) -> string binds repeatstring; // To use the '*' operator
+export fn split(a: string, b: string) -> string[] binds splitstring;
+export fn div(a: string, b: string) -> string[] binds splitstring; // To use the '/' operator
+export fn len(a: string) -> i64 binds lenstring;
+export fn trim(a: string) -> string binds trimstring;
+export fn index(a: string, b: string) -> Result{i64} binds indexstring;
 export fn min(a: string, b: string) -> string binds minstring;
 export fn max(a: string, b: string) -> string binds maxstring;
 export fn eq(a: string, b: string) -> bool binds eqstring;
@@ -547,14 +570,16 @@ export fn run(g: GPU, gg: GPGPU) binds gpu_run;
 export fn read(g: GPU, b: GBuffer) -> Vec{i32} binds read_buffer; // TODO: Support other output types
 
 /// Built-in operator definitions
+// TODO: New plan is to make operators only map to one function per symbol and *kind* of operator,
+// so you can have an infix and prefix operator with the same symbol linked to different functions,
+// but you can't have an infix operator of the same symbol linked to multiple functions. This does
+// produce some ambiguity of what kind of operator an operator is, but should still be unambiguous
+// to humans to "read" the symbol as whatever kind of function it represents.
 export infix add as + precedence 2;
-// export infix concat as + precedence 2;
 export infix sub as - precedence 2;
-// export prefix negate as - precedence 1;
+//export prefix neg as - precedence 1; // TODO: Rework operator storage and selection
 export infix mul as * precedence 3;
-// export infix repeat as * precedence 3;
 export infix div as / precedence 3;
-// export infix split as / precedence 3;
 export infix mod as % precedence 3;
 // export infix template as % precedence 3;
 export infix pow as ** precedence 4;
@@ -571,3 +596,5 @@ export infix lt as < precedence 1;
 export infix lte as <= precedence 1;
 export infix gt as > precedence 1;
 export infix gte as >= precedence 1;
+export prefix len as # precedence 1;
+export infix index as @ precedence 1;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -28,6 +28,14 @@ impl From<&str> for AlanError {
     }
 }
 
+impl From<String> for AlanError {
+    fn from(s: String) -> AlanError {
+        AlanError {
+            message: s,
+        }
+    }
+}
+
 /// `alan_ok` is a wrapper function that takes a reference to a value, clones it, and returns it as
 /// a Result-wrapped value. Hopefully this weird function will die soon.
 #[inline(always)]
@@ -269,6 +277,21 @@ fn maxi8_result(a: &Result<i8, AlanError>, b: &Result<i8, AlanError>) -> Result<
             Err(e) => Err(e.clone()),
             Ok(b) => if a > b { Ok(*a) } else { Ok(*b) }
         }
+    }
+}
+
+/// `negi8` negates the `i8` provided
+#[inline(always)]
+fn negi8(a: &i8) -> i8 {
+    -(*a)
+}
+
+/// `negi8_result negates the `Result<i8, AlanError>` provided, if possible
+#[inline(always)]
+fn negi8_result(a: &Result<i8, AlanError>) -> Result<i8, AlanError> {
+    match a {
+        Err(e) => Err(e.clone()),
+        Ok(a) => Ok(-(*a)),
     }
 }
 
@@ -581,6 +604,21 @@ fn maxi16_result(a: &Result<i16, AlanError>, b: &Result<i16, AlanError>) -> Resu
     }
 }
 
+/// `negi16` negates the `i16` provided
+#[inline(always)]
+fn negi16(a: &i16) -> i16 {
+    -(*a)
+}
+
+/// `negi16_result negates the `Result<i16, AlanError>` provided, if possible
+#[inline(always)]
+fn negi16_result(a: &Result<i16, AlanError>) -> Result<i16, AlanError> {
+    match a {
+        Err(e) => Err(e.clone()),
+        Ok(a) => Ok(-(*a)),
+    }
+}
+
 /// `andi16` performs a bitwise `and`
 #[inline(always)]
 fn andi16(a: &i16, b: &i16) -> i16 {
@@ -890,6 +928,21 @@ fn maxi32_result(a: &Result<i32, AlanError>, b: &Result<i32, AlanError>) -> Resu
     }
 }
 
+/// `negi32` negates the `i32` provided
+#[inline(always)]
+fn negi32(a: &i32) -> i32 {
+    -(*a)
+}
+
+/// `negi32_result negates the `Result<i32, AlanError>` provided, if possible
+#[inline(always)]
+fn negi32_result(a: &Result<i32, AlanError>) -> Result<i32, AlanError> {
+    match a {
+        Err(e) => Err(e.clone()),
+        Ok(a) => Ok(-(*a)),
+    }
+}
+
 /// `andi32` performs a bitwise `and`
 #[inline(always)]
 fn andi32(a: &i32, b: &i32) -> i32 {
@@ -1196,6 +1249,21 @@ fn maxi64_result(a: &Result<i64, AlanError>, b: &Result<i64, AlanError>) -> Resu
             Err(e) => Err(e.clone()),
             Ok(b) => if a > b { Ok(*a) } else { Ok(*b) }
         }
+    }
+}
+
+/// `negi64` negates the `i64` provided
+#[inline(always)]
+fn negi64(a: &i64) -> i64 {
+    -(*a)
+}
+
+/// `negi64_result negates the `Result<i64, AlanError>` provided, if possible
+#[inline(always)]
+fn negi64_result(a: &Result<i64, AlanError>) -> Result<i64, AlanError> {
+    match a {
+        Err(e) => Err(e.clone()),
+        Ok(a) => Ok(-(*a)),
     }
 }
 
@@ -1547,6 +1615,21 @@ fn maxf32_result(a: &Result<f32, AlanError>, b: &Result<f32, AlanError>) -> Resu
     }
 }
 
+/// `negf32` negates the `f32` provided
+#[inline(always)]
+fn negf32(a: &f32) -> f32 {
+    -(*a)
+}
+
+/// `negf32_result negates the `Result<f32, AlanError>` provided, if possible
+#[inline(always)]
+fn negf32_result(a: &Result<f32, AlanError>) -> Result<f32, AlanError> {
+    match a {
+        Err(e) => Err(e.clone()),
+        Ok(a) => Ok(-(*a)),
+    }
+}
+
 /// `eqf32` compares two f32s and returns if they are equal
 #[inline(always)]
 fn eqf32(a: &f32, b: &f32) -> bool {
@@ -1852,6 +1935,21 @@ fn maxf64_result(a: &Result<f64, AlanError>, b: &Result<f64, AlanError>) -> Resu
     }
 }
 
+/// `negf64` negates the `f64` provided
+#[inline(always)]
+fn negf64(a: &f64) -> f64 {
+    -(*a)
+}
+
+/// `negf64_result negates the `Result<f64, AlanError>` provided, if possible
+#[inline(always)]
+fn negf64_result(a: &Result<f64, AlanError>) -> Result<f64, AlanError> {
+    match a {
+        Err(e) => Err(e.clone()),
+        Ok(a) => Ok(-(*a)),
+    }
+}
+
 /// `eqf64` compares two f64s and returns if they are equal
 #[inline(always)]
 fn eqf64(a: &f64, b: &f64) -> bool {
@@ -1956,6 +2054,39 @@ fn booltostring(a: &bool) -> String {
 #[inline(always)]
 fn concatstring(a: &String, b: &String) -> String {
     format!("{}{}", a, b).to_string()
+}
+
+/// `repeatstring` creates a new string composed of the original string repeated `n` times
+#[inline(always)]
+fn repeatstring(a: &String, n: &i64) -> String {
+    a.repeat(*n as usize).to_string()
+}
+
+/// `splitstring` creates a vector of strings split by the specified separator string
+#[inline(always)]
+fn splitstring(a: &String, b: &String) -> Vec<String> {
+    a.split(b).map(|v| v.to_string()).collect::<Vec<String>>()
+}
+
+/// `lenstring` returns the length of the string
+#[inline(always)]
+fn lenstring(a: &String) -> i64 {
+    a.len() as i64
+}
+
+/// `trimstring` trims the string of whitespace
+#[inline(always)]
+fn trimstring(a: &String) -> String {
+    a.trim().to_string()
+}
+
+/// `indexstring` finds the index where the specified substring starts, if possible
+#[inline(always)]
+fn indexstring(a: &String, b: &String) -> Result<i64, AlanError> {
+    match a.find(b) {
+        Some(v) => Ok(v as i64),
+        None => Err(format!("Could not find {} in {}", b, a).into()),
+    }
 }
 
 /// `minstring` compares two string and returns the "earlier" string (by byte ordering)


### PR DESCRIPTION
This PR implements most of the string operators (skipping regex matching for now) and implements the negate function, but doesn't bind it to an operator, yet. Also implements `Min{A, B}`, `Max{A, B}`, and `Neg{A}` type functions since they were missed earlier.

A few bugs/not-yet-implemented things were found during this:

1. If the input and output types of a function is being defined for the first time, their constructor and accessor functions are not created. Added a hack to get that working for the return type only for now, but it's making a lot of bad assumptions and really ought to be centralized in the `CType` construction.
2. Operators are index *only* on their string representation internally, which was fine when there was basically only infix operators because I decided that multiple bindings for the same kind of operator will just make what the compiler's doing almost impossible to predict, while saying "`+` always resolves to `add(a, b)`" makes it easier to figure out which functions you're actually calling. But the same operator symbol being used as a prefix or postfix operator shouldn't have to bind to the same function name, since it's conceptually a different symbol. You can write the math `1 - -2`and that is clearly `3`, and you should be able to write `a - -b` and it should similarly work, turning into `sub(a, neg(b))`. I don't know why you'd ever do that, but it should work. The main point, though, is that the operator symbol in a different context should behave differently, so we need to support that style of indexing and lookup, which will rework how operators are stored in the scope and `resolve_operator`'s arguments (we'll need to tell it we want an infix, prefix, or postfix operator).
3. That brings us to the next point: currently we're deciding what kind of operator we're dealing with based on the symbol, when we should be determining this based on other context within the set of operators and base assignables, so that entire resolution logic needs to be reworked. It also needs to make sure that the same operator symbol is only used for 2 out of the 3 categories. If you have `a - - b` if all three are specified, then it isn't clear if the first `-` is an infix or postfix operator, and if the second operator is an infix or prefix operator. It could reasonably be whichever. You could *theoretically* use operator precedence values to resolve this, but I think the code is simply ridiculous and confusing. Better to not have it. In fact, if I didn't think being able to write stuff like `a = -a` was important, I'd stick with the current operator logic. I am slightly tempted to say you have to negate things with `a = 0 - a`, but probably not.
