### PR TITLE
Drop most string operators

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -198,7 +198,7 @@ test!(non_global_memory_exit_code => r#"
 // Unorganized Tests (TODO: Find a better grouping for these)
 test!(passing_ints_to_function => r#"
     fn aNumber(num: i64) {
-      print('I got a number! ' + num.string);
+      print('I got a number! '.concat(num.string));
     }
 
     export fn main {
@@ -738,47 +738,33 @@ true
 test!(string_ops => r#"
     export fn main {
       concat('Hello, ', 'World!').print;
-      print('Hello, ' + 'World!');
 
       repeat('hi ', 5).print;
-      print('hi ' * 5);
 
       // TODO: Add regex support
       //matches('foobar', 'fo.*').print;
       //print('foobar' ~ 'fo.*');
 
       index('foobar', 'ba').print;
-      print('foobar' @ 'ba');
 
       len('foobar').print;
       print(#'foobar');
 
       trim('   hi   ').print;
-      // TODO: Do we really want this operator?
-      // print(\`'   hi   ');
 
       split('Hello, World!', ', ')[0].print;
-      print(('Hello, World!' / ', ')[1]);
 
-      const res = split('Hello, World!', ', ');
+      const res = "Hello, World!".split(', ');
       res[0].print;
-
-      const res2 = 'Hello, World!' / ', ';
-      print(res2[1]);
     }"#;
     stdout r#"Hello, World!
-Hello, World!
 hi hi hi hi hi 
-hi hi hi hi hi 
-3
 3
 6
 6
 hi
 Hello
-World!
 Hello
-World!
 "#;
 );
 test!(string_const_vs_computed_equality => r#"

--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -1127,11 +1127,11 @@ test!(functions_and_custom_operators => r#"
     }
 
     fn bar(str: string, a: i64, b: i64) -> string {
-      return str * a + b.string;
+      return str.repeat(a).concat(b.string);
     }
 
     fn baz(pre: string, body: string) -> void {
-      print(pre + bar(body, 1, 2));
+      print(pre.concat(bar(body, 1, 2)));
     }
 
     fn double(a: i64) -> i64 = a * 2;

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -319,11 +319,8 @@ export fn string(f: f64) -> string binds f64tostring;
 export fn string(b: bool) -> string binds booltostring;
 export fn string(s: string) -> string = s;
 export fn concat(a: string, b: string) -> string binds concatstring;
-export fn add(a: string, b: string) -> string binds concatstring; // To use the '+' operator
 export fn repeat(a: string, n: i64) -> string binds repeatstring;
-export fn mul(a: string, n: i64) -> string binds repeatstring; // To use the '*' operator
 export fn split(a: string, b: string) -> string[] binds splitstring;
-export fn div(a: string, b: string) -> string[] binds splitstring; // To use the '/' operator
 export fn len(a: string) -> i64 binds lenstring;
 export fn get(a: string, i: i64) -> Fallible{string} binds getstring;
 export fn trim(a: string) -> string binds trimstring;
@@ -459,8 +456,7 @@ export infix lt as < precedence 0;
 export infix lte as <= precedence 0;
 export infix gt as > precedence 0;
 export infix gte as >= precedence 0;
-export prefix len as # precedence 0;
-export infix index as @ precedence 0;
+export prefix len as # precedence 0; // TODO: Is this useful?
 export infix shl as << precedence 1;
 export infix shr as >> precedence 1;
 export infix wrl as <<< precedence 1;


### PR DESCRIPTION
After thinking about it, there's no agreed upon set of operators for string manipulation like there is for arithmetic, and most languages are moving away from the few that gained some traction (eg `+`) and are moving towards string templating, instead.

So this removes almost all of them. I am still keeping `#` as a `len` operator for now since it applies to strings, buffers, arrays, and potentially other types, and I recall Perl having an operator like this. But it may also get dropped in the future.
