### PR TITLE
Implement more array functionality

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1597,11 +1597,11 @@ test_ignore!(map_support => r#"
 
 // Arrays
 
-test_ignore!(array_accessor_and_length => r#"
+test!(array_accessor_and_length => r#"
     export fn main {
       print('Testing...');
       const test = '1,2,3'.split(',');
-      print(test.length);
+      print(test.len);
       print(test[0]);
       print(test[1]);
       print(test[2]);
@@ -1635,10 +1635,10 @@ test!(array_literal_syntax => r#"
 6
 "#;
 );
-test_ignore!(array_mutable_push_pop => r#"
+test!(array_mutable_push_pop => r#"
     export fn main {
       print('Testing...');
-      let test = new Array{int64} [];
+      let test = Array{i64}();
       test.push(1);
       test.push(2);
       test.push(3);
@@ -1648,7 +1648,7 @@ test_ignore!(array_mutable_push_pop => r#"
       print(test.pop);
       print(test.pop);
       print(test.pop);
-      print(test.pop); // Should print error message
+      print(test.pop); // Should print void
     }"#;
     stdout r#"Testing...
 1
@@ -1657,7 +1657,7 @@ test_ignore!(array_mutable_push_pop => r#"
 3
 2
 1
-cannot pop empty array
+void
 "#;
 );
 test_ignore!(array_length_index_has_join => r#"

--- a/src/program.rs
+++ b/src/program.rs
@@ -1578,7 +1578,19 @@ fn baseassignablelist_to_microstatements(
                 // TODO: Currently assuming all array values are the same type, should check that
                 // better
                 let inner_type = array_vals[0].get_type(scope, program)?;
+                let inner_type_str = inner_type.to_strict_string(false);
+                let array_type_name = format!("Array_{}_", inner_type_str
+                    .replace(" ", "_")
+                    .replace(",", "_")
+                    .replace(":", "_")
+                    .replace("{", "_")
+                    .replace("}", "_")
+                    .replace("|", "_")
+                    .replace("()", "void")); // Really bad
                 let array_type = CType::Array(Box::new(inner_type));
+                let type_str = format!("type {} = {}[];", array_type_name, inner_type_str);
+                let parse_type = parse::types(&type_str);
+                CType::from_ast(scope, program, &parse_type.unwrap().1, false)?;
                 prior_value = Some(Microstatement::Array {
                     typen: array_type,
                     vals: array_vals,

--- a/src/program.rs
+++ b/src/program.rs
@@ -1579,14 +1579,17 @@ fn baseassignablelist_to_microstatements(
                 // better
                 let inner_type = array_vals[0].get_type(scope, program)?;
                 let inner_type_str = inner_type.to_strict_string(false);
-                let array_type_name = format!("Array_{}_", inner_type_str
-                    .replace(" ", "_")
-                    .replace(",", "_")
-                    .replace(":", "_")
-                    .replace("{", "_")
-                    .replace("}", "_")
-                    .replace("|", "_")
-                    .replace("()", "void")); // Really bad
+                let array_type_name = format!(
+                    "Array_{}_",
+                    inner_type_str
+                        .replace(" ", "_")
+                        .replace(",", "_")
+                        .replace(":", "_")
+                        .replace("{", "_")
+                        .replace("}", "_")
+                        .replace("|", "_")
+                        .replace("()", "void")
+                ); // Really bad
                 let array_type = CType::Array(Box::new(inner_type));
                 let type_str = format!("type {} = {}[];", array_type_name, inner_type_str);
                 let parse_type = parse::types(&type_str);

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -490,7 +490,12 @@ export fn eq(a: bool, b: bool) -> bool binds eqbool;
 export fn neq(a: bool, b: bool) -> bool binds neqbool;
 
 /// Array related bindings
-export fn get(a: Array{i64}, i: i64) -> Maybe{i64} binds getarray; // TODO: Real generics
+export fn len(a: i64[]) -> i64 binds lenarray; // TODO: Real generics
+export fn len(a: string[]) -> i64 binds lenarray; // TODO: Real generics
+export fn push(a: Array{i64}, v: i64) -> () binds pusharray; // TODO: Real generics
+export fn push(a: Array{string}, v: string) -> () binds pusharray; // TODO: Real generics
+export fn pop(a: i64[]) -> Maybe{i64} binds poparray; // TODO: Real generics, not Option
+export fn pop(a: string[]) -> Maybe{string} binds poparray; // TODO: Real generics, not Option
 
 /// Process exit-related bindings
 export fn ExitCode(e: i8) -> ExitCode binds to_exit_code_i8;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -2251,6 +2251,24 @@ fn getarray<T: Clone>(a: &Vec<T>, i: &i64) -> Option<T> {
     }
 }
 
+/// `lenarray` returns the length of an array
+#[inline(always)]
+fn lenarray<T>(a: &Vec<T>) -> i64 {
+    a.len() as i64
+}
+
+/// `pusharray` pushes a value onto the array
+#[inline(always)]
+fn pusharray<T: Clone>(mut a: &mut Vec<T>, v: &T) {
+    a.push(v.clone());
+}
+
+/// `poparray` pops a value off of the array into an Option<T>
+#[inline(always)]
+fn poparray<T>(mut a: &mut Vec<T>) -> Option<T> {
+    a.pop()
+}
+
 /// `println` is a simple function that prints basically anything
 #[inline(always)]
 fn println<A: std::fmt::Display>(a: &A) {


### PR DESCRIPTION
Also need to create the array type to get the constructor and accessors with the array literal notation. Really need to clean that up.

The lack of proper generic functions and/or interface functions is starting to impact the root scope more regularly. Should dig into that soon-ish.
