### PR TITLE
Implement the Buffer len function with a type system hat-trick

### DIFF
--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -75,7 +75,10 @@ pub fn from_microstatement(
                                                 s.replace("<", "_")
                                                     .replace(">", "_")
                                                     .replace(",", "_")
-                                                    .replace(" ", ""),
+                                                    .replace(" ", "")
+                                                    .replace("[", "_")
+                                                    .replace("]", "_")
+                                                    .replace(";", "_"),
                                             );
                                             /* TODO: Handle generic types better, also type inference */
                                             Ok(())
@@ -143,7 +146,10 @@ pub fn from_microstatement(
                                     s.replace("<", "_")
                                         .replace(">", "_")
                                         .replace(",", "_")
-                                        .replace(" ", ""),
+                                        .replace(" ", "")
+                                        .replace("[", "_")
+                                        .replace("]", "_")
+                                        .replace(";", "_"),
                                 );
                                 /* TODO: Handle generic types better, also type inference */
                                 Ok(())

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -428,7 +428,7 @@ export fn concat{T}(a: Array{T}, b: Array{T}) -> Array{T} binds concat;
 export fn filled{T}(v: T, l: i64) -> Array{T} binds filled;
 
 /// Buffer related bindings
-export fn len{T, S}(a: T[S]) -> i64 binds lenbuffer;
+export fn len{T, S}(T[S]) -> i64 = {S}();
 export fn map{T, S, U}(a: Buffer{T, S}, m: T -> U) -> Buffer{U, S} binds mapbuffer_onearg;
 export fn map{T, S, U}(a: Buffer{T, S}, m: (T, i64) -> U) -> Buffer{U, S} binds mapbuffer_twoarg;
 

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -1937,12 +1937,6 @@ fn lenarray<T>(a: &Vec<T>) -> i64 {
     a.len() as i64
 }
 
-/// `lenbuffer` returns the length of a buffer (Rust array)
-#[inline(always)]
-fn lenbuffer<T>(a: &[T]) -> i64 {
-    a.len() as i64
-}
-
 /// `pusharray` pushes a value onto the array
 #[inline(always)]
 fn pusharray<T: Clone>(a: &mut Vec<T>, v: &T) {


### PR DESCRIPTION
If I only cared about the buffer length, this would be a bad PR because it's much large now than before, but now it's possible to use resolved Int or Float types as values within the code. It's unfortunately jumping through a useless function at the moment, but hopefully that can be eliminated in the future.

But in any case, this is particularly useful for any code that needs to use a generic-derived integer or float type as a value to accomplish what's necessary. Here returning the length of a buffer by just inspecting the type information, but it could potentially be used for matrix math or what-have-you, and before it required writing a Rust function to get at this information, and now it's pure Alan code.
