### PR TITLE
Fix an off-by-one error in the workgroup creation caught by the Raspberry Pi

### DIFF
--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -2219,7 +2219,7 @@ fn GPGPU_new_easy<'a>(source: &mut String, buffer: &'a mut wgpu::Buffer) -> GPGP
     let y_div = z_rem / 65535;
     let y = y_div + 1;
     let y_rem = z_rem.wrapping_rem(65535);
-    let x = y_rem + 1;
+    let x = std::cmp::max(y_rem, 1);
     GPGPU::new(source.clone(), vec![vec![buffer]], [x, y, z])
 }
 


### PR DESCRIPTION
So the way it was working before would create 5 parallel tasks for an array of length 4. It worked in most of the drivers because they just *ignored* an out-of-bounds memory access, while the Raspberry Pi driver, for whatever reason (but good for me), instead does the modulus of the index into the array of memory, so the 5th access wrapped around to the first index and then performed 2 * 4 = 8 to store that into memory.

This fixes that, which fixes things on the Pi, and potentially improves performance (in case the GPU was entering some sort of error path on the other machines and then needing to recover from that) but I have zero evidence on that either way.
