### PR TITLE
Buffer type syntax improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cfg-if"

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1623,7 +1623,8 @@ test!(conditional_compilation => r#"
     fn{true} bar = print(true);
     fn{false} bar = print(false);
 
-    type TestBuffer = Buffer{i64, 1 + 2 * 3};
+    // type TestBuffer = Buffer{i64, 1 + 2 * 3};
+    type TestBuffer = i64[1 + 2 * 3];
     // TODO: Have a generic version instead of binding here
     fn len(t: TestBuffer) -> i64 binds lenbuffer;
 

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -610,6 +610,10 @@ impl CType {
                 (anything, CType::Int(size)) => {
                     CType::Buffer(Box::new(anything.clone()), size as usize)
                 }
+                (anything, CType::Group(g)) => match *g {
+                    CType::Int(size) => CType::Buffer(Box::new(anything.clone()), size as usize),
+                    _ => CType::fail("The buffer size must be a positive integer"),
+                },
                 _ => CType::fail("The buffer size must be a positive integer"),
             }
         }

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -66,11 +66,11 @@ export type Debug = Eq{Env{"ALAN_TARGET"}, "debug"};
 
 // Defining the operators in the type system
 export type infix Function as -> precedence 2; // I -> O, where I is the input and O is the output. With Tuples and Fields you can reconstruct arguments for functions.
-export type infix Tuple as , precedence 1; // A, B, C, ... The tuple type combines with other tuple types to become a larger tuple type. To have a tuple of tuples, you need to `Group` the inner tuple, eg `(a, b), c`
+export type infix Tuple as , precedence 0; // A, B, C, ... The tuple type combines with other tuple types to become a larger tuple type. To have a tuple of tuples, you need to `Group` the inner tuple, eg `(a, b), c`
 export type infix Field as : precedence 3; // Foo: Bar, let's you specify a property access label for the type, useful for syntactic sugar on a tuple type and the Either type (eventually).
-export type infix Either as | precedence 1; // A | B, the type has a singular value from only one of the types at once. `Result` is just `Either{T, Error}` and `Option` is just `Either{T, ()}` (or `Either{T, void}`, however we want to represent it, also might go with `Fallible` and `Maybe` instead of `Result` and `Option` as those feel more descriptive of what they are.
-export type infix Buffer as [ precedence 4; // Technically allows `Foo[3` by itself to be valid syntax, but...
-export type postfix Group as ] precedence 4; // Technically not necessary, but allows for `Foo[3]` to do the "right thing" and become a buffer of size 3, with a singular useless Group being wrapped around it (and then unwrapped on type generation). The only "bad" thing here is `Group` gets special behavior, matching the `(...)` syntax, so there's two ways to invoke a Group via symbols.
+export type infix Either as | precedence 0; // A | B, the type has a singular value from only one of the types at once. `Result` is just `Either{T, Error}` and `Option` is just `Either{T, ()}` (or `Either{T, void}`, however we want to represent it, also might go with `Fallible` and `Maybe` instead of `Result` and `Option` as those feel more descriptive of what they are.
+export type infix Buffer as [ precedence 1; // Technically allows `Foo[3` by itself to be valid syntax, but...
+export type postfix Group as ] precedence 1; // Technically not necessary, but allows for `Foo[3]` to do the "right thing" and become a buffer of size 3, with a singular useless Group being wrapped around it (and then unwrapped on type generation). The only "bad" thing here is `Group` gets special behavior, matching the `(...)` syntax, so there's two ways to invoke a Group via symbols.
 export type postfix Array as [] precedence 4; // Allows `Foo[]` to do the right thing
 export type postfix Maybe as ? precedence 4; // Allows `Foo?` for nullable types. Should this have a precedence of 5?
 export type postfix Fallible as ! precedence 4; // Allows `Foo!` for fallible types. Same question on the precedence.


### PR DESCRIPTION
A minor change adjusting the precedence of the buffer and group operators, as well as adding some logic to handle groups a bit better within the buffer type (though on this, I am thinking of having a "strip groups" helper method that I use everywhere rather than dealing with them piecemeal like this).

While the Generic Type Function syntax is what everything is going to be internally, I want to push the Typescript-style type syntax as the standard way to write these things because I think it's more directly legible with the symbols interspersed with type names.
