### PR TITLE
Put underscores in numbers for easier reading

### DIFF
--- a/benches/bench.ln
+++ b/benches/bench.ln
@@ -35,7 +35,7 @@ fn bench(l: i64) {
 
 // Until I have conditionals working, I need to do this kind of tomfoolery
 fn bench_billion {
-  let v = filled(2.i32, 1000000000);
+  let v = filled(2.i32, 1_000_000_000);
   v.length.print;
   let t1 = now();
   v.map(double);
@@ -43,7 +43,7 @@ fn bench_billion {
   let t2 = now();
   v.parmap(double);
   t2.elapsed.print;
-  let v2 = filled(2.i32, 500000000);
+  let v2 = filled(2.i32, 500_000_000);
   let t3 = now();
   let g = GPU();
   let b = g.createBuffer(storageBuffer(), v2);
@@ -87,13 +87,13 @@ export fn main {
   bench(1);
   bench(10);
   bench(100);
-  bench(1000);
-  bench(10000);
-  bench(100000);
-  bench(1000000);
-  bench(10000000);
-  bench(100000000);
+  bench(1_000);
+  bench(10_000);
+  bench(100_000);
+  bench(1_000_000);
+  bench(10_000_000);
+  bench(100_000_000);
   // Commented out because it crashes on my laptop GPU. Try swapping which is commented on your's!
-  // bench(1000000000);
+  // bench(1_000_000_000);
   bench_billion();
 }

--- a/benches/map.rs
+++ b/benches/map.rs
@@ -42,29 +42,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         fn double(x: i64) -> Result{i64} = x * 2;
         export fn main { filled(2, 100).map(double); }
     "#);
-    build!(map_1000 => r#"
+    build!(map_1_000 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
-        export fn main { filled(2, 1000).map(double); }
+        export fn main { filled(2, 1_000).map(double); }
     "#);
-    build!(map_10000 => r#"
+    build!(map_10_000 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
-        export fn main { filled(2, 10000).map(double); }
+        export fn main { filled(2, 10_000).map(double); }
     "#);
-    build!(map_100000 => r#"
+    build!(map_100_000 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
-        export fn main { filled(2, 100000).map(double); }
+        export fn main { filled(2, 100_000).map(double); }
     "#);
-    build!(map_1000000 => r#"
+    build!(map_1_000_000 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
-        export fn main { filled(2, 1000000).map(double); }
+        export fn main { filled(2, 1_000_000).map(double); }
     "#);
-    build!(map_10000000 => r#"
+    build!(map_10_000_000 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
-        export fn main { filled(2, 10000000).map(double); }
+        export fn main { filled(2, 10_000_000).map(double); }
     "#);
-    build!(map_100000000 => r#"
+    build!(map_100_000_000 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
-        export fn main { filled(2, 100000000).map(double); }
+        export fn main { filled(2, 100_000_000).map(double); }
     "#);
     build!(parmap_1 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
@@ -78,29 +78,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         fn double(x: i64) -> Result{i64} = x * 2;
         export fn main { filled(2, 100).parmap(double); }
     "#);
-    build!(parmap_1000 => r#"
+    build!(parmap_1_000 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
-        export fn main { filled(2, 1000).parmap(double); }
+        export fn main { filled(2, 1_000).parmap(double); }
     "#);
-    build!(parmap_10000 => r#"
+    build!(parmap_10_000 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
-        export fn main { filled(2, 10000).parmap(double); }
+        export fn main { filled(2, 10_000).parmap(double); }
     "#);
-    build!(parmap_100000 => r#"
+    build!(parmap_100_000 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
-        export fn main { filled(2, 100000).parmap(double); }
+        export fn main { filled(2, 100_000).parmap(double); }
     "#);
-    build!(parmap_1000000 => r#"
+    build!(parmap_1_000_000 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
-        export fn main { filled(2, 1000000).parmap(double); }
+        export fn main { filled(2, 1_000_000).parmap(double); }
     "#);
-    build!(parmap_10000000 => r#"
+    build!(parmap_10_000_000 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
-        export fn main { filled(2, 10000000).parmap(double); }
+        export fn main { filled(2, 10_000_000).parmap(double); }
     "#);
-    build!(parmap_100000000 => r#"
+    build!(parmap_100_000_000 => r#"
         fn double(x: i64) -> Result{i64} = x * 2;
-        export fn main { filled(2, 100000000).parmap(double); }
+        export fn main { filled(2, 100_000_000).parmap(double); }
     "#);
     build!(gpgpu_1 => r#"
         export fn main {
@@ -168,10 +168,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
           g.read(b);
         }
     "#);
-    build!(gpgpu_1000 => r#"
+    build!(gpgpu_1_000 => r#"
         export fn main {
           let g = GPU();
-          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 1000));
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 1_000));
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -190,10 +190,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
           g.read(b);
         }
     "#);
-    build!(gpgpu_10000 => r#"
+    build!(gpgpu_10_000 => r#"
         export fn main {
           let g = GPU();
-          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 10000));
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 10_000));
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -212,10 +212,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
           g.read(b);
         }
     "#);
-    build!(gpgpu_100000 => r#"
+    build!(gpgpu_100_000 => r#"
         export fn main {
           let g = GPU();
-          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 100000));
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 100_000));
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -234,10 +234,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
           g.read(b);
         }
     "#);
-    build!(gpgpu_1000000 => r#"
+    build!(gpgpu_1_000_000 => r#"
         export fn main {
           let g = GPU();
-          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 1000000));
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 1_000_000));
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -256,10 +256,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
           g.read(b);
         }
     "#);
-    build!(gpgpu_10000000 => r#"
+    build!(gpgpu_10_000_000 => r#"
         export fn main {
           let g = GPU();
-          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 10000000));
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 10_000_000));
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -278,10 +278,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
           g.read(b);
         }
     "#);
-    build!(gpgpu_100000000 => r#"
+    build!(gpgpu_100_000_000 => r#"
         export fn main {
           let g = GPU();
-          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 100000000));
+          let b = g.createBuffer(storageBuffer(), filled(2.i32(), 100_000_000));
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -304,57 +304,57 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     clean!(map_1);
     clean!(map_10);
     clean!(map_100);
-    clean!(map_1000);
-    clean!(map_10000);
-    clean!(map_100000);
-    clean!(map_1000000);
-    clean!(map_10000000);
-    clean!(map_100000000);
+    clean!(map_1_000);
+    clean!(map_10_000);
+    clean!(map_100_000);
+    clean!(map_1_000_000);
+    clean!(map_10_000_000);
+    clean!(map_100_000_000);
     clean!(parmap_1);
     clean!(parmap_10);
     clean!(parmap_100);
-    clean!(parmap_1000);
-    clean!(parmap_10000);
-    clean!(parmap_100000);
-    clean!(parmap_1000000);
-    clean!(parmap_10000000);
-    clean!(parmap_100000000);
+    clean!(parmap_1_000);
+    clean!(parmap_10_000);
+    clean!(parmap_100_000);
+    clean!(parmap_1_000_000);
+    clean!(parmap_10_000_000);
+    clean!(parmap_100_000_000);
     clean!(gpgpu_1);
     clean!(gpgpu_10);
     clean!(gpgpu_100);
-    clean!(gpgpu_1000);
-    clean!(gpgpu_10000);
-    clean!(gpgpu_100000);
-    clean!(gpgpu_1000000);
-    clean!(gpgpu_10000000);
-    clean!(gpgpu_100000000);
+    clean!(gpgpu_1_000);
+    clean!(gpgpu_10_000);
+    clean!(gpgpu_100_000);
+    clean!(gpgpu_1_000_000);
+    clean!(gpgpu_10_000_000);
+    clean!(gpgpu_100_000_000);
     Ok(())
 }
 
 run!(map_1);
 run!(map_10);
 run!(map_100);
-run!(map_1000);
-run!(map_10000);
-run!(map_100000);
-run!(map_1000000);
-run!(map_10000000);
-run!(map_100000000);
+run!(map_1_000);
+run!(map_10_000);
+run!(map_100_000);
+run!(map_1_000_000);
+run!(map_10_000_000);
+run!(map_100_000_000);
 run!(parmap_1);
 run!(parmap_10);
 run!(parmap_100);
-run!(parmap_1000);
-run!(parmap_10000);
-run!(parmap_100000);
-run!(parmap_1000000);
-run!(parmap_10000000);
-run!(parmap_100000000);
+run!(parmap_1_000);
+run!(parmap_10_000);
+run!(parmap_100_000);
+run!(parmap_1_000_000);
+run!(parmap_10_000_000);
+run!(parmap_100_000_000);
 run!(gpgpu_1);
 run!(gpgpu_10);
 run!(gpgpu_100);
-run!(gpgpu_1000);
-run!(gpgpu_10000);
-run!(gpgpu_100000);
-run!(gpgpu_1000000);
-run!(gpgpu_10000000);
-run!(gpgpu_100000000);
+run!(gpgpu_1_000);
+run!(gpgpu_10_000);
+run!(gpgpu_100_000);
+run!(gpgpu_1_000_000);
+run!(gpgpu_10_000_000);
+run!(gpgpu_100_000_000);

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -429,7 +429,7 @@ World!
     status 0;
 );
 
-// Event Tests
+// Exit Tests
 
 test!(normal_exit_code => r#"
     export fn main() -> ExitCode {
@@ -448,7 +448,9 @@ test!(non_global_memory_exit_code => r#"
     }"#;
     status 0;
 );
-test!(passing_ints_from_global_memory => r#"
+
+// Unorganized Tests (TODO: Find a better grouping for these)
+test!(passing_ints_to_function => r#"
     fn aNumber(num: i64) {
       print('I got a number! ' + num.string);
     }
@@ -457,6 +459,12 @@ test!(passing_ints_from_global_memory => r#"
       aNumber(5);
     }"#;
     stdout "I got a number! 5\n";
+    status 0;
+);
+test!(underscores_in_numbers => r#"
+    export fn main = print(1_000_000 * 2);
+"#;
+    stdout "2000000\n";
     status 0;
 );
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -366,14 +366,22 @@ build!(optsemicolon, zero_or_one!(semicolon));
 build!(at, token!("@"));
 build!(slash, token!("/"));
 // Validating charset
-build!(base10, charset!('0'..='9'));
+build!(base10, or!(charset!('0'..='9'), under));
 test!(base10 =>
     fail "";
     fail "a";
     pass "0" => "", "0";
     pass "00" => "0", "0";
+    pass "_" => "", "_";
 );
 build!(natural, one_or_more!(base10));
+test!(natural =>
+    fail "";
+    fail "a";
+    pass "0" => "", "0";
+    pass "00" => "", "00";
+    pass "1_000_000" => "", "1_000_000";
+);
 build!(integer, and!(zero_or_one!(negate), natural));
 build!(real, and!(integer, dot, natural));
 // Validating named_or

--- a/src/program.rs
+++ b/src/program.rs
@@ -2215,13 +2215,13 @@ fn typebaselist_to_ctype(
                         parse::Constants::Num(n) => match n {
                             parse::Number::RealNum(r) => {
                                 prior_value = Some(CType::Float(
-                                    r.parse::<f64>().unwrap(), // This should never fail if the
-                                                               // parser says it's a float
+                                    r.replace("_", "").parse::<f64>().unwrap(), // This should never fail if the
+                                                                                // parser says it's a float
                                 ))
                             }
                             parse::Number::IntNum(i) => {
                                 prior_value = Some(CType::Int(
-                                    i.parse::<i128>().unwrap(), // Same deal here
+                                    i.replace("_", "").parse::<i128>().unwrap(), // Same deal here
                                 ))
                             }
                         },


### PR DESCRIPTION
This has been a lower priority task, but finally implemented it. Still on the list for numbers: integer binary, octal, and hexadecimal, and float scientific notation.
