### PR TITLE
Update the autopublish's repository-dispatch action

### DIFF
--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Autopublish Docs
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.AUTOPUBLISH }}
           repository: alantech/alanlang-docs
           event-type: autopublish
           client-payload: '{}'
       - name: Autopublish Homepage
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.AUTOPUBLISH }}
           repository: alantech/alanlang-homepage


### PR DESCRIPTION
I missed this in the last PR. There's no way to test it without merging, though, so we'll see if it works on the other side.
