### PR TITLE
Drop ok, err, some (both kinds), none from language

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -1546,26 +1546,6 @@ test!(array_every => r#"
     }"#;
     stdout "false\n";
 );
-test_ignore!(array_every_some_del => r#"
-    fn isOdd (val: int64) -> bool = val % 2 == 1;
-
-    export fn main {
-      const test = [ 1, 1, 2, 3, 5, 8 ];
-      test.every(isOdd).print;
-      test.some(isOdd).print;
-      print(test.length);
-      print(test.delete(1));
-      print(test.delete(4));
-      print(test.delete(10));
-    }"#;
-    stdout r#"false
-true
-6
-1
-8
-cannot remove idx 10 from array with length 4
-"#;
-);
 test!(array_reduce_filter_concat_no_closures => r#"
     // Temporary test until closure functions are implemented
     fn isOdd(i: i64) -> bool = i % 2 == 1;
@@ -3436,7 +3416,7 @@ test_ignore!(tree_user_defined_types => r#"
     }"#;
     stdout "myFoo\n";
 );
-test_ignore!(tree_every_find_some_reduce_prune => r#"
+test_ignore!(tree_every_find_has_reduce_prune => r#"
     export fn main {
       const myTree = newTree('foo');
       const barNode = myTree.addChild('bar');
@@ -3444,7 +3424,7 @@ test_ignore!(tree_every_find_some_reduce_prune => r#"
       const bayNode = barNode.addChild('bay');
 
       print(myTree.every(fn (c: Node{string}) -> bool = (c || 'wrong').length == 3));
-      print(myTree.some(fn (c: Node{string}) -> bool = (c || 'wrong').length == 1));
+      print(myTree.has(fn (c: Node{string}) -> bool = (c || 'wrong').length == 1));
       print(myTree.find(fn (c: Node{string}) -> bool = (c || 'wrong') == 'bay').getOr('wrong'));
       print(myTree.find(fn (c: Node{string}) -> bool = (c || 'wrong') == 'asf').getOr('wrong'));
 

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -123,7 +123,6 @@ export type Duration binds std::time::Duration;
 /// Fallible and Maybe functions
 export fn getOr{T}(v: Maybe{T}, d: T) -> T binds maybe_get_or;
 export fn getOr{T}(v: Fallible{T}, d: T) -> T binds fallible_get_or;
-export fn ok{T}(v: T) -> Fallible{T} binds alan_ok;
 
 /// Integer-related functions and function bindings
 export fn i8(i: i8) -> i8 = i;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -34,13 +34,6 @@ impl From<String> for AlanError {
     }
 }
 
-/// `alan_ok` is a wrapper function that takes a reference to a value, clones it, and returns it as
-/// a Result-wrapped value. Hopefully this weird function will die soon.
-#[inline(always)]
-fn alan_ok<A: std::clone::Clone>(val: &A) -> Result<A, AlanError> {
-    Ok(val.clone())
-}
-
 /// `maybe_get_or` gets the Option's value or returns the default if not present.
 #[inline(always)]
 fn maybe_get_or<T: std::clone::Clone>(v: &Option<T>, d: &T) -> T {


### PR DESCRIPTION
Alan v0.2 doesn't really need these functions for the optional and fallible types. You can just `Maybe(val)` to be equivalent to `some(val)`, `Maybe{myType}(void)` to be equivalent to `none` (a bit more awkward, type inference should eventually support `Maybe(void)` for `none`), `Fallible(val)` for `ok(val)` and `Fallible{myType}(errorVal)` for `err(errorVal)` (again, type inference may help here). And the `Maybe` and `Fallible` "functions" could be bound to `?` and `!` postfix operators to turn that into just `val?`, `void?` (assuming inference works as desired), `val!`, and `errorVal!` (again assuming inference works as desired) which is even shorter.

At the same time, many languages have a different meaning for `some`, as an array method for determining if any of the elements of the array passes the provided check function. Alan since v0.1 includes a `has` function that accepts a value directly and returns true if that value is present in the array. This is like a shorthand for a check function that performs an equality check on the value, so I decided to expand `has` to also accept check functions, which therefore made it equivalent to `some` in those languages.

Since this language is aimed at both crowds, completely eliminating these terms from the language may be initially confusing, but should hopefully be less confusing than having a known term with a different meaning.
