### PR TITLE
Set up ARM64 testing

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   bench:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, X64]
     steps:
     - uses: actions/checkout@v4
     - name: Build Alan
@@ -34,6 +34,15 @@ jobs:
 
   bench-macos:
     runs-on: [self-hosted, macOS]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build Alan
+      run: cargo build --verbose
+    - name: Rust-managed Benchmarks
+      run: cargo bench
+
+  bench-arm-linux:
+    runs-on: [self-hosted, linux, ARM64]
     steps:
     - uses: actions/checkout@v4
     - name: Build Alan

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test:
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, X64]
     steps:
     - uses: actions/checkout@v4
     - name: Check lockfile is up to date
@@ -42,6 +42,19 @@ jobs:
 
   test-macos:
     runs-on: [self-hosted, macOS]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - if: ${{ github.ref_name == 'main' }}
+      name: Run tests
+      run: cargo test --verbose -- --include-ignored
+    - if: ${{ github.ref_name != 'main' }}
+      name: Run tests
+      run: cargo test --verbose
+
+  test-arm-linux:
+    runs-on: [self-hosted, linux, ARM64]
     steps:
     - uses: actions/checkout@v4
     - name: Build


### PR DESCRIPTION
This gets the Raspberry Pi 5 involved in the CI. There's no RISC-V support for Github's Actions runner because there's no RISC-V support for .NET, which surprisingly is what the Actions runner is written in, so I'm not yet sure how I'm gonna involve my RISC-V SBC in the testing, yet.
