### PR TITLE
Implement Buffer join

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -1651,6 +1651,13 @@ test!(buffer_map => r#"
     }"#;
     stdout "[1, 2, 3]\n3\n[2, 4, 6]\n[1, 3, 5]\n";
 );
+test!(buffer_join => r#"
+    export fn main {
+        const b = {string[2]}("Hello", "World!");
+        b.join(", ").print;
+    }"#;
+    stdout "Hello, World!\n";
+);
 
 // Hashing
 // TODO: I have no idea how I'm going to make this work in pure Rust, but damnit I'm gonna try.

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -392,6 +392,7 @@ export fn lte(a: string, b: string) -> bool binds ltestring;
 export fn gt(a: string, b: string) -> bool binds gtstring;
 export fn gte(a: string, b: string) -> bool binds gtestring;
 export fn join(a: Array{string}, s: string) -> string binds joinstring;
+export fn join{S}(a: Buffer{string, S}, s: string) -> string binds bufferjoinstring;
 
 /// Boolean related bindings
 export fn bool(i: i8) -> bool binds i8tobool;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -1819,6 +1819,12 @@ fn joinstring(a: &Vec<String>, s: &String) -> String {
     a.join(s)
 }
 
+/// `bufferjoinstring` joins a buffer of strings with the separator in-between
+#[inline(always)]
+fn bufferjoinstring<const S: usize>(a: &[String; S], s: &String) -> String {
+    a.join(s)
+}
+
 /// `i8tobool` converts an integer into a boolean
 #[inline(always)]
 fn i8tobool(a: &i8) -> bool {


### PR DESCRIPTION
This went much more smoothly, likely thanks to the work on the prior PR.

Also nice to note that `Buffer{string, 2}` is equivalent to `string[2]` and that you can use that latter format wrapped in `{}` for constructor function usage. That's what's *supposed* to happen, but it's nice that it's working correctly even for types I hadn't tested it on, yet. :)
