### PR TITLE
Simplify the planned interface design

### DIFF
--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -201,7 +201,7 @@ impl Program {
             }
         }
         // The following is insanity to deal with the borrow checker. It could have been done
-        // withotu the temporary vector or the child scopes, but using a mutable reference in a
+        // without the temporary vector or the child scopes, but using a mutable reference in a
         // loop is a big no-no.
         let mut temp_scopes = Vec::new();
         for _ in &generic_fs {


### PR DESCRIPTION
Some groundwork for interfaces (but not implementing them, yet). With Alan v0.2, there's no distinction between properties and functions. Properties are just functions that return the sub-type for you. On top of that, with operators now only allowed to bind to a single function name, a special interface line type for operators is no longer necessary. This means that now interface lines are just function names and call signatures, which has been converted into *any* type you want, so a lot of special parsing logic can also disappear.
