### PR TITLE
Implement the other integer syntaxes (binary, octal, hexadecimal)

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -467,6 +467,15 @@ test!(underscores_in_numbers => r#"
     stdout "2000000\n";
     status 0;
 );
+test!(other_integer_syntaxes => r#"
+    export fn main {
+      print(0b10 == 2);
+      print(0o10 == 8);
+      print(0x10 == 16);
+    }
+"#;
+    stdout "true\ntrue\ntrue\n";
+);
 
 // Printing Tests
 


### PR DESCRIPTION
They only support being positive numbers, since they're usually used in conjunction with the actual byte representation. I can probably support other kinds if necessary, but will avoid unless someone asks for it.
