### PR TITLE
TODO cleanup

### DIFF
--- a/benches/bench.ln
+++ b/benches/bench.ln
@@ -31,7 +31,7 @@ fn bench(l: i64) {
     }
   ", b);
   g.run(plan);
-  let v3 = g.read(b);
+  let v3 = g.read{i32}(b);
   v3[0];
   t3.elapsed.print;
 }
@@ -67,7 +67,7 @@ fn bench_billion {
     }
   ", b);
   g.run(plan);
-  g.read(b);
+  g.read{i32}(b);
   let b = g.createBuffer(storageBuffer(), v2);
   let plan = GPGPU("
     @group(0)
@@ -84,7 +84,7 @@ fn bench_billion {
     }
   ", b);
   g.run(plan);
-  let v3 = g.read(b);
+  let v3 = g.read{i32}(b);
   v3[0];
   t3.elapsed.print;
 }

--- a/benches/map.rs
+++ b/benches/map.rs
@@ -125,7 +125,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          let v = g.read(b);
+          let v = g.read{i32}(b);
           v[0].print;
         }
     "#);
@@ -148,7 +148,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          let v = g.read(b);
+          let v = g.read{i32}(b);
           v[0].print;
         }
     "#);
@@ -171,7 +171,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          let v = g.read(b);
+          let v = g.read{i32}(b);
           v[0].print;
         }
     "#);
@@ -194,7 +194,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          let v = g.read(b);
+          let v = g.read{i32}(b);
           v[0].print;
         }
     "#);
@@ -217,7 +217,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          let v = g.read(b);
+          let v = g.read{i32}(b);
           v[0].print;
         }
     "#);
@@ -240,7 +240,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          let v = g.read(b);
+          let v = g.read{i32}(b);
           v[0].print;
         }
     "#);
@@ -263,7 +263,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          let v = g.read(b);
+          let v = g.read{i32}(b);
           v[0].print;
         }
     "#);
@@ -286,7 +286,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          let v = g.read(b);
+          let v = g.read{i32}(b);
           v[0].print;
         }
     "#);
@@ -309,7 +309,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
           ", b);
           g.run(plan);
-          let v = g.read(b);
+          let v = g.read{i32}(b);
           v[0].print;
         }
     "#);

--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -584,7 +584,7 @@ test!(hello_gpu => r#"
         }
       ", b);
       g.run(plan);
-      g.read(b).print;
+      g.read{i32}(b).print;
     }"#;
     stdout "[0, 2, 4, 6]\n";
 );

--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -1292,8 +1292,6 @@ test!(conditional_compilation => r#"
 
     // type TestBuffer = Buffer{i64, 1 + 2 * 3};
     type TestBuffer = i64[1 + 2 * 3];
-    // TODO: Have a generic version instead of binding here
-    // fn len(t: TestBuffer) -> i64 binds lenbuffer;
 
     export fn main {
       print(var.foo); // Should print "Hello, World!"

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -18,10 +18,20 @@ mod integration_tests;
 /// instead, the contents of the Cargo.toml are just hardwired in here for now.
 pub fn build(source_file: String) -> Result<String, Box<dyn std::error::Error>> {
     let find_process = if cfg!(windows) { "where" } else { "which" };
-    // Fail if rustc is not present TODO: Present a better error to the user
-    Command::new(find_process).arg("rustc").output()?;
+    // Fail if rustc is not present
+    match Command::new(find_process).arg("rustc").output() {
+        Ok(a) => Ok(a),
+        Err(_) => {
+            Err("rustc not found. Please make sure you have rust installed before using Alan!")
+        }
+    }?;
     // Also fail if cargo is not present
-    Command::new(find_process).arg("cargo").output()?;
+    match Command::new(find_process).arg("cargo").output() {
+        Ok(a) => Ok(a),
+        Err(_) => {
+            Err("cargo not found. Please make sure you have rust installed before using Alan!")
+        }
+    }?;
     // Because all Alan programs use the same Rust dependencies (for now), we can cut down a *lot*
     // of build time by re-using the `./target/release/build` and `./target/release/deps` directory
     // in subsequent builds. Since it takes over 30 seconds to make a release build on my laptop

--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -267,9 +267,6 @@ pub fn from_microstatement(
                                             ),
                                             out,
                                         ));
-                                        // TODO: Someday revive something like this, but for
-                                        // now we are using Option, so it's much simpler
-                                        // return Ok((format!("match {}.get({}) {{ Some(v) => {}::{}(v), None => {}::void }}", argstrs[0], argstrs[1], n, ts[0].to_string(), n), out));
                                     }
                                     _ => {} // Just fall through
                                 }
