### PR TITLE
Implement a variant of has that accepts a checking function

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -1469,12 +1469,16 @@ void
 );
 // TODO: Restore the old test later, or just break this up permanently?
 test!(array_has => r#"
+    fn even(t: i64) -> bool = t % 2 == 0;
+    fn odd(t: i64) -> bool = t % 2 == 1;
     export fn main {
         const test = [ 1, 1, 2, 3, 5, 8 ];
         test.has(3).print;
         test.has(4).print;
+        test.has(even).print;
+        test.has(odd).print;
     }"#;
-    stdout "true\nfalse\n";
+    stdout "true\nfalse\ntrue\ntrue\n";
 );
 test_ignore!(array_length_index_has_join => r#"
     export fn main {
@@ -1677,12 +1681,16 @@ test!(buffer_reduce => r#"
     stdout "15\n012345\n";
 );
 test!(buffer_has => r#"
+    fn even(t: i64) -> bool = t % 2 == 0;
+    fn odd(t: i64) -> bool = t % 2 == 1;
     export fn main {
         const test = {i64[6]}(1, 1, 2, 3, 5, 8);
         test.has(3).print;
         test.has(4).print;
+        test.has(even).print;
+        test.has(odd).print;
     }"#;
-    stdout "true\nfalse\n";
+    stdout "true\nfalse\ntrue\ntrue\n";
 );
 
 // Hashing

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -427,6 +427,7 @@ export fn reduce{T, U}(a: Array{T}, i: U, f: (U, T) -> U) -> U binds reduce_diff
 export fn concat{T}(a: Array{T}, b: Array{T}) -> Array{T} binds concat;
 export fn filled{T}(v: T, l: i64) -> Array{T} binds filled;
 export fn has{T}(a: Array{T}, v: T) -> bool binds hasarray;
+export fn has{T}(a: Array{T}, f: (T) -> bool) -> bool binds hasfnarray;
 
 /// Buffer related bindings
 export fn len{T, S}(T[S]) -> i64 = {S}();
@@ -435,6 +436,7 @@ export fn map{T, S, U}(a: Buffer{T, S}, m: (T, i64) -> U) -> Buffer{U, S} binds 
 export fn reduce{T, S}(a: Buffer{T, S}, f: (T, T) -> T) -> Maybe{T} binds reducebuffer_sametype;
 export fn reduce{T, S, U}(a: Buffer{T, S}, i: U, f: (U, T) -> U) -> U binds reducebuffer_difftype;
 export fn has{T, S}(a: Buffer{T, S}, v: T) -> bool binds hasbuffer;
+export fn has{T, S}(a: Buffer{T, S}, f: (T) -> bool) -> bool binds hasfnbuffer;
 
 /// Process exit-related bindings
 export fn ExitCode(e: i8) -> ExitCode binds to_exit_code_i8;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -2256,6 +2256,17 @@ fn hasarray<T: std::cmp::PartialEq>(a: &Vec<T>, v: &T) -> bool {
     a.contains(v)
 }
 
+/// `hasfnarray` returns true if the check function returns true for any element of the vector
+#[inline(always)]
+fn hasfnarray<T>(a: &Vec<T>, f: fn(&T) -> bool) -> bool {
+    for v in a {
+        if f(v) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /// `mapbuffer_onearg` runs the provided single-argument function on each element of the buffer,
 /// returning a new buffer
 #[inline(always)]
@@ -2322,6 +2333,17 @@ fn reducebuffer_difftype<A: std::clone::Clone, const S: usize, B: std::clone::Cl
 fn hasbuffer<T: std::cmp::PartialEq, const S: usize>(a: &[T; S], v: &T) -> bool {
     for val in a {
         if val == v {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// `hasfnbuffer` returns true if the check function returns true for any element of the array
+#[inline(always)]
+fn hasfnbuffer<T, const S: usize>(a: &[T; S], f: fn(&T) -> bool) -> bool {
+    for v in a {
+        if f(v) {
             return true;
         }
     }


### PR DESCRIPTION
While looking at the closely related `find` and `index` functions, I realized that there was some missing functionality with `has` (and `index`) -- the ability to provide a checking function instead of an exact match on the value, letting you use your own logic to decide if the array or buffer has what you want.
