### PR TITLE
Implement map for the Buffer type

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -1499,15 +1499,12 @@ join test
 Hello, World!
 "#;
 );
-/* Without the ternary syntax, there is no ternary abuse possible. But a syntax kinda like this
- * doesn't seem so bad? (Eg `1:2:3` produces an array of [1, 2, 3]. It almost feels like a
- * replacement for the array literal syntax. */
 test_ignore!(array_map => r#"
     export fn main {
       const count = [1, 2, 3, 4, 5]; // Ah, ah, ahh!
-      const byTwos = count.map(fn (n: int64) -> Result{int64} = n * 2);
-      count.map(fn (n: int64) = string(n)).join(', ').print;
-      byTwos.map(fn (n: Result{int64}) = string(n)).join(', ').print;
+      const byTwos = count.map(fn (n: i64) -> i64 = n * 2);
+      count.map(fn (n: i64) = string(n)).join(', ').print;
+      byTwos.map(fn (n: i64) = string(n)).join(', ').print;
     }"#;
     stdout "1, 2, 3, 4, 5\n2, 4, 6, 8, 10\n";
 );
@@ -1641,6 +1638,18 @@ test_ignore!(array_custom_types => r#"
       }).filter(fn (f: Foo) -> bool = f.bar).map(fn (f: Foo) -> string = f.foo).join(', ').print;
     }"#;
     stdout "2, 4\n";
+);
+// Buffers
+test!(buffer_map => r#"
+    fn double(x: i64) -> i64 = x * 2;
+    export fn main {
+        const b = Buffer{i64, 3}(1, 2, 3);
+        b.print;
+        b.len.print;
+        b.map(double).print;
+        b.map(add).print;
+    }"#;
+    stdout "[1, 2, 3]\n3\n[2, 4, 6]\n[1, 3, 5]\n";
 );
 
 // Hashing