@@ -350,7 +347,13 @@ pub fn from_microstatement(
                         };
                         match inner_ret_type {
                             CType::Buffer(_, s) => {
-                                if argstrs.len() == s {
+                                let size = match *s {
+                                    CType::Int(s) => Ok(s as usize),
+                                    _ => Err(format!(
+                                        "Somehow received a buffer with a non-integer size"
+                                    )),
+                                }?;
+                                if argstrs.len() == size {
                                     return Ok((format!("[{}]", argstrs.join(", ")), out));
                                 } else if argstrs.len() == 1 {
                                     return Ok((
@@ -360,7 +363,7 @@ pub fn from_microstatement(
                                                 Some(v) => v,
                                                 None => &argstrs[0],
                                             },
-                                            s
+                                            size
                                         ),
                                         out,
                                     ));

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -110,7 +110,12 @@ pub fn ctype_to_rtype(
         CType::Buffer(t, s) => Ok(format!(
             "[{};{}]",
             ctype_to_rtype(t, scope, program, in_function_type)?,
-            s
+            match **s {
+                CType::Int(size) => Ok(size as usize),
+                _ => Err(format!(
+                    "Somehow received a buffer definition with a non-integer size"
+                )),
+            }?
         )),
         CType::Array(t) => Ok(format!(
             "Vec<{}>",

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -511,7 +511,7 @@ impl Program {
                         Ok(gs) => {
                             return Some(gs);
                         }
-                        Err(e) => {
+                        Err(_) => {
                             continue;
                         }
                     };

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -84,7 +84,7 @@ export type infix Mod as % precedence 3;
 export type infix Pow as ** precedence 4;
 export type infix If as ?? precedence 1; // C puts this kind of thing as a very high precedence. I'm not sure if I want to follow it. I feel like that would force grouping parens everywhere.
 export type infix And as && precedence 3;
-export type infix Or as || precedence 2; // TODO: Which should get `||` and which should get `|`?
+export type infix Or as || precedence 2;
 export type infix Xor as ^ precedence 2;
 export type prefix Not as ! precedence 4; // TODO: Do we want `!` to mean `Not` or `Result` depending on where it's placed syntactically? Seems easily ambiguous
 export type infix Nand as !& precedence 3;
@@ -458,7 +458,7 @@ export type GPGPU binds GPGPU;
 export fn GPGPU(source: string, buffers: Array{Array{GBuffer}}) -> GPGPU binds GPGPU_new;
 export fn GPGPU(source: string, buffer: GBuffer) -> GPGPU binds GPGPU_new_easy;
 export fn run(g: GPU, gg: GPGPU) binds gpu_run;
-export fn read(g: GPU, b: GBuffer) -> Array{i32} binds read_buffer; // TODO: Support other output types
+export fn read{T}(g: GPU, b: GBuffer) -> Array{T} binds read_buffer;
 
 /// Stdout/stderr-related bindings
 // TODO: Rework this to just print anything that can be converted to `string` via interfaces

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -68,11 +68,11 @@ export type Debug = Eq{Env{"ALAN_TARGET"}, "debug"};
 // Defining the operators in the type system
 export type infix Function as -> precedence 3; // I -> O, where I is the input and O is the output. With Tuples and Fields you can reconstruct arguments for functions.
 export type infix Tuple as , precedence 0; // A, B, C, ... The tuple type combines with other tuple types to become a larger tuple type. To have a tuple of tuples, you need to `Group` the inner tuple, eg `(a, b), c`
-export type infix Field as : precedence 2; // Foo: Bar, let's you specify a property access label for the type, useful for syntactic sugar on a tuple type and the Either type (eventually).
+export type infix Field as : precedence 1; // Foo: Bar, let's you specify a property access label for the type, useful for syntactic sugar on a tuple type and the Either type (eventually).
 export type infix Either as | precedence 0; // A | B, the type has a singular value from only one of the types at once. `Result` is just `Either{T, Error}` and `Option` is just `Either{T, ()}` (or `Either{T, void}`, however we want to represent it, also might go with `Fallible` and `Maybe` instead of `Result` and `Option` as those feel more descriptive of what they are.
 export type infix AnyOf as & precedence 0; // A & B, which can be passed to a function that takes A or B as necessary.
-export type infix Buffer as [ precedence 1; // Technically allows `Foo[3` by itself to be valid syntax, but...
-export type postfix Group as ] precedence 1; // Technically not necessary, but allows for `Foo[3]` to do the "right thing" and become a buffer of size 3, with a singular useless Group being wrapped around it (and then unwrapped on type generation). The only "bad" thing here is `Group` gets special behavior, matching the `(...)` syntax, so there's two ways to invoke a Group via symbols.
+export type infix Buffer as [ precedence 2; // Technically allows `Foo[3` by itself to be valid syntax, but...
+export type postfix Group as ] precedence 2; // Technically not necessary, but allows for `Foo[3]` to do the "right thing" and become a buffer of size 3, with a singular useless Group being wrapped around it (and then unwrapped on type generation). The only "bad" thing here is `Group` gets special behavior, matching the `(...)` syntax, so there's two ways to invoke a Group via symbols.
 export type postfix Array as [] precedence 4; // Allows `Foo[]` to do the right thing
 export type postfix Maybe as ? precedence 4; // Allows `Foo?` for nullable types. Should this have a precedence of 5?
 export type postfix Fallible as ! precedence 4; // Allows `Foo!` for fallible types. Same question on the precedence.
@@ -381,7 +381,6 @@ export fn split(a: string, b: string) -> string[] binds splitstring;
 export fn div(a: string, b: string) -> string[] binds splitstring; // To use the '/' operator
 export fn len(a: string) -> i64 binds lenstring;
 export fn get(a: string, i: i64) -> Result{string} binds getstring;
-export fn toCharArray(a: string) -> string[] binds to_char_array;
 export fn trim(a: string) -> string binds trimstring;
 export fn index(a: string, b: string) -> Result{i64} binds indexstring;
 export fn min(a: string, b: string) -> string binds minstring;
@@ -426,6 +425,9 @@ export fn reduce{T}(a: Array{T}, f: (T, T) -> T) -> Maybe{T} binds reduce_samety
 export fn reduce{T, U}(a: Array{T}, i: U, f: (U, T) -> U) -> U binds reduce_difftype;
 export fn concat{T}(a: Array{T}, b: Array{T}) -> Array{T} binds concat;
 export fn filled{T}(v: T, l: i64) -> Array{T} binds filled;
+
+/// Buffer related bindings
+export fn len{T, S}(a: T[S]) -> i64 binds lenbuffer;
 
 /// Process exit-related bindings
 export fn ExitCode(e: i8) -> ExitCode binds to_exit_code_i8;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -1734,19 +1734,12 @@ fn getstring(a: &String, i: &i64) -> Result<String, AlanError> {
     match a.chars().nth(*i as usize) {
         Some(c) => Ok(String::from(c)),
         None => Err(format!(
-            "Index {} is longer than the string length of {}",
+            "Index {} is out-of-bounds for a string length of {}",
             i,
             lenstring(a)
         )
         .into()),
     }
-}
-
-/// `to_char_array` returns an array of the characters of a string (TODO: What is a "character" in
-/// Alan?)
-#[inline(always)]
-fn to_char_array(a: &String) -> Vec<String> {
-    a.chars().map(|c| String::from(c)).collect::<Vec<String>>()
 }
 
 /// `trimstring` trims the string of whitespace
@@ -1967,7 +1960,7 @@ fn println<A: std::fmt::Display>(a: &A) {
 fn println_result<A: std::fmt::Display>(a: &Result<A, AlanError>) {
     match a {
         Ok(o) => println!("{}", o),
-        Err(e) => println!("{:?}", e),
+        Err(e) => println!("{}", e.to_string()),
     };
 }
 


### PR DESCRIPTION
This PR was focused on cleaning up a lot of various TODOs. Part of that made it clear that you couldn't infer the length of a buffer type with type inference, so a generic buffer length function wouldn't work. This resolves that at the same time.
