### PR TITLE
Avoid benchmark optimization on ARM by actually using the output array

### DIFF
--- a/benches/bench.ln
+++ b/benches/bench.ln
@@ -6,10 +6,12 @@ fn bench(l: i64) {
   let v = filled(2.i32, l);
   v.length.print;
   let t1 = now();
-  v.map(double);
+  let v1 = v.map(double);
+  v1.length;
   t1.elapsed.print;
   let t2 = now();
-  v.parmap(double);
+  let v2 = v.parmap(double);
+  v2.length;
   t2.elapsed.print;
   let t3 = now();
   let g = GPU();
@@ -29,7 +31,8 @@ fn bench(l: i64) {
     }
   ", b);
   g.run(plan);
-  g.read(b);
+  let v3 = g.read(b);
+  v3.length;
   t3.elapsed.print;
 }
 
@@ -38,10 +41,12 @@ fn bench_billion {
   let v = filled(2.i32, 1_000_000_000);
   v.length.print;
   let t1 = now();
-  v.map(double);
+  let v1 = v.map(double);
+  v1.length;
   t1.elapsed.print;
   let t2 = now();
-  v.parmap(double);
+  let v2 = v.parmap(double);
+  v2.length;
   t2.elapsed.print;
   let v2 = filled(2.i32, 500_000_000);
   let t3 = now();
@@ -79,7 +84,8 @@ fn bench_billion {
     }
   ", b);
   g.run(plan);
-  g.read(b);
+  let v3 = g.read(b);
+  v3.length;
   t3.elapsed.print;
 }
 

--- a/benches/map.rs
+++ b/benches/map.rs
@@ -32,75 +32,75 @@ macro_rules! clean {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build!(map_1 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 1).map(double); }
+        export fn main { let v = filled(2, 1).map(double); v[0].print; }
     "#);
     build!(map_10 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 10).map(double); }
+        export fn main { let v = filled(2, 10).map(double); v[0].print; }
     "#);
     build!(map_100 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 100).map(double); }
+        export fn main { let v = filled(2, 100).map(double); v[0].print; }
     "#);
     build!(map_1_000 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 1_000).map(double); }
+        export fn main { let v = filled(2, 1_000).map(double); v[0].print; }
     "#);
     build!(map_10_000 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 10_000).map(double); }
+        export fn main { let v = filled(2, 10_000).map(double); v[0].print; }
     "#);
     build!(map_100_000 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 100_000).map(double); }
+        export fn main { let v = filled(2, 100_000).map(double); v[0].print; }
     "#);
     build!(map_1_000_000 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 1_000_000).map(double); }
+        export fn main { let v = filled(2, 1_000_000).map(double); v[0].print; }
     "#);
     build!(map_10_000_000 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 10_000_000).map(double); }
+        export fn main { let v = filled(2, 10_000_000).map(double); v[0].print; }
     "#);
     build!(map_100_000_000 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 100_000_000).map(double); }
+        export fn main { let v = filled(2, 100_000_000).map(double); v[0].print; }
     "#);
     build!(parmap_1 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 1).parmap(double); }
+        export fn main { let v = filled(2, 1).parmap(double); v[0].print; }
     "#);
     build!(parmap_10 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 10).parmap(double); }
+        export fn main { let v = filled(2, 10).parmap(double); v[0].print; }
     "#);
     build!(parmap_100 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 100).parmap(double); }
+        export fn main { let v = filled(2, 100).parmap(double); v[0].print; }
     "#);
     build!(parmap_1_000 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 1_000).parmap(double); }
+        export fn main { let v = filled(2, 1_000).parmap(double); v[0].print; }
     "#);
     build!(parmap_10_000 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 10_000).parmap(double); }
+        export fn main { let v = filled(2, 10_000).parmap(double); v[0].print; }
     "#);
     build!(parmap_100_000 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 100_000).parmap(double); }
+        export fn main { let v = filled(2, 100_000).parmap(double); v[0].print; }
     "#);
     build!(parmap_1_000_000 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 1_000_000).parmap(double); }
+        export fn main { let v = filled(2, 1_000_000).parmap(double); v[0].print; }
     "#);
     build!(parmap_10_000_000 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 10_000_000).parmap(double); }
