### PR TITLE
Add testing for MacOS

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,3 +31,12 @@ jobs:
       run: cargo build --verbose
     - name: Rust-managed Benchmarks
       run: cargo bench
+
+  bench-macos:
+    runs-on: [self-hosted, macOS]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build Alan
+      run: cargo build --verbose
+    - name: Rust-managed Benchmarks
+      run: cargo bench

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,3 +39,16 @@ jobs:
     - if: ${{ github.ref_name != 'main' }}
       name: Run tests
       run: cargo test --verbose
+
+  test-macos:
+    runs-on: [self-hosted, macOS]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - if: ${{ github.ref_name == 'main' }}
+      name: Run tests
+      run: cargo test --verbose -- --include-ignored
+    - if: ${{ github.ref_name != 'main' }}
+      name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
I just got a used Mac Mini (x86-64, only a dual core Intel i5) so now I can do some validation that things work on MacOS, too.

I can spot check from time-to-time with my wife's M2 MacBook, but I'm not going to set up a runner on that.
