### PR TITLE
Fix benchmarks on windows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,10 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
-    runs-on: self-hosted
-
+  bench:
+    runs-on: [self-hosted, linux]
     steps:
     - uses: actions/checkout@v4
     - name: Build Alan
@@ -24,3 +22,12 @@ jobs:
       run: cargo run -- compile benches/bench.ln
     - name: Alan-managed Benchmarks
       run: ./bench
+
+  bench-windows:
+    runs-on: [self-hosted, windows]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build Alan
+      run: cargo build --verbose
+    - name: Rust-managed Benchmarks
+      run: cargo bench

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,15 +11,26 @@ env:
 
 jobs:
   test:
-
-    runs-on: self-hosted
-
+    runs-on: [self-hosted, linux]
     steps:
     - uses: actions/checkout@v4
     - name: Check lockfile is up to date
       run: cargo update --locked
     - name: Check formatting
       run: cargo fmt --check
+    - name: Build
+      run: cargo build --verbose
+    - if: ${{ github.ref_name == 'main' }}
+      name: Run tests
+      run: cargo test --verbose -- --include-ignored
+    - if: ${{ github.ref_name != 'main' }}
+      name: Run tests
+      run: cargo test --verbose
+
+  test-windows:
+    runs-on: [self-hosted, windows]
+    steps:
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
     - if: ${{ github.ref_name == 'main' }}

--- a/benches/map.rs
+++ b/benches/map.rs
@@ -23,7 +23,11 @@ macro_rules! run {
 macro_rules! clean {
     ( $name:ident ) => {
         let sourcefile = format!("{}.ln", stringify!($name));
-        let executable = format!("{}", stringify!($name));
+        let executable = if cfg!(windows) {
+            format!("{}.exe", stringify!($name))
+        } else {
+            format!("{}", stringify!($name))
+        };
         remove_file(&sourcefile)?;
         remove_file(&executable)?;
     };


### PR DESCRIPTION
Now that I have a little Intel NUC to use for testing Windows, I manually tested and noticed a small problem with the benchmarks. This should fix that and also enable testing with it. Since I have only one Windows machine, I have also trimmed the work done on Windows vs Linux to try and reduce an increase in latency. I have also forced the normal testing path to use Linux so it doesn't accidentally clog up the Windows machine's queue.