--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -354,7 +354,20 @@ pub fn from_microstatement(
                                     )),
                                 }?;
                                 if argstrs.len() == size {
-                                    return Ok((format!("[{}]", argstrs.join(", ")), out));
+                                    return Ok((
+                                        format!(
+                                            "[{}]",
+                                            argstrs
+                                                .iter()
+                                                .map(|a| match a.strip_prefix("&mut ") {
+                                                    Some(v) => v,
+                                                    None => a,
+                                                })
+                                                .collect::<Vec<&str>>()
+                                                .join(", ")
+                                        ),
+                                        out,
+                                    ));
                                 } else if argstrs.len() == 1 {
                                     return Ok((
                                         format!(

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -511,9 +511,7 @@ impl Program {
                         Ok(gs) => {
                             return Some(gs);
                         }
-                        Err(_) => {
-                            continue;
-                        }
+                        Err(_) => { /* Do nothing */ }
                     };
                 }
             }

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -428,6 +428,8 @@ export fn filled{T}(v: T, l: i64) -> Array{T} binds filled;
 
 /// Buffer related bindings
 export fn len{T, S}(a: T[S]) -> i64 binds lenbuffer;
+export fn map{T, S, U}(a: Buffer{T, S}, m: T -> U) -> Buffer{U, S} binds mapbuffer_onearg;
+export fn map{T, S, U}(a: Buffer{T, S}, m: (T, i64) -> U) -> Buffer{U, S} binds mapbuffer_twoarg;
 
 /// Process exit-related bindings
 export fn ExitCode(e: i8) -> ExitCode binds to_exit_code_i8;
@@ -465,6 +467,7 @@ export fn read{T}(g: GPU, b: GBuffer) -> Array{T} binds read_buffer;
 export fn print{T}(v: Result{T}) binds println_result;
 export fn print{T}(v: Maybe{T}) binds println_maybe;
 export fn print{T}(v: Array{T}) binds print_vec;
+export fn print{T, N}(v: Buffer{T, N}) binds print_buffer;
 export fn print{T}(v: Array{Result{T}}) binds print_vec_result;
 export fn print{T}(v: T) binds println;
 export fn eprint{T}(v: Result{T}) binds eprintln_result;
@@ -486,7 +489,9 @@ export infix mod as % precedence 3;
 // export infix template as % precedence 3;
 export infix pow as ** precedence 4;
 export infix and as & precedence 3;
+export infix and as && precedence 3;
 export infix or as | precedence 2;
+export infix or as || precedence 2;
 export infix xor as ^ precedence 2;
 export prefix not as ! precedence 4;
 export infix nand as !& precedence 3;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -1939,13 +1939,13 @@ fn lenbuffer<T>(a: &[T]) -> i64 {
 
 /// `pusharray` pushes a value onto the array
 #[inline(always)]
-fn pusharray<T: Clone>(mut a: &mut Vec<T>, v: &T) {
+fn pusharray<T: Clone>(a: &mut Vec<T>, v: &T) {
     a.push(v.clone());
 }
 
 /// `poparray` pops a value off of the array into an Option<T>
 #[inline(always)]
-fn poparray<T>(mut a: &mut Vec<T>) -> Option<T> {
+fn poparray<T>(a: &mut Vec<T>) -> Option<T> {
     a.pop()
 }
 
@@ -2060,6 +2060,18 @@ fn print_vec_result<A: std::fmt::Display>(vs: &Vec<Result<A, AlanError>>) {
     );
 }
 
+/// `print_buffer` pretty prints a buffer assuming the input type can be displayed
+#[inline(always)]
+fn print_buffer<A: std::fmt::Display, const N: usize>(vs: &[A; N]) {
+    println!(
+        "[{}]",
+        vs.iter()
+            .map(|v| format!("{}", v))
+            .collect::<Vec<String>>()
+            .join(", ")
+    );
+}
+
 /// `vec_len` returns the length of a vector
 #[inline(always)]
 fn vec_len<A>(v: &Vec<A>) -> i64 {
@@ -2080,16 +2092,6 @@ fn map_twoarg<A, B>(v: &Vec<A>, m: fn(&A, i64) -> B) -> Vec<B> {
     v.iter()
         .enumerate()
         .map(|(i, val)| m(val, i as i64))
-        .collect::<Vec<B>>()
-}
-
-/// `map_threearg` runs the provided three-argument (value, index, vec_ref) function on each
-/// element of the vector, returning a new vector
-#[inline(always)]
-fn map_threearg<A, B>(v: &Vec<A>, m: fn(&A, usize, &Vec<A>) -> B) -> Vec<B> {
-    v.iter()
-        .enumerate()
-        .map(|(i, val)| m(val, i, &v))
         .collect::<Vec<B>>()
 }
 
@@ -2246,6 +2248,31 @@ fn concat<A: std::clone::Clone>(a: &Vec<A>, b: &Vec<A>) -> Vec<A> {
 #[inline(always)]
 fn push<A: std::clone::Clone>(v: &mut Vec<A>, a: &A) {
     v.push(a.clone());
+}
+
+/// `mapbuffer_onearg` runs the provided single-argument function on each element of the buffer,
+/// returning a new buffer
+#[inline(always)]
+fn mapbuffer_onearg<A, const N: usize, B: std::marker::Copy>(v: &[A; N], m: fn(&A) -> B) -> [B; N] {
+    let mut out = [m(&v[0]); N];
+    for i in 1..N {
+        out[i] = m(&v[i]);
+    }
+    out
+}
+
+/// `mapbuffer_twoarg` runs the provided two-argument (value, index) function on each element of the
+/// buffer, returning a new buffer
+#[inline(always)]
+fn mapbuffer_twoarg<A, const N: usize, B: std::marker::Copy>(
+    v: &[A; N],
+    m: fn(&A, &i64) -> B,
+) -> [B; N] {
+    let mut out = [m(&v[0], &0); N];
+    for i in 1..N {
+        out[i] = m(&v[i], &(i as i64));
+    }
+    out
 }
 
 struct GPU {


### PR DESCRIPTION
This one took a while to do because it uncovered issues with the type inference as written; it was accepting garbage because I had blurred two different ways of inferring it in my head to resolve the `AnyOf` type, and it only worked accidentally before.

It also took some time because the way it was constructing an array (equivalent to buffers in Alan/JS/etc) in Rust was incorrect and I was getting really weird Rust compilation errors about fn items instead of fn pointers due to that. (Which might point at a bug in the Rust compiler, because it apparently had no problem creating an array of mutable pointers to constant integers, which is nonsensical.)

I realized that I had forgotten to create a task to make sure that *most* of the Array methods are also implemented for Buffers, and that's what this is about.
