### PR TITLE
Implement generic type inference

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -2344,8 +2344,8 @@ test_ignore!(closure_creation_and_usage => r#"
     }"#;
     stdout "1\n2\n1\n";
 );
-test_ignore!(closure_by_name => r#"
-    fn double(x: i64) -> i64 = x * 2 || 0;
+test!(closure_by_name => r#"
+    fn double(x: i64) -> i64 = x * 2;
 
     export fn main {
       const numbers = [1, 2, 3, 4, 5];
@@ -2463,7 +2463,7 @@ new Piece {
 
 // Module-level constants
 
-test_ignore!(module_level_constant => r#"
+test!(module_level_constant => r#"
     const helloWorld = 'Hello, World!';
 
     export fn main {
@@ -3424,7 +3424,7 @@ test_ignore!(subtree_and_nested_tree_construction => r#"
 
 // Error printing
 
-test_ignore!(eprint => r#"
+test!(eprint => r#"
     export fn main {
       eprint('This is an error');
     }"#;

--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -53,38 +53,61 @@ pub fn from_microstatement(
             }
             CType::Function(..) => {
                 // We need to make sure this function we're referencing exists
-                match scope.functions.get(representation) {
-                    Some(fns) => {
-                        let f = &fns[0]; // TODO: Proper implementation selection
-                        let mut arg_strs = Vec::new();
-                        for arg in &f.args {
-                            match typen::ctype_to_rtype(&arg.1, scope, program, false) {
-                                Err(e) => Err(e),
-                                Ok(s) => {
-                                    arg_strs.push(
-                                        s.replace("<", "_")
-                                            .replace(">", "_")
-                                            .replace(",", "_")
-                                            .replace(" ", ""),
-                                    );
-                                    /* TODO: Handle generic types better, also type inference */
-                                    Ok(())
+                let mut scope_to_check = Some(scope);
+                while scope_to_check.is_some() {
+                    match scope_to_check.unwrap().functions.get(representation) {
+                        Some(fns) => {
+                            let f = &fns[0]; // TODO: Proper implementation selection
+                            match &f.kind {
+                                FnKind::Normal
+                                | FnKind::Generic(..)
+                                | FnKind::Derived
+                                | FnKind::DerivedVariadic => {
+                                    let mut arg_strs = Vec::new();
+                                    for arg in &f.args {
+                                        match typen::ctype_to_rtype(&arg.1, scope, program, false) {
+                                            Err(e) => Err(e),
+                                            Ok(s) => {
+                                                arg_strs.push(
+                                                    s.replace("<", "_")
+                                                        .replace(">", "_")
+                                                        .replace(",", "_")
+                                                        .replace(" ", ""),
+                                                );
+                                                /* TODO: Handle generic types better, also type inference */
+                                                Ok(())
+                                            }
+                                        }?;
+                                    }
+                                    // Come up with a function name that is unique so Rust doesn't choke on
+                                    // duplicate function names that are allowed in Alan
+                                    let rustname =
+                                        format!("{}_{}", f.name, arg_strs.join("_")).to_string();
+                                    // Make the function we need, but with the name we're
+                                    out = generate(rustname.clone(), &f, scope, program, out)?;
+                                    return Ok((rustname, out));
                                 }
-                            }?;
+                                FnKind::Bind(rustname) | FnKind::BoundGeneric(_, rustname) => {
+                                    return Ok((rustname.clone(), out));
+                                }
+                            }
                         }
-                        // Come up with a function name that is unique so Rust doesn't choke on
-                        // duplicate function names that are allowed in Alan
-                        let rustname = format!("{}_{}", f.name, arg_strs.join("_")).to_string();
-                        // Make the function we need, but with the name we're
-                        out = generate(rustname.clone(), &f, scope, program, out)?;
-                        Ok((rustname, out))
+                        None => {
+                            scope_to_check = match &scope_to_check.unwrap().parent {
+                                Some(p) => match program.scopes_by_file.get(p) {
+                                    Some((_, _, s)) => Some(s),
+                                    None => None,
+                                },
+                                None => None,
+                            };
+                        }
                     }
-                    None => Err(format!(
-                        "Somehow can't find a definition for function {}",
-                        representation
-                    )
-                    .into()),
                 }
+                Err(format!(
+                    "Somehow can't find a definition for function {}",
+                    representation
+                )
+                .into())
             }
             _ => Ok((representation.clone(), out)),
         },
@@ -116,375 +139,369 @@ pub fn from_microstatement(
                     }
                 }?
             }
-            match program.resolve_function(scope, function, &arg_types) {
-                None => Err(format!(
-                    "Function {}({}) not found",
-                    function,
-                    arg_type_strs.join(", ")
-                )
-                .into()),
-                Some(f) => {
-                    match &f.kind {
-                        FnKind::Generic(..) | FnKind::BoundGeneric(..) => Err(
-                            "Generic functions should have been resolved before reaching here"
-                                .into(),
-                        ),
-                        FnKind::Normal => {
-                            let (_, o) = typen::generate(&f.rettype, scope, program, out)?;
-                            out = o;
-                            let mut arg_strs = Vec::new();
-                            for arg in &f.args {
-                                match typen::ctype_to_rtype(&arg.1, scope, program, false) {
-                                    Err(e) => Err(e),
-                                    Ok(s) => {
-                                        arg_strs.push(
-                                            s.replace("<", "_")
-                                                .replace(">", "_")
-                                                .replace(",", "_")
-                                                .replace(" ", ""),
-                                        );
-                                        /* TODO: Handle generic types better, also type inference */
-                                        Ok(())
-                                    }
-                                }?;
+            match &function.kind {
+                FnKind::Generic(..) | FnKind::BoundGeneric(..) => {
+                    Err("Generic functions should have been resolved before reaching here".into())
+                }
+                FnKind::Normal => {
+                    let (_, o) = typen::generate(&function.rettype, scope, program, out)?;
+                    out = o;
+                    let mut arg_strs = Vec::new();
+                    for arg in &function.args {
+                        match typen::ctype_to_rtype(&arg.1, scope, program, false) {
+                            Err(e) => Err(e),
+                            Ok(s) => {
+                                arg_strs.push(
+                                    s.replace("<", "_")
+                                        .replace(">", "_")
+                                        .replace(",", "_")
+                                        .replace(" ", ""),
+                                );
+                                /* TODO: Handle generic types better, also type inference */
+                                Ok(())
                             }
-                            // Come up with a function name that is unique so Rust doesn't choke on
-                            // duplicate function names that are allowed in Alan
-                            let rustname = format!("{}_{}", f.name, arg_strs.join("_")).to_string();
-                            // Make the function we need, but with the name we're
-                            out = generate(rustname.clone(), &f, scope, program, out)?;
-                            // Now call this function
-                            let mut argstrs = Vec::new();
-                            for arg in args {
-                                let (a, o) = from_microstatement(arg, scope, program, out)?;
-                                out = o;
-                                // If the argument is itself a function, this is the only place in Rust
-                                // where you can't pass by reference, so we check the type and change
-                                // the argument output accordingly.
-                                let arg_type = arg.get_type(scope, program)?;
-                                match arg_type {
-                                    CType::Function(..) => argstrs.push(format!("{}", a)),
-                                    _ => argstrs.push(format!("&mut {}", a)),
-                                }
-                            }
-                            Ok((
-                                format!("{}({})", rustname, argstrs.join(", ")).to_string(),
-                                out,
-                            ))
+                        }?;
+                    }
+                    // Come up with a function name that is unique so Rust doesn't choke on
+                    // duplicate function names that are allowed in Alan
+                    let rustname = format!("{}_{}", function.name, arg_strs.join("_")).to_string();
+                    // Make the function we need, but with the name we're
+                    out = generate(rustname.clone(), &function, scope, program, out)?;
+                    // Now call this function
+                    let mut argstrs = Vec::new();
+                    for arg in args {
+                        let (a, o) = from_microstatement(arg, scope, program, out)?;
+                        out = o;
+                        // If the argument is itself a function, this is the only place in Rust
+                        // where you can't pass by reference, so we check the type and change
+                        // the argument output accordingly.
+                        let arg_type = arg.get_type(scope, program)?;
+                        match arg_type {
+                            CType::Function(..) => argstrs.push(format!("{}", a)),
+                            _ => argstrs.push(format!("&mut {}", a)),
                         }
-                        FnKind::Bind(rustname) => {
-                            let mut argstrs = Vec::new();
-                            for arg in args {
-                                let (a, o) = from_microstatement(arg, scope, program, out)?;
-                                out = o;
-                                // If the argument is itself a function, this is the only place in Rust
-                                // where you can't pass by reference, so we check the type and change
-                                // the argument output accordingly.
-                                let arg_type = arg.get_type(scope, program)?;
-                                match arg_type {
-                                    CType::Function(..) => argstrs.push(format!("{}", a)),
-                                    _ => argstrs.push(format!("&mut {}", a)),
-                                }
-                            }
-                            Ok((
-                                format!("{}({})", rustname, argstrs.join(", ")).to_string(),
-                                out,
-                            ))
+                    }
+                    Ok((
+                        format!("{}({})", rustname, argstrs.join(", ")).to_string(),
+                        out,
+                    ))
+                }
+                FnKind::Bind(rustname) => {
+                    let mut argstrs = Vec::new();
+                    for arg in args {
+                        let (a, o) = from_microstatement(arg, scope, program, out)?;
+                        out = o;
+                        // If the argument is itself a function, this is the only place in Rust
+                        // where you can't pass by reference, so we check the type and change
+                        // the argument output accordingly.
+                        let arg_type = arg.get_type(scope, program)?;
+                        match arg_type {
+                            CType::Function(..) => argstrs.push(format!("{}", a)),
+                            _ => argstrs.push(format!("&mut {}", a)),
                         }
-                        FnKind::Derived | FnKind::DerivedVariadic => {
-                            // The initial work to get the values to construct the type is the same as
-                            // with bound functions, though.
-                            let (_, o) = typen::generate(&f.rettype, scope, program, out)?;
-                            out = o;
-                            let mut argstrs = Vec::new();
-                            for arg in args {
-                                let (a, o) = from_microstatement(arg, scope, program, out)?;
-                                out = o;
-                                // If the argument is itself a function, this is the only place in Rust
-                                // where you can't pass by reference, so we check the type and change
-                                // the argument output accordingly.
-                                let arg_type = arg.get_type(scope, program)?;
-                                match arg_type {
-                                    CType::Function(..) => argstrs.push(format!("{}", a)),
-                                    _ => argstrs.push(format!("&mut {}", a)),
-                                }
-                            }
-                            // The behavior of the generated code depends on the structure of the
-                            // return type and the input types. We also do some logic based on the name
-                            // of the function.
-                            // 1) If the name of the function matches the name of return type, it's a
-                            //    constructor function, and will interpret the arguments in different
-                            //    ways:
-                            //    a) If the return type is a Buffer, the arg count must be either the
-                            //       size of the buffer with all args having the same type *or* it must
-                            //       be exactly 1, with the arg matching the buffer's primary type that
-                            //       the buffer will be filled with. In case someone creates a
-                            //       one-element buffer, well, those two definitions are the same so it
-                            //       will use the first implementation (as it will be faster).
-                            //    b) If the return type is an Array, any number of values can be
-                            //       provided and it will pre-populate the array with those values.
-                            //    c) If the return type is an Either, it will expect only *one*
-                            //       argument, and fail otherwise. The argument needs to be one of the
-                            //       possibilities, which it will then put into the correct enum. An
-                            //       earlier stage of the compiler should have generated function
-                            //       definitions for each type in the Either.
-                            //    d) If the return type is a tuple type, each argument of the function
-                            //       needs to match, in the same order, the tuple's types. It doesn't
-                            //       matter if the type itself has fields with names, those are ignored
-                            //       and they're all turned into tuples.
-                            //    e) If the return type is a group type or "type" type, it's unwrapped
-                            //       and checked if it is one of the types above.
-                            //    f) If it's any other type, it's a compiler error. There's no way to
-                            //       derive an implementation for them that would be sensical.
-                            // 2) If the input type is a tuple and the name of the function matches the
-                            //    name of a field in the tuple, it's an accessor function.
-                            // 3) If the input type is an either and the name of the function matches
-                            //    the name of a sub-type, it returns a Maybe{T} for the type in
-                            //    question. (This conflicts with (1) so it's checked first.)
-                            // 4) If the name of the function is `get` write a getter function for the
-                            //    first argument type in question.
-                            // 5) If the name of the function is `set` write a setter function for the
-                            //    first argument type in question. TODO: Do this path.
-                            if &f.name == "get" && f.args.len() == 2 {
-                                let first_type = &f.args[0].1;
-                                let second_type = &f.args[1].1;
-                                match (first_type, second_type, &f.rettype) {
-                                    (CType::Type(_, a), CType::Bound(i, _), CType::Type(_, r))
-                                        if i == "i64" =>
-                                    {
-                                        match (*a.clone(), *r.clone()) {
-                                            (CType::Array(_), CType::Either(ts))
-                                                if ts.len() == 2 =>
-                                            {
-                                                return Ok((
-                                                    format!(
-                                                        "{}.get({})",
-                                                        argstrs[0],
-                                                        match argstrs[1].strip_prefix("&mut ") {
-                                                            Some(s) => s,
-                                                            None => &argstrs[1],
-                                                        }
-                                                    ),
-                                                    out,
-                                                ));
-                                                // TODO: Someday revive something like this, but for
-                                                // now we are using Option, so it's much simpler
-                                                // return Ok((format!("match {}.get({}) {{ Some(v) => {}::{}(v), None => {}::void }}", argstrs[0], argstrs[1], n, ts[0].to_string(), n), out));
-                                            }
-                                            _ => {} // Just fall through
-                                        }
+                    }
+                    Ok((
+                        format!("{}({})", rustname, argstrs.join(", ")).to_string(),
+                        out,
+                    ))
+                }
+                FnKind::Derived | FnKind::DerivedVariadic => {
+                    // The initial work to get the values to construct the type is the same as
+                    // with bound functions, though.
+                    let (_, o) = typen::generate(&function.rettype, scope, program, out)?;
+                    out = o;
+                    let mut argstrs = Vec::new();
+                    for arg in args {
+                        let (a, o) = from_microstatement(arg, scope, program, out)?;
+                        out = o;
+                        // If the argument is itself a function, this is the only place in Rust
+                        // where you can't pass by reference, so we check the type and change
+                        // the argument output accordingly.
+                        let arg_type = arg.get_type(scope, program)?;
+                        match arg_type {
+                            CType::Function(..) => argstrs.push(format!("{}", a)),
+                            _ => argstrs.push(format!("&mut {}", a)),
+                        }
+                    }
+                    // The behavior of the generated code depends on the structure of the
+                    // return type and the input types. We also do some logic based on the name
+                    // of the function.
+                    // 1) If the name of the function matches the name of return type, it's a
+                    //    constructor function, and will interpret the arguments in different
+                    //    ways:
+                    //    a) If the return type is a Buffer, the arg count must be either the
+                    //       size of the buffer with all args having the same type *or* it must
+                    //       be exactly 1, with the arg matching the buffer's primary type that
+                    //       the buffer will be filled with. In case someone creates a
+                    //       one-element buffer, well, those two definitions are the same so it
+                    //       will use the first implementation (as it will be faster).
+                    //    b) If the return type is an Array, any number of values can be
+                    //       provided and it will pre-populate the array with those values.
+                    //    c) If the return type is an Either, it will expect only *one*
+                    //       argument, and fail otherwise. The argument needs to be one of the
+                    //       possibilities, which it will then put into the correct enum. An
+                    //       earlier stage of the compiler should have generated function
+                    //       definitions for each type in the Either.
+                    //    d) If the return type is a tuple type, each argument of the function
+                    //       needs to match, in the same order, the tuple's types. It doesn't
+                    //       matter if the type itself has fields with names, those are ignored
+                    //       and they're all turned into tuples.
+                    //    e) If the return type is a group type or "type" type, it's unwrapped
+                    //       and checked if it is one of the types above.
+                    //    f) If it's any other type, it's a compiler error. There's no way to
+                    //       derive an implementation for them that would be sensical.
+                    // 2) If the input type is a tuple and the name of the function matches the
+                    //    name of a field in the tuple, it's an accessor function.
+                    // 3) If the input type is an either and the name of the function matches
+                    //    the name of a sub-type, it returns a Maybe{T} for the type in
+                    //    question. (This conflicts with (1) so it's checked first.)
+                    // 4) If the name of the function is `get` write a getter function for the
+                    //    first argument type in question.
+                    // 5) If the name of the function is `set` write a setter function for the
+                    //    first argument type in question. TODO: Do this path.
+                    if &function.name == "get" && function.args.len() == 2 {
+                        let first_type = &function.args[0].1;
+                        let second_type = &function.args[1].1;
+                        match (first_type, second_type, &function.rettype) {
+                            (CType::Type(_, a), CType::Bound(i, _), CType::Type(_, r))
+                                if i == "i64" =>
+                            {
+                                match (*a.clone(), *r.clone()) {
+                                    (CType::Array(_), CType::Either(ts)) if ts.len() == 2 => {
+                                        return Ok((
+                                            format!(
+                                                "{}.get({})",
+                                                argstrs[0],
+                                                match argstrs[1].strip_prefix("&mut ") {
+                                                    Some(s) => s,
+                                                    None => &argstrs[1],
+                                                }
+                                            ),
+                                            out,
+                                        ));
+                                        // TODO: Someday revive something like this, but for
+                                        // now we are using Option, so it's much simpler
+                                        // return Ok((format!("match {}.get({}) {{ Some(v) => {}::{}(v), None => {}::void }}", argstrs[0], argstrs[1], n, ts[0].to_string(), n), out));
                                     }
                                     _ => {} // Just fall through
                                 }
                             }
-                            if f.args.len() == 1 {
-                                // This is a wacky unwrapping logic...
-                                let mut input_type = &f.args[0].1;
-                                while match input_type {
-                                    CType::Type(..) => true,
-                                    CType::Group(_) => true,
+                            _ => {} // Just fall through
+                        }
+                    }
+                    if function.args.len() == 1 {
+                        // This is a wacky unwrapping logic...
+                        let mut input_type = &function.args[0].1;
+                        while match input_type {
+                            CType::Type(..) => true,
+                            CType::Group(_) => true,
+                            _ => false,
+                        } {
+                            input_type = match input_type {
+                                CType::Type(_, t) => t,
+                                CType::Group(t) => t,
+                                t => t,
+                            };
+                        }
+                        match input_type {
+                            CType::Tuple(ts) => {
+                                let accessor_field = ts.iter().enumerate().find(|(_, t)| match t {
+                                    CType::Field(n, _) => *n == function.name,
                                     _ => false,
-                                } {
-                                    input_type = match input_type {
-                                        CType::Type(_, t) => t,
-                                        CType::Group(t) => t,
-                                        t => t,
-                                    };
-                                }
-                                match input_type {
-                                    CType::Tuple(ts) => {
-                                        let accessor_field =
-                                            ts.iter().enumerate().find(|(_, t)| match t {
-                                                CType::Field(n, _) => *n == f.name,
-                                                _ => false,
-                                            });
-                                        match accessor_field {
-                                            Some((i, _)) => {
-                                                return Ok((format!("{}.{}", argstrs[0], i), out));
-                                            }
-                                            None => {} // Fall through main checking logic
-                                        }
+                                });
+                                match accessor_field {
+                                    Some((i, _)) => {
+                                        return Ok((format!("{}.{}", argstrs[0], i), out));
                                     }
-                                    CType::Either(ts) => {
-                                        // The kinds of types allowed here are `Type`, `Bound`, and
-                                        // `ResolvedBoundGeneric`, and `Field`. Other types don't have
-                                        // a string name we can match against the function name
-                                        let accessor_field = ts.iter().find(|t| match t {
-                                            CType::Field(n, _) => *n == f.name,
-                                            CType::Type(n, _) => *n == f.name,
-                                            CType::Bound(n, _) => *n == f.name,
-                                            CType::ResolvedBoundGeneric(n, ..) => *n == f.name,
-                                            _ => false,
-                                        });
-                                        // We're assuming the enum sub-type naming scheme also follows
-                                        // the convention of matching the type name or field name,
-                                        // which works because we're generating all of the code that
-                                        // defines the enums. We also need the name of the enum for
-                                        // this to work, so we're assuming we got it from the first
-                                        // function argument. We blow up here if the first argument is
-                                        // *not* a Type we can get an enum name from (it *shouldn't* be
-                                        // possible, but..)
-                                        let enum_type = f.args[0].1.degroup();
-                                        let enum_name = enum_type.to_callable_string();
-                                        // We pass through to the main path if we can't find a matching
-                                        // name
-                                        if let Some(_) = accessor_field {
-                                            return Ok((format!("(match {} {{ {}::{}(v) => Some(v), _ => None }})", argstrs[0], enum_name, f.name), out));
-                                        }
-                                    }
-                                    _ => {}
+                                    None => {} // Fall through main checking logic
                                 }
                             }
-                            let ret_type = &f.rettype.degroup();
-                            let ret_name = ret_type.to_callable_string();
-                            if f.name == ret_name {
-                                let inner_ret_type = match ret_type {
-                                    CType::Field(_, t) => *t.clone(),
-                                    CType::Type(_, t) => *t.clone(),
-                                    t => t.clone(),
-                                };
-                                match inner_ret_type {
-                                    CType::Buffer(_, s) => {
-                                        if argstrs.len() == s {
-                                            return Ok((format!("[{}]", argstrs.join(", ")), out));
-                                        } else if argstrs.len() == 1 {
+                            CType::Either(ts) => {
+                                // The kinds of types allowed here are `Type`, `Bound`, and
+                                // `ResolvedBoundGeneric`, and `Field`. Other types don't have
+                                // a string name we can match against the function name
+                                let accessor_field = ts.iter().find(|t| match t {
+                                    CType::Field(n, _) => *n == function.name,
+                                    CType::Type(n, _) => *n == function.name,
+                                    CType::Bound(n, _) => *n == function.name,
+                                    CType::ResolvedBoundGeneric(n, ..) => *n == function.name,
+                                    _ => false,
+                                });
+                                // We're assuming the enum sub-type naming scheme also follows
+                                // the convention of matching the type name or field name,
+                                // which works because we're generating all of the code that
+                                // defines the enums. We also need the name of the enum for
+                                // this to work, so we're assuming we got it from the first
+                                // function argument. We blow up here if the first argument is
+                                // *not* a Type we can get an enum name from (it *shouldn't* be
+                                // possible, but..)
+                                let enum_type = function.args[0].1.degroup();
+                                let enum_name = enum_type.to_callable_string();
+                                // We pass through to the main path if we can't find a matching
+                                // name
+                                if let Some(_) = accessor_field {
+                                    return Ok((
+                                        format!(
+                                            "(match {} {{ {}::{}(v) => Some(v), _ => None }})",
+                                            argstrs[0], enum_name, function.name
+                                        ),
+                                        out,
+                                    ));
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    let ret_type = &function.rettype.degroup();
+                    let ret_name = ret_type.to_callable_string();
+                    if function.name == ret_name {
+                        let inner_ret_type = match ret_type {
+                            CType::Field(_, t) => *t.clone(),
+                            CType::Type(_, t) => *t.clone(),
+                            t => t.clone(),
+                        };
+                        match inner_ret_type {
+                            CType::Buffer(_, s) => {
+                                if argstrs.len() == s {
+                                    return Ok((format!("[{}]", argstrs.join(", ")), out));
+                                } else if argstrs.len() == 1 {
+                                    return Ok((
+                                        format!(
+                                            "[{};{}]",
+                                            match argstrs[0].strip_prefix("&mut ") {
+                                                Some(v) => v,
+                                                None => &argstrs[0],
+                                            },
+                                            s
+                                        ),
+                                        out,
+                                    ));
+                                } else {
+                                    return Err(format!("Invalid arguments {} provided for Buffer constructor function, must be either 1 element to fill, or the full size of the buffer", argstrs.join(", ")).into());
+                                }
+                            }
+                            CType::Array(_) => {
+                                return Ok((
+                                    format!(
+                                        "vec![{}]",
+                                        argstrs
+                                            .iter()
+                                            .map(|a| match a.strip_prefix("&mut ") {
+                                                Some(v) => v.to_string(),
+                                                None => a.clone(),
+                                            })
+                                            .collect::<Vec<String>>()
+                                            .join(", ")
+                                    ),
+                                    out,
+                                ));
+                            }
+                            CType::Either(ts) => {
+                                if argstrs.len() != 1 {
+                                    return Err(format!("Invalid arguments {} provided for Either constructor function, must be only one argument", argstrs.join(", ")).into());
+                                }
+                                let enum_type = &function.args[0].1.degroup();
+                                let enum_name = match enum_type {
+                                CType::Field(n, _) => Ok(n.clone()),
+                                CType::Type(n, _) => Ok(n.clone()),
+                                CType::Bound(n, _) => Ok(n.clone()),
+                                CType::ResolvedBoundGeneric(n, ..) => Ok(n.clone()),
+                                _ => Err(format!("Cannot generate an constructor function for {} type as the input type has no name?", function.name)),
+                            }?;
+                                for t in ts {
+                                    let inner_type = t.degroup();
+                                    match &inner_type {
+                                        CType::Field(n, _) if *n == enum_name => {
                                             return Ok((
                                                 format!(
-                                                    "[{};{}]",
+                                                    "{}::{}({})",
+                                                    function.name,
+                                                    enum_name,
                                                     match argstrs[0].strip_prefix("&mut ") {
-                                                        Some(v) => v,
+                                                        Some(s) => s,
                                                         None => &argstrs[0],
                                                     },
-                                                    s
                                                 ),
                                                 out,
                                             ));
-                                        } else {
-                                            return Err(format!("Invalid arguments {} provided for Buffer constructor function, must be either 1 element to fill, or the full size of the buffer", argstrs.join(", ")).into());
                                         }
-                                    }
-                                    CType::Array(_) => {
-                                        return Ok((
-                                            format!(
-                                                "vec![{}]",
-                                                argstrs
-                                                    .iter()
-                                                    .map(|a| match a.strip_prefix("&mut ") {
-                                                        Some(v) => v.to_string(),
-                                                        None => a.clone(),
-                                                    })
-                                                    .collect::<Vec<String>>()
-                                                    .join(", ")
-                                            ),
-                                            out,
-                                        ));
-                                    }
-                                    CType::Either(ts) => {
-                                        if argstrs.len() != 1 {
-                                            return Err(format!("Invalid arguments {} provided for Either constructor function, must be only one argument", argstrs.join(", ")).into());
+                                        CType::Type(n, _) if *n == enum_name => {
+                                            return Ok((
+                                                format!(
+                                                    "{}::{}({})",
+                                                    function.name,
+                                                    enum_name,
+                                                    match argstrs[0].strip_prefix("&mut ") {
+                                                        Some(s) => s,
+                                                        None => &argstrs[0],
+                                                    },
+                                                ),
+                                                out,
+                                            ));
                                         }
-                                        let enum_type = &f.args[0].1.degroup();
-                                        let enum_name = match enum_type {
-                                        CType::Field(n, _) => Ok(n.clone()),
-                                        CType::Type(n, _) => Ok(n.clone()),
-                                        CType::Bound(n, _) => Ok(n.clone()),
-                                        CType::ResolvedBoundGeneric(n, ..) => Ok(n.clone()),
-                                        _ => Err(format!("Cannot generate an constructor function for {} type as the input type has no name?", f.name)),
-                                    }?;
-                                        for t in ts {
-                                            let inner_type = t.degroup();
-                                            match &inner_type {
-                                                CType::Field(n, _) if *n == enum_name => {
-                                                    return Ok((
-                                                        format!(
-                                                            "{}::{}({})",
-                                                            f.name,
-                                                            enum_name,
-                                                            match argstrs[0].strip_prefix("&mut ") {
-                                                                Some(s) => s,
-                                                                None => &argstrs[0],
-                                                            },
-                                                        ),
-                                                        out,
-                                                    ));
-                                                }
-                                                CType::Type(n, _) if *n == enum_name => {
-                                                    return Ok((
-                                                        format!(
-                                                            "{}::{}({})",
-                                                            f.name,
-                                                            enum_name,
-                                                            match argstrs[0].strip_prefix("&mut ") {
-                                                                Some(s) => s,
-                                                                None => &argstrs[0],
-                                                            },
-                                                        ),
-                                                        out,
-                                                    ));
-                                                }
-                                                CType::Bound(n, _) if *n == enum_name => {
-                                                    return Ok((
-                                                        format!(
-                                                            "{}::{}({})",
-                                                            f.name,
-                                                            enum_name,
-                                                            match argstrs[0].strip_prefix("&mut ") {
-                                                                Some(s) => s,
-                                                                None => &argstrs[0],
-                                                            },
-                                                        ),
-                                                        out,
-                                                    ));
-                                                }
-                                                CType::ResolvedBoundGeneric(n, ..)
-                                                    if *n == enum_name =>
-                                                {
-                                                    return Ok((
-                                                        format!(
-                                                            "{}::{}({})",
-                                                            f.name,
-                                                            enum_name,
-                                                            match argstrs[0].strip_prefix("&mut ") {
-                                                                Some(s) => s,
-                                                                None => &argstrs[0],
-                                                            },
-                                                        ),
-                                                        out,
-                                                    ));
-                                                }
-                                                _ => {}
-                                            }
+                                        CType::Bound(n, _) if *n == enum_name => {
+                                            return Ok((
+                                                format!(
+                                                    "{}::{}({})",
+                                                    function.name,
+                                                    enum_name,
+                                                    match argstrs[0].strip_prefix("&mut ") {
+                                                        Some(s) => s,
+                                                        None => &argstrs[0],
+                                                    },
+                                                ),
+                                                out,
+                                            ));
                                         }
-                                        return Err(format!("Cannot generate a constructor function for {} type as it is not part of the {} type", enum_name, f.name).into());
-                                    }
-                                    CType::Tuple(ts) => {
-                                        // TODO: Better type checking here, but it's *probably* being
-                                        // done at a higher layer
-                                        if argstrs.len() == ts.len() {
-                                            return Ok((format!("({})", argstrs.join(", ")), out));
-                                        } else {
-                                            return Err(format!(
-                                                "{} has {} fields but {} provided",
-                                                f.name,
-                                                ts.len(),
-                                                argstrs.len()
-                                            )
-                                            .into());
+                                        CType::ResolvedBoundGeneric(n, ..) if *n == enum_name => {
+                                            return Ok((
+                                                format!(
+                                                    "{}::{}({})",
+                                                    function.name,
+                                                    enum_name,
+                                                    match argstrs[0].strip_prefix("&mut ") {
+                                                        Some(s) => s,
+                                                        None => &argstrs[0],
+                                                    },
+                                                ),
+                                                out,
+                                            ));
                                         }
-                                    }
-                                    CType::Bound(_, _) => {
-                                        // TODO: Is this the right thing to do for aliases to bound
-                                        // types in all cases?
-                                        return Ok((format!("{}", argstrs.join(", ")), out));
-                                    }
-                                    otherwise => {
-                                        return Err(format!("How did you get here? Trying to create a constructor function for {:?}", otherwise).into());
+                                        _ => {}
                                     }
                                 }
+                                return Err(format!("Cannot generate a constructor function for {} type as it is not part of the {} type", enum_name, function.name).into());
                             }
-                            Err(format!("Trying to create an automatic function for {} but the return type is {}", f.name, ret_name).into())
+                            CType::Tuple(ts) => {
+                                // TODO: Better type checking here, but it's *probably* being
+                                // done at a higher layer
+                                if argstrs.len() == ts.len() {
+                                    return Ok((format!("({})", argstrs.join(", ")), out));
+                                } else {
+                                    return Err(format!(
+                                        "{} has {} fields but {} provided",
+                                        function.name,
+                                        ts.len(),
+                                        argstrs.len()
+                                    )
+                                    .into());
+                                }
+                            }
+                            CType::Bound(_, _) => {
+                                // TODO: Is this the right thing to do for aliases to bound
+                                // types in all cases?
+                                return Ok((format!("{}", argstrs.join(", ")), out));
+                            }
+                            otherwise => {
+                                return Err(format!("How did you get here? Trying to create a constructor function for {:?}", otherwise).into());
+                            }
                         }
                     }
+                    Err(format!(
+                        "Trying to create an automatic function for {} but the return type is {}",
+                        function.name, ret_name
+                    )
+                    .into())
                 }
             }
         }

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -11,7 +11,7 @@ pub fn ctype_to_rtype(
 ) -> Result<String, Box<dyn std::error::Error>> {
     match ctype {
         CType::Void => Ok("void".to_string()),
-        CType::Infer(s) => Err(format!(
+        CType::Infer(s, _) => Err(format!(
             "Inferred type matching {} was not realized before code generation",
             s
         )

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -337,6 +337,14 @@ impl CType {
                         arg.push(&*g1);
                         input.push(&*g2);
                     }
+                    (Some(CType::Group(g1)), Some(b)) => {
+                        arg.push(&*g1);
+                        input.push(b);
+                    }
+                    (Some(a), Some(CType::Group(g2))) => {
+                        arg.push(a);
+                        input.push(&*g2);
+                    }
                     (Some(CType::Function(i1, o1)), Some(CType::Function(i2, o2))) => {
                         arg.push(&*i1);
                         arg.push(&*o1);

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use ordered_hash_map::{OrderedHashMap, OrderedHashSet};
 
 use super::Export;
 use super::FnKind;
@@ -11,7 +11,7 @@ use crate::parse;
 #[derive(Clone, Debug, PartialEq)]
 pub enum CType {
     Void,
-    Infer(String), // TODO: Switch to an Interface here once they exist
+    Infer(String, String), // TODO: Switch to an Interface here once they exist
     Type(String, Box<CType>),
     Generic(String, Vec<String>, Vec<parse::WithTypeOperators>),
     Bound(String, String),
@@ -38,7 +38,7 @@ impl CType {
     pub fn to_strict_string(&self, strict: bool) -> String {
         match self {
             CType::Void => "()".to_string(),
-            CType::Infer(s) => s.clone(), // TODO: Replace this
+            CType::Infer(s, _) => s.clone(), // TODO: Replace this
             CType::Type(n, t) => match strict {
                 true => format!("{}", n),
                 false => t.to_strict_string(strict),
@@ -99,7 +99,7 @@ impl CType {
     pub fn to_functional_string(&self) -> String {
         match self {
             CType::Void => "void".to_string(),
-            CType::Infer(s) => s.clone(), // TODO: What to do here?
+            CType::Infer(s, _) => s.clone(), // TODO: What to do here?
             CType::Type(_, t) => t.to_functional_string(),
             CType::Generic(n, gs, _) => format!("{}{{{}}}", n, gs.join(", ")),
             CType::Bound(_, b) => b.clone(),
@@ -163,7 +163,7 @@ impl CType {
     pub fn degroup(&self) -> CType {
         match self {
             CType::Void => CType::Void,
-            CType::Infer(s) => CType::Infer(s.clone()),
+            CType::Infer(s, i) => CType::Infer(s.clone(), i.clone()),
             CType::Type(n, t) => CType::Type(n.clone(), Box::new((*t).degroup())),
             CType::Generic(n, gs, wtos) => CType::Generic(n.clone(), gs.clone(), wtos.clone()),
             CType::Bound(n, b) => CType::Bound(n.clone(), b.clone()),
@@ -193,6 +193,267 @@ impl CType {
             CType::Buffer(t, s) => CType::Buffer(Box::new((*t).degroup()), *s),
             CType::Array(t) => CType::Array(Box::new((*t).degroup())),
         }
+    }
+    // Given a list of generic type names, a list of argument types provided, and the original type
+    // ast of the function, we can infer the generic type mappings by creating a temporary child
+    // scope, creating `Infer` CTypes for each generic name and parsing the type ast inside of that
+    // scope, then for each input record for the function traverse the tree of the input argument
+    // type *and* the created CType tree of the same argument index and we can either error out if
+    // they don't match, or reach the `Infer` type on the new tree and assign the corresponding
+    // sub-tree of the provided type to the generic in question. If we get a sub-tree for all
+    // generic type names, we succeed, otherwise we have to fail on being unable to resolve
+    // specific generics.
+    pub fn infer_generics(
+        scope: &Scope,
+        generics: &Vec<(String, CType)>,
+        fn_args: &Vec<(String, CType)>,
+        call_args: &Vec<CType>,
+    ) -> Result<Vec<CType>, Box<dyn std::error::Error>> {
+        let mut temp_scope = scope.temp_child();
+        for (generic_name, generic_type) in generics {
+            temp_scope
+                .types
+                .insert(generic_name.clone(), generic_type.clone());
+        }
+        let input_types = fn_args
+            .iter()
+            .map(|(_, t)| t.clone())
+            .collect::<Vec<CType>>();
+        let mut generic_types = OrderedHashMap::new();
+        for (a, i) in call_args.iter().zip(input_types.iter()) {
+            let mut arg = vec![a];
+            let mut input = vec![i];
+            while arg.len() > 0 {
+                let a = arg.pop();
+                let i = input.pop();
+                match (a, i) {
+                    (Some(CType::Void), Some(CType::Void)) => { /* Do nothing */ }
+                    (Some(CType::Infer(s, _)), _) => {
+                        return Err(format!(
+                            "While attempting to infer {} but found an inference type for {} somehow",
+                            generics.iter().map(|(n, _)| n.as_str()).collect::<Vec<&str>>().join(", "),
+                            s
+                        )
+                        .into());
+                    }
+                    (Some(CType::Type(_, t1)), Some(CType::Type(_, t2))) => {
+                        arg.push(t1);
+                        input.push(t2);
+                    }
+                    (Some(CType::Type(_, t1)), Some(b)) => {
+                        arg.push(t1);
+                        input.push(b);
+                    }
+                    (Some(a), Some(CType::Type(_, t2))) => {
+                        arg.push(a);
+                        input.push(t2);
+                    }
+                    (Some(CType::Generic(..)), _) => {
+                        return Err(format!(
+                            "Ran into an unresolved generic in the arguments list: {:?}",
+                            arg
+                        )
+                        .into());
+                    }
+                    (Some(CType::Bound(n1, b1)), Some(CType::Bound(n2, b2))) => {
+                        if !(n1 == n2 && b1 == b2) {
+                            return Err(format!(
+                                "Mismatched bound types {} -> {} and {} -> {} during inference",
+                                n1, b1, n2, b2
+                            )
+                            .into());
+                        }
+                    }
+                    (
+                        Some(CType::BoundGeneric(n1, gs1, b1)),
+                        Some(CType::BoundGeneric(n2, gs2, b2)),
+                    ) => {
+                        if !(n1 == n2 && b1 == b2 && gs1.len() == gs2.len()) {
+                            // TODO: Better generic arg matching
+                            return Err(format!("Mismatched bound generic types {}{{{}}} -> {} and {}{{{}}} -> {} during inference", n1, gs1.join(", "), b1, n2, gs2.join(", "), b2).into());
+                        }
+                    }
+                    (
+                        Some(CType::ResolvedBoundGeneric(n1, gs1, ts1, b1)),
+                        Some(CType::ResolvedBoundGeneric(n2, gs2, ts2, b2)),
+                    ) => {
+                        if !(n1 == n2 && b1 == b2 && gs1.len() == gs2.len()) {
+                            // TODO: Better generic arg matching
+                            return Err(format!("Mismatched resolved bound generic types {}{{{}}} -> {} and {}{{{}}} -> {} during inference", n1, gs1.join(", "), b1, n2, gs2.join(", "), b2).into());
+                        }
+                        // Enqueue the bound types for checking purposes
+                        for t1 in ts1 {
+                            arg.push(&t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(&t2);
+                        }
+                    }
+                    (
+                        Some(CType::IntrinsicGeneric(n1, s1)),
+                        Some(CType::IntrinsicGeneric(n2, s2)),
+                    ) => {
+                        if !(n1 == n2 && s1 == s2) {
+                            return Err(format!(
+                                "Mismatched generics {} and {} during inference",
+                                n1, n2
+                            )
+                            .into());
+                        }
+                    }
+                    (Some(CType::Int(i1)), Some(CType::Int(i2))) => {
+                        if i1 != i2 {
+                            return Err(format!(
+                                "Mismatched integers {} and {} during inference",
+                                i1, i2
+                            )
+                            .into());
+                        }
+                    }
+                    (Some(CType::Float(f1)), Some(CType::Float(f2))) => {
+                        if f1 != f2 {
+                            return Err(format!(
+                                "Mismatched floats {} and {} during inference",
+                                f1, f2
+                            )
+                            .into());
+                        }
+                    }
+                    (Some(CType::Bool(b1)), Some(CType::Bool(b2))) => {
+                        if b1 != b2 {
+                            return Err(format!("Mismatched booleans during inference").into());
+                        }
+                    }
+                    (Some(CType::TString(s1)), Some(CType::TString(s2))) => {
+                        if s1 != s2 {
+                            return Err(format!(
+                                "Mismatched strings {} and {} during inference",
+                                s1, s2
+                            )
+                            .into());
+                        }
+                    }
+                    (Some(CType::Group(g1)), Some(CType::Group(g2))) => {
+                        arg.push(&*g1);
+                        input.push(&*g2);
+                    }
+                    (Some(CType::Function(i1, o1)), Some(CType::Function(i2, o2))) => {
+                        arg.push(&*i1);
+                        arg.push(&*o1);
+                        input.push(&*i2);
+                        input.push(&*o2);
+                    }
+                    (Some(CType::Tuple(ts1)), Some(CType::Tuple(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched tuple types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        // TODO: Allow out-of-order listing based on Field labels
+                        for t1 in ts1 {
+                            arg.push(&*t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(&*t2);
+                        }
+                    }
+                    (Some(CType::Tuple(ts1)), Some(b)) if ts1.len() == 1 => {
+                        arg.push(&ts1[0]);
+                        input.push(b);
+                    }
+                    (Some(a), Some(CType::Tuple(ts2))) if ts2.len() == 1 => {
+                        arg.push(a);
+                        input.push(&ts2[0]);
+                    }
+                    (Some(CType::Field(l1, t1)), Some(CType::Field(l2, t2))) => {
+                        // TODO: Allow out-of-order listing based on Field labels
+                        if l1 != l2 {
+                            return Err(format!(
+                                "Mismatched fields {} and {} during inference",
+                                l1, l2
+                            )
+                            .into());
+                        }
+                        arg.push(&*t1);
+                        input.push(&*t2);
+                    }
+                    (Some(a), Some(CType::Field(_, t2))) => {
+                        arg.push(&a);
+                        input.push(&*t2);
+                    }
+                    (Some(CType::Field(_, t1)), Some(b)) => {
+                        arg.push(&*t1);
+                        input.push(&b);
+                    }
+                    (Some(CType::Either(ts1)), Some(CType::Either(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched either types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(&*t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(&*t2);
+                        }
+                    }
+                    (Some(CType::Buffer(t1, s1)), Some(CType::Buffer(t2, s2))) => {
+                        if s1 != s2 {
+                            return Err(format!(
+                                "Mismatched buffer lengths {} and {} found during inference",
+                                s1, s2
+                            )
+                            .into());
+                        }
+                        arg.push(&*t1);
+                        input.push(&*t2);
+                    }
+                    (Some(CType::Array(t1)), Some(CType::Array(t2))) => {
+                        arg.push(&*t1);
+                        input.push(&*t2);
+                    }
+                    (Some(a), Some(CType::Infer(g, _))) => {
+                        // Found place to infer!
+                        if generic_types.contains_key(g) {
+                            // Possible found the same thing, already, let's confirm that we aren't
+                            // in an impossible scenario.
+                            let other_type: &CType = generic_types.get(g).unwrap();
+                            if other_type.degroup().to_callable_string()
+                                != a.degroup().to_callable_string()
+                            {
+                                return Err(format!(
+                                    "Generic type {} resolved to both {} and {}",
+                                    g,
+                                    other_type.to_string(),
+                                    a.to_string()
+                                )
+                                .into());
+                            }
+                        } else {
+                            generic_types.insert(g.clone(), a.clone());
+                        }
+                    }
+                    _ => {
+                        return Err(format!("Mismatch between {:?} and {:?}", a, i).into());
+                    }
+                }
+            }
+        }
+        let mut output_types = Vec::new();
+        for (generic_name, _) in generics {
+            output_types.push(match generic_types.get(generic_name) {
+                Some(t) => Ok(t.clone()),
+                None => Err(format!("No inferred type found for {}", generic_name)),
+            }?);
+        }
+        Ok(output_types)
     }
     pub fn from_ast(
         scope: &mut Scope,
@@ -488,7 +749,7 @@ impl CType {
         if is_export {
             scope.exports.insert(name.clone(), Export::Type);
             if fs.len() > 0 {
-                let mut names = HashSet::new();
+                let mut names = OrderedHashSet::new();
                 for f in &fs {
                     names.insert(f.name.clone());
                 }
@@ -499,7 +760,7 @@ impl CType {
         }
         scope.types.insert(name, t.clone());
         if fs.len() > 0 {
-            let mut name_fn_pairs = HashMap::new();
+            let mut name_fn_pairs = OrderedHashMap::new();
             for f in fs {
                 if name_fn_pairs.contains_key(&f.name) {
                     let v: &mut Vec<Function> = name_fn_pairs.get_mut(&f.name).unwrap();
@@ -543,7 +804,7 @@ impl CType {
         }
         match self {
             CType::Void
-            | CType::Infer(_)
+            | CType::Infer(..)
             | CType::Generic(..)
             | CType::Bound(..)
             | CType::BoundGeneric(..)

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -1,4 +1,4 @@
-use ordered_hash_map::{OrderedHashMap, OrderedHashSet};
+use std::collections::{HashMap, HashSet};
 
 use super::Export;
 use super::FnKind;
@@ -219,7 +219,7 @@ impl CType {
             .iter()
             .map(|(_, t)| t.clone())
             .collect::<Vec<CType>>();
-        let mut generic_types = OrderedHashMap::new();
+        let mut generic_types = HashMap::new();
         for (a, i) in call_args.iter().zip(input_types.iter()) {
             let mut arg = vec![a];
             let mut input = vec![i];
@@ -749,7 +749,7 @@ impl CType {
         if is_export {
             scope.exports.insert(name.clone(), Export::Type);
             if fs.len() > 0 {
-                let mut names = OrderedHashSet::new();
+                let mut names = HashSet::new();
                 for f in &fs {
                     names.insert(f.name.clone());
                 }
@@ -760,7 +760,7 @@ impl CType {
         }
         scope.types.insert(name, t.clone());
         if fs.len() > 0 {
-            let mut name_fn_pairs = OrderedHashMap::new();
+            let mut name_fn_pairs = HashMap::new();
             for f in fs {
                 if name_fn_pairs.contains_key(&f.name) {
                     let v: &mut Vec<Function> = name_fn_pairs.get_mut(&f.name).unwrap();

--- a/src/program/function.rs
+++ b/src/program/function.rs
@@ -112,7 +112,10 @@ impl Function {
                             // TODO: This should be an interface type, instead
                             generics.push((
                                 t1.to_string().trim().to_string(),
-                                CType::Infer(t3.to_string().trim().to_string()),
+                                CType::Infer(
+                                    t1.to_string().trim().to_string(),
+                                    t3.to_string().trim().to_string(),
+                                ),
                             ));
                             i = i + 4;
                         }
@@ -120,7 +123,10 @@ impl Function {
                             // TODO: This should be an interface type, instead
                             generics.push((
                                 t1.to_string().trim().to_string(),
-                                CType::Infer(t3.to_string().trim().to_string()),
+                                CType::Infer(
+                                    t1.to_string().trim().to_string(),
+                                    t3.to_string().trim().to_string(),
+                                ),
                             ));
                             i = i + 3; // This should exit the loop
                         }
@@ -128,7 +134,7 @@ impl Function {
                             // TODO: This should be an interface type, instead
                             generics.push((
                                 t1.to_string().trim().to_string(),
-                                CType::Infer("Any".to_string()),
+                                CType::Infer(t1.to_string().trim().to_string(), "Any".to_string()),
                             ));
                             i = i + 2;
                         }
@@ -136,7 +142,7 @@ impl Function {
                             // TODO: This should be an interface type, instead
                             generics.push((
                                 t1.to_string().trim().to_string(),
-                                CType::Infer("Any".to_string()),
+                                CType::Infer(t1.to_string().trim().to_string(), "Any".to_string()),
                             ));
                             i = i + 1;
                         }
@@ -167,7 +173,10 @@ impl Function {
                             // TODO: This should be an interface type, instead
                             generics.push((
                                 t1.to_string().trim().to_string(),
-                                CType::Infer(t3.to_string().trim().to_string()),
+                                CType::Infer(
+                                    t1.to_string().trim().to_string(),
+                                    t3.to_string().trim().to_string(),
+                                ),
                             ));
                             i = i + 4;
                         }
@@ -175,7 +184,10 @@ impl Function {
                             // TODO: This should be an interface type, instead
                             generics.push((
                                 t1.to_string().trim().to_string(),
-                                CType::Infer(t3.to_string().trim().to_string()),
+                                CType::Infer(
+                                    t1.to_string().trim().to_string(),
+                                    t3.to_string().trim().to_string(),
+                                ),
                             ));
                             i = i + 3; // This should exit the loop
                         }
@@ -183,7 +195,7 @@ impl Function {
                             // TODO: This should be an interface type, instead
                             generics.push((
                                 t1.to_string().trim().to_string(),
-                                CType::Infer("Any".to_string()),
+                                CType::Infer(t1.to_string().trim().to_string(), "Any".to_string()),
                             ));
                             i = i + 2;
                         }
@@ -191,7 +203,7 @@ impl Function {
                             // TODO: This should be an interface type, instead
                             generics.push((
                                 t1.to_string().trim().to_string(),
-                                CType::Infer("Any".to_string()),
+                                CType::Infer(t1.to_string().trim().to_string(), "Any".to_string()),
                             ));
                             i = i + 1;
                         }

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -65,9 +65,9 @@ export type Release = Eq{Env{"ALAN_TARGET"}, "release"};
 export type Debug = Eq{Env{"ALAN_TARGET"}, "debug"};
 
 // Defining the operators in the type system
-export type infix Function as -> precedence 2; // I -> O, where I is the input and O is the output. With Tuples and Fields you can reconstruct arguments for functions.
+export type infix Function as -> precedence 3; // I -> O, where I is the input and O is the output. With Tuples and Fields you can reconstruct arguments for functions.
 export type infix Tuple as , precedence 0; // A, B, C, ... The tuple type combines with other tuple types to become a larger tuple type. To have a tuple of tuples, you need to `Group` the inner tuple, eg `(a, b), c`
-export type infix Field as : precedence 3; // Foo: Bar, let's you specify a property access label for the type, useful for syntactic sugar on a tuple type and the Either type (eventually).
+export type infix Field as : precedence 2; // Foo: Bar, let's you specify a property access label for the type, useful for syntactic sugar on a tuple type and the Either type (eventually).
 export type infix Either as | precedence 0; // A | B, the type has a singular value from only one of the types at once. `Result` is just `Either{T, Error}` and `Option` is just `Either{T, ()}` (or `Either{T, void}`, however we want to represent it, also might go with `Fallible` and `Maybe` instead of `Result` and `Option` as those feel more descriptive of what they are.
 export type infix Buffer as [ precedence 1; // Technically allows `Foo[3` by itself to be valid syntax, but...
 export type postfix Group as ] precedence 1; // Technically not necessary, but allows for `Foo[3]` to do the "right thing" and become a buffer of size 3, with a singular useless Group being wrapped around it (and then unwrapped on type generation). The only "bad" thing here is `Group` gets special behavior, matching the `(...)` syntax, so there's two ways to invoke a Group via symbols.
@@ -363,10 +363,10 @@ export fn gt(a: f64, b: f64) -> bool binds gtf64;
 export fn gte(a: f64, b: f64) -> bool binds gtef64;
 
 /// String related bindings
+export fn string(i: i64) -> string binds i64tostring; // TODO: Fix match ordering
 export fn string(i: i8) -> string binds i8tostring;
 export fn string(i: i16) -> string binds i16tostring;
 export fn string(i: i32) -> string binds i32tostring;
-export fn string(i: i64) -> string binds i64tostring;
 export fn string(f: f32) -> string binds f32tostring;
 export fn string(f: f64) -> string binds f64tostring;
 export fn string(b: bool) -> string binds booltostring;
@@ -390,6 +390,7 @@ export fn lt(a: string, b: string) -> bool binds ltstring;
 export fn lte(a: string, b: string) -> bool binds ltestring;
 export fn gt(a: string, b: string) -> bool binds gtstring;
 export fn gte(a: string, b: string) -> bool binds gtestring;
+export fn join(a: Array{string}, s: string) -> string binds joinstring;
 
 /// Boolean related bindings
 export fn bool(i: i8) -> bool binds i8tobool;
@@ -411,12 +412,10 @@ export fn eq(a: bool, b: bool) -> bool binds eqbool;
 export fn neq(a: bool, b: bool) -> bool binds neqbool;
 
 /// Array related bindings
-export fn len(a: i64[]) -> i64 binds lenarray; // TODO: Real generics
-export fn len(a: string[]) -> i64 binds lenarray; // TODO: Real generics
-export fn push(a: Array{i64}, v: i64) -> () binds pusharray; // TODO: Real generics
-export fn push(a: Array{string}, v: string) -> () binds pusharray; // TODO: Real generics
-export fn pop(a: i64[]) -> Maybe{i64} binds poparray; // TODO: Real generics
-export fn pop(a: string[]) -> Maybe{string} binds poparray; // TODO: Real generics
+export fn len{T}(a: T[]) -> i64 binds lenarray;
+export fn push{T}(a: Array{T}, v: T) -> () binds pusharray;
+export fn pop{T}(a: T[]) -> Maybe{T} binds poparray;
+export fn map{T, U}(a: Array{T}, m: T -> U) -> Array{U} binds map_onearg;
 
 /// Process exit-related bindings
 export fn ExitCode(e: i8) -> ExitCode binds to_exit_code_i8;
@@ -431,27 +430,6 @@ export fn getOrExit(a: i8?) -> i8 binds get_or_maybe_exit; // TODO: Support real
 export fn getOrExit(a: i16?) -> i16 binds get_or_maybe_exit; // TODO: Support real generics
 export fn getOrExit(a: i32?) -> i32 binds get_or_maybe_exit; // TODO: Support real generics
 export fn getOrExit(a: i64?) -> i64 binds get_or_maybe_exit; // TODO: Support real generics
-
-/// Stdout/stderr-related bindings
-export fn print(str: string) binds println;
-export fn print(str: Result{string}) binds println_result;
-export fn print(b: bool) binds println;
-export fn print(b: Result{bool}) binds println_result;
-export fn print(i: i8) binds println;
-export fn print(i: Result{i8}) binds println_result;
-export fn print(i: i16) binds println;
-export fn print(i: Result{i16}) binds println_result;
-export fn print(i: i32) binds println;
-export fn print(i: Result{i32}) binds println_result;
-export fn print(i: i64) binds println;
-export fn print(i: Result{i64}) binds println_result;
-export fn print(f: f32) binds println;
-export fn print(f: Result{f32}) binds println_result;
-export fn print(f: f64) binds println;
-export fn print(f: Result{f64}) binds println_result;
-export fn print(o: Maybe{string}) binds println_maybe; // TODO: Do this with real generics
-export fn print(o: Maybe{i64}) binds println_maybe;
-export fn print(o: Maybe{i32}) binds println_maybe;
 
 /// Thread-related bindings
 export fn wait(t: i64) binds wait;
@@ -498,6 +476,14 @@ export fn GPGPU(source: string, buffers: Vec{Vec{GBuffer}}) -> GPGPU binds GPGPU
 export fn GPGPU(source: string, buffer: GBuffer) -> GPGPU binds GPGPU_new_easy;
 export fn run(g: GPU, gg: GPGPU) binds gpu_run;
 export fn read(g: GPU, b: GBuffer) -> Vec{i32} binds read_buffer; // TODO: Support other output types
+
+/// Stdout/stderr-related bindings
+export fn print{T}(v: Result{T}) binds println_result;
+export fn print{T}(v: Maybe{T}) binds println_maybe;
+export fn print{T}(v: T) binds println;
+export fn eprint{T}(v: Result{T}) binds eprintln_result;
+export fn eprint{T}(v: Maybe{T}) binds eprintln_maybe;
+export fn eprint{T}(v: T) binds eprintln;
 
 /// Built-in operator definitions
 // TODO: New plan is to make operators only map to one function per symbol and *kind* of operator,

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -1820,6 +1820,12 @@ fn gtestring(a: &String, b: &String) -> bool {
     *a >= *b
 }
 
+/// `joinstring` joins an array of strings with the separator in-between
+#[inline(always)]
+fn joinstring(a: &Vec<String>, s: &String) -> String {
+    a.join(s)
+}
+
 /// `i8tobool` converts an integer into a boolean
 #[inline(always)]
 fn i8tobool(a: &i8) -> bool {
@@ -1971,6 +1977,30 @@ fn println_maybe<A: std::fmt::Display>(a: &Option<A>) {
     match a {
         Some(o) => println!("{}", o),
         None => println!("void"),
+    };
+}
+
+/// `eprintln` is a simple function that prints basically anything
+#[inline(always)]
+fn eprintln<A: std::fmt::Display>(a: &A) {
+    eprintln!("{}", a);
+}
+
+/// `eprintln_result` is a small wrapper function that makes printing Result types easy
+#[inline(always)]
+fn eprintln_result<A: std::fmt::Display>(a: &Result<A, AlanError>) {
+    match a {
+        Ok(o) => eprintln!("{}", o),
+        Err(e) => eprintln!("{:?}", e),
+    };
+}
+
+/// `eprintln_maybe` is a small wrapper function that makes printing Option types easy
+#[inline(always)]
+fn eprintln_maybe<A: std::fmt::Display>(a: &Option<A>) {
+    match a {
+        Some(o) => eprintln!("{}", o),
+        None => eprintln!("void"),
     };
 }
 


### PR DESCRIPTION
This lets me finally start cleaning up a lot of the duplication within the root scope, and makes `map` possible as a method call.

There are still some corner cases:

* Because of shortcuts taken, functions passed by name into `map` always resolves to the first definition of that function, so for now I just re-ordered the `string` constructor functions to work around this.
* Since interfaces don't exist yet, it's treating all generic type names as if they're bound to an implicit `Any` interface. Once I have interfaces, I want that binding to be explicit and if there is no binding it should refuse to infer the generic type and require it to be defined when you call the generic function.
* Since it's all implict `Any`, it's not doing any constraint checking on what it infers beyond just confirming that it infers the same type in all locations that particular generic type is specified.
* There's still no automatic return type inference when the return type is elided from a function definition. In Alan that should *always* be safe once the input types are determined -- literally just take the `return` Microstatement's type once the function has been constructed.
* I had to make some `clone`s that I'm not proud of, so the test suite has slowed down by more than just the extra tests would imply. It looks like it's ~5% slower than before?
