### PR TITLE
Better function dispatch and more array methods

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -1579,6 +1579,33 @@ true
 cannot remove idx 10 from array with length 4
 "#;
 );
+test!(array_reduce_filter_concat_no_closures => r#"
+    // Temporary test until closure functions are implemented
+    fn isOdd(i: i64) -> bool = i % 2 == 1;
+    export fn main {
+      const test = [ 1, 1, 2, 3, 5, 8 ];
+      const test2 = [ 4, 5, 6 ];
+      print('reduce test');
+      test.reduce(add).print;
+      test.reduce(min).print;
+      test.reduce(max).print;
+
+      print('filter test');
+      test.filter(isOdd).map(string).join(', ').print;
+
+      print('concat test');
+      test.concat(test2).map(string).join(', ').print;
+    }"#;
+    stdout r#"reduce test
+20
+1
+8
+filter test
+1, 1, 3, 5
+concat test
+1, 1, 2, 3, 5, 8, 4, 5, 6
+"#;
+);
 test_ignore!(array_reduce_filter_concat => r#"
     export fn main {
       const test = [ 1, 1, 2, 3, 5, 8 ];

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -106,6 +106,7 @@ pub fn ctype_to_rtype(
             }
         }
         CType::Either(_) => Ok("".to_string()), // What to do in this case?
+        CType::AnyOf(_) => Ok("".to_string()),  // Same question. Does this make any sense in Rust?
         CType::Buffer(t, s) => Ok(format!(
             "[{};{}]",
             ctype_to_rtype(t, scope, program, in_function_type)?,

--- a/src/program/scope.rs
+++ b/src/program/scope.rs
@@ -106,7 +106,7 @@ impl Scope {
                                 | "Bool" | "String" => { /* Do nothing for the 'structural' types */ }
                                 g @ ("Group" | "Array" | "Fail" | "Neg" | "Len" | "Size" | "FileStr"
                                 | "Env" | "EnvExists" | "Not") => CType::from_generic(&mut s, g, 1),
-                                g @ ("Function" | "Tuple" | "Field" | "Either" | "Buffer" | "Add"
+                                g @ ("Function" | "Tuple" | "Field" | "Either" | "AnyOf" | "Buffer" | "Add"
                                 | "Sub" | "Mul" | "Div" | "Mod" | "Pow" | "Min" | "Max" | "If" | "And" | "Or"
                                 | "Xor" | "Nand" | "Nor" | "Xnor" | "Eq" | "Neq" | "Lt" | "Lte"
                                 | "Gt" | "Gte") => CType::from_generic(&mut s, g, 2),

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -19,6 +19,7 @@ export ctype Function{I, O}; // A function type, indicating the input and output
 export ctype Tuple{A, B}; // A tuple of two (or more) types in a single compound type
 export ctype Field{L, V}; // Labeling a type with a property name. Useful to turn tuples into structs
 export ctype Either{A, B}; // An either type, allowing the value to be from *one* of the specified types, kinda like Rust enums
+export ctype AnyOf{A, B}; // The AnyOf type is kinda like a Tuple, in that all sub-types are present, but it only *resolves* into one of these types above it. Useful for choosing the "best" integer, or a particular function by name.
 export ctype Buffer{T, S}; // A buffer type, a pre-allocated, fixed-length array of the specified type the specified amount
 export ctype Array{T}; // An array type, a variable-length array of the specified type the specified amount. This would usually be an stdlib type built in the language itself, but we're just going to re-use the one in the platform language
 
@@ -69,6 +70,7 @@ export type infix Function as -> precedence 3; // I -> O, where I is the input a
 export type infix Tuple as , precedence 0; // A, B, C, ... The tuple type combines with other tuple types to become a larger tuple type. To have a tuple of tuples, you need to `Group` the inner tuple, eg `(a, b), c`
 export type infix Field as : precedence 2; // Foo: Bar, let's you specify a property access label for the type, useful for syntactic sugar on a tuple type and the Either type (eventually).
 export type infix Either as | precedence 0; // A | B, the type has a singular value from only one of the types at once. `Result` is just `Either{T, Error}` and `Option` is just `Either{T, ()}` (or `Either{T, void}`, however we want to represent it, also might go with `Fallible` and `Maybe` instead of `Result` and `Option` as those feel more descriptive of what they are.
+export type infix AnyOf as & precedence 0; // A & B, which can be passed to a function that takes A or B as necessary.
 export type infix Buffer as [ precedence 1; // Technically allows `Foo[3` by itself to be valid syntax, but...
 export type postfix Group as ] precedence 1; // Technically not necessary, but allows for `Foo[3]` to do the "right thing" and become a buffer of size 3, with a singular useless Group being wrapped around it (and then unwrapped on type generation). The only "bad" thing here is `Group` gets special behavior, matching the `(...)` syntax, so there's two ways to invoke a Group via symbols.
 export type postfix Array as [] precedence 4; // Allows `Foo[]` to do the right thing
@@ -81,7 +83,7 @@ export type infix Div as / precedence 3;
 export type infix Mod as % precedence 3;
 export type infix Pow as ** precedence 4;
 export type infix If as ?? precedence 1; // C puts this kind of thing as a very high precedence. I'm not sure if I want to follow it. I feel like that would force grouping parens everywhere.
-export type infix And as & precedence 3;
+export type infix And as && precedence 3;
 export type infix Or as || precedence 2; // TODO: Which should get `||` and which should get `|`?
 export type infix Xor as ^ precedence 2;
 export type prefix Not as ! precedence 4; // TODO: Do we want `!` to mean `Not` or `Result` depending on where it's placed syntactically? Seems easily ambiguous
@@ -363,10 +365,10 @@ export fn gt(a: f64, b: f64) -> bool binds gtf64;
 export fn gte(a: f64, b: f64) -> bool binds gtef64;
 
 /// String related bindings
-export fn string(i: i64) -> string binds i64tostring; // TODO: Fix match ordering
 export fn string(i: i8) -> string binds i8tostring;
 export fn string(i: i16) -> string binds i16tostring;
 export fn string(i: i32) -> string binds i32tostring;
+export fn string(i: i64) -> string binds i64tostring;
 export fn string(f: f32) -> string binds f32tostring;
 export fn string(f: f64) -> string binds f64tostring;
 export fn string(b: bool) -> string binds booltostring;
@@ -416,7 +418,13 @@ export fn len{T}(a: T[]) -> i64 binds lenarray;
 export fn push{T}(a: Array{T}, v: T) -> () binds pusharray;
 export fn pop{T}(a: T[]) -> Maybe{T} binds poparray;
 export fn map{T, U}(a: Array{T}, m: T -> U) -> Array{U} binds map_onearg;
+export fn map{T, U}(a: Array{T}, m: (T, i64) -> U) -> Array{U} binds map_twoarg;
 export fn parmap{T, U}(a: Array{T}, m: T -> U) -> Array{U} binds parmap_onearg;
+export fn filter{T}(a: Array{T}, f: T -> bool) -> Array{T} binds filter_onearg;
+export fn filter{T}(a: Array{T}, f: (T, i64) -> bool) -> Array{T} binds filter_twoarg;
+export fn reduce{T}(a: Array{T}, f: (T, T) -> T) -> Maybe{T} binds reduce_sametype;
+export fn reduce{T, U}(a: Array{T}, i: U, f: (U, T) -> U) -> U binds reduce_difftype;
+export fn concat{T}(a: Array{T}, b: Array{T}) -> Array{T} binds concat;
 export fn filled{T}(v: T, l: i64) -> Array{T} binds filled;
 
 /// Process exit-related bindings

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -2083,10 +2083,10 @@ fn map_onearg<A, B>(v: &Vec<A>, m: fn(&A) -> B) -> Vec<B> {
 /// `map_twoarg` runs the provided two-argument (value, index) function on each element of the
 /// vector, returning a new vector
 #[inline(always)]
-fn map_twoarg<A, B>(v: &Vec<A>, m: fn(&A, usize) -> B) -> Vec<B> {
+fn map_twoarg<A, B>(v: &Vec<A>, m: fn(&A, i64) -> B) -> Vec<B> {
     v.iter()
         .enumerate()
-        .map(|(i, val)| m(val, i))
+        .map(|(i, val)| m(val, i as i64))
         .collect::<Vec<B>>()
 }
 
@@ -2181,6 +2181,72 @@ fn parmap_onearg<
             out
         }
     }
+}
+
+/// `filter_onearg` runs the provided single-argument function on each element of the vector,
+/// returning a new vector
+#[inline(always)]
+fn filter_onearg<A: std::clone::Clone>(v: &Vec<A>, f: fn(&A) -> bool) -> Vec<A> {
+    v.iter()
+        .filter(|val| f(val))
+        .map(|val| val.clone())
+        .collect::<Vec<A>>()
+}
+
+/// `filter_twoarg` runs the provided function each element of the vector plus its index,
+/// returning a new vector
+#[inline(always)]
+fn filter_twoarg<A: std::clone::Clone>(v: &Vec<A>, f: fn(&A, i64) -> bool) -> Vec<A> {
+    v.iter()
+        .enumerate()
+        .filter(|(i, val)| f(val, *i as i64))
+        .map(|(_, val)| val.clone())
+        .collect::<Vec<A>>()
+}
+
+/// `reduce_sametype` runs the provided function to reduce the vector into a singular value
+#[inline(always)]
+fn reduce_sametype<A: std::clone::Clone>(v: &Vec<A>, f: fn(&A, &A) -> A) -> Option<A> {
+    // The built-in iter `reduce` is awkward for our use case
+    if v.len() == 0 {
+        None
+    } else if v.len() == 1 {
+        Some(v[0].clone())
+    } else {
+        let mut out = v[0].clone();
+        for i in 1..v.len() {
+            out = f(&out, &v[i]);
+        }
+        Some(out)
+    }
+}
+
+/// `reduce_difftype` runs the provided function and initial value to reduce the vector into a
+/// singular value. Because an initial value is provided, it always returns at least that value
+#[inline(always)]
+fn reduce_difftype<A: std::clone::Clone, B: std::clone::Clone>(
+    v: &Vec<A>,
+    i: &B,
+    f: fn(&B, &A) -> B,
+) -> B {
+    let mut out = i.clone();
+    for i in 0..v.len() {
+        out = f(&out, &v[i]);
+    }
+    out
+}
+
+/// `concat` returns a new vector combining the two vectors provided
+#[inline(always)]
+fn concat<A: std::clone::Clone>(a: &Vec<A>, b: &Vec<A>) -> Vec<A> {
+    let mut out = Vec::new();
+    for i in 0..a.len() {
+        out.push(a[i].clone());
+    }
+    for i in 0..b.len() {
+        out.push(b[i].clone());
+    }
+    out
 }
 
 /// `push` pushes an element into a vector


### PR DESCRIPTION
While working on adding more array methods, the limitations of the temporary function dispatch logic I had were preventing these new functions to actually be useable, because the correct function was not being selected when multiple had the same name *in some situations.*

This PR improves on this a lot (but not perfectly; it's only matching one statement at a time, so it may fail if it needs to cross multiple statement boundaries. I need to do a lot of reworking to resolve that), getting the `closures_by_name` test to *actually* work, rather than me cheating by reordering the function definitions, and implementing `filter`, `reduce`, and more array functions.