+        export fn main { let v = filled(2, 10_000_000).parmap(double); v[0].print; }
     "#);
     build!(parmap_100_000_000 => r#"
         fn double(x: i64) -> i64 = x * 2;
-        export fn main { filled(2, 100_000_000).parmap(double); }
+        export fn main { let v = filled(2, 100_000_000).parmap(double); v[0].print; }
     "#);
     build!(gpgpu_1 => r#"
         export fn main {
@@ -121,7 +121,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          g.read(b);
+          let v = g.read(b);
+          v[0].print;
         }
     "#);
     build!(gpgpu_10 => r#"
@@ -143,7 +144,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          g.read(b);
+          let v = g.read(b);
+          v[0].print;
         }
     "#);
     build!(gpgpu_100 => r#"
@@ -165,7 +167,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          g.read(b);
+          let v = g.read(b);
+          v[0].print;
         }
     "#);
     build!(gpgpu_1_000 => r#"
@@ -187,7 +190,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          g.read(b);
+          let v = g.read(b);
+          v[0].print;
         }
     "#);
     build!(gpgpu_10_000 => r#"
@@ -209,7 +213,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          g.read(b);
+          let v = g.read(b);
+          v[0].print;
         }
     "#);
     build!(gpgpu_100_000 => r#"
@@ -231,7 +236,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          g.read(b);
+          let v = g.read(b);
+          v[0].print;
         }
     "#);
     build!(gpgpu_1_000_000 => r#"
@@ -253,7 +259,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          g.read(b);
+          let v = g.read(b);
+          v[0].print;
         }
     "#);
     build!(gpgpu_10_000_000 => r#"
@@ -275,7 +282,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          g.read(b);
+          let v = g.read(b);
+          v[0].print;
         }
     "#);
     build!(gpgpu_100_000_000 => r#"
@@ -297,7 +305,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          g.read(b);
+          let v = g.read(b);
+          v[0].print;
         }
     "#);
     divan::main();

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -396,8 +396,8 @@ export fn len(a: i64[]) -> i64 binds lenarray; // TODO: Real generics
 export fn len(a: string[]) -> i64 binds lenarray; // TODO: Real generics
 export fn push(a: Array{i64}, v: i64) -> () binds pusharray; // TODO: Real generics
 export fn push(a: Array{string}, v: string) -> () binds pusharray; // TODO: Real generics
-export fn pop(a: i64[]) -> Maybe{i64} binds poparray; // TODO: Real generics, not Option
-export fn pop(a: string[]) -> Maybe{string} binds poparray; // TODO: Real generics, not Option
+export fn pop(a: i64[]) -> Maybe{i64} binds poparray; // TODO: Real generics
+export fn pop(a: string[]) -> Maybe{string} binds poparray; // TODO: Real generics
 
 /// Process exit-related bindings
 export fn ExitCode(e: i8) -> ExitCode binds to_exit_code_i8;
@@ -432,6 +432,7 @@ export fn print(f: f64) binds println;
 export fn print(f: Result{f64}) binds println_result;
 export fn print(o: Maybe{string}) binds println_maybe; // TODO: Do this with real generics
 export fn print(o: Maybe{i64}) binds println_maybe;
+export fn print(o: Maybe{i32}) binds println_maybe;
 
 /// Thread-related bindings
 export fn wait(t: i64) binds wait;
@@ -454,6 +455,8 @@ export fn parmap(v: Vec{i32}, m: i32 -> i32) -> Vec{i32} binds parmap_onearg; //
 export fn push(v: Vec{i64}, a: i64) binds push;
 export fn length(v: Vec{i64}) -> i64 binds vec_len;
 export fn length(v: Vec{i32}) -> i64 binds vec_len;
+export fn get(v: Vec{i32}, i: i64) -> Maybe{i32} binds getarray;
+export fn get(v: Vec{i64}, i: i64) -> Maybe{i64} binds getarray;
 
 /// GPU-related bindings
 export type GPU binds GPU;


### PR DESCRIPTION
This was discovered on the Raspberry Pi 5 when the single threaded performance was unbelievably fast. This change prevents the compiler from removing the actual calculation steps because now the output is actually used.
