### PR TITLE
Get Array and Buffer 'concat' working... by a major update to the type system

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -1532,6 +1532,14 @@ test!(array_every => r#"
     }"#;
     stdout "false\n";
 );
+test!(array_concat => r#"
+    export fn main {
+        const test = [ 1, 1, 2, 3, 5, 8 ];
+        const test2 = [ 4, 5, 6 ];
+        test.concat(test2).map(string).join(', ').print;
+    }"#;
+    stdout "1, 1, 2, 3, 5, 8, 4, 5, 6\n";
+);
 test!(array_reduce_filter_concat_no_closures => r#"
     // Temporary test until closure functions are implemented
     fn isOdd(i: i64) -> bool = i % 2 == 1;
@@ -1676,6 +1684,14 @@ test!(buffer_every => r#"
         test.every(odd).print;
     }"#;
     stdout "false\n";
+);
+test!(buffer_concat => r#"
+    export fn main {
+        const test = {i64[6]}(1, 1, 2, 3, 5, 8);
+        const test2 = {i64[3]}(4, 5, 6);
+        test.concat(test2).map(string).join(', ').print;
+    }"#;
+    stdout "1, 1, 2, 3, 5, 8, 4, 5, 6\n";
 );
 
 // Hashing

--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -248,10 +248,12 @@ pub fn from_microstatement(
                                 if i == "i64" =>
                             {
                                 match (*a.clone(), *r.clone()) {
-                                    (CType::Array(_), CType::Either(ts)) if ts.len() == 2 => {
+                                    (CType::Array(_) | CType::Buffer(..), CType::Either(ts))
+                                        if ts.len() == 2 =>
+                                    {
                                         return Ok((
                                             format!(
-                                                "{}.get({})",
+                                                "{}.get({}).map(|v| v.clone())",
                                                 argstrs[0],
                                                 match argstrs[1].strip_prefix("&mut ") {
                                                     Some(s) => s,

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -107,7 +107,7 @@ pub fn ctype_to_rtype(
             }?
         )),
         CType::Array(t) => Ok(format!("Vec<{}>", ctype_to_rtype(t, in_function_type)?)),
-        CType::Fail(m) => CType::fail(&m),
+        CType::Fail(m) => CType::fail(m),
         otherwise => CType::fail(&format!("Lower stage of the compiler received unresolved algebraic type {}, cannot deal with it here. Please report this error.", otherwise.to_strict_string(false))),
     }
 }

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -107,6 +107,8 @@ pub fn ctype_to_rtype(
             }?
         )),
         CType::Array(t) => Ok(format!("Vec<{}>", ctype_to_rtype(t, in_function_type)?)),
+        CType::Fail(m) => CType::fail(&m),
+        otherwise => CType::fail(&format!("Lower stage of the compiler received unresolved algebraic type {}, cannot deal with it here. Please report this error.", otherwise.to_strict_string(false))),
     }
 }
 

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -31,6 +31,35 @@ pub enum CType {
     AnyOf(Vec<CType>),
     Buffer(Box<CType>, Box<CType>),
     Array(Box<CType>),
+    Fail(String),
+    Add(Vec<CType>),
+    Sub(Vec<CType>),
+    Mul(Vec<CType>),
+    Div(Vec<CType>),
+    Mod(Vec<CType>),
+    Pow(Vec<CType>),
+    Min(Vec<CType>),
+    Max(Vec<CType>),
+    Neg(Box<CType>),
+    Len(Box<CType>),
+    Size(Box<CType>),
+    FileStr(Box<CType>),
+    Env(Vec<CType>),
+    EnvExists(Box<CType>),
+    TIf(Box<CType>, Vec<CType>),
+    And(Vec<CType>),
+    Or(Vec<CType>),
+    Xor(Vec<CType>),
+    Not(Box<CType>),
+    Nand(Vec<CType>),
+    Nor(Vec<CType>),
+    Xnor(Vec<CType>),
+    TEq(Vec<CType>),
+    Neq(Vec<CType>),
+    Lt(Vec<CType>),
+    Lte(Vec<CType>),
+    Gt(Vec<CType>),
+    Gte(Vec<CType>),
 }
 
 impl CType {
@@ -106,6 +135,132 @@ impl CType {
                 s.to_strict_string(strict)
             ),
             CType::Array(t) => format!("{}[]", t.to_strict_string(strict)),
+            CType::Fail(m) => format!("Fail{{{}}}", m),
+            CType::Add(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" + "),
+            CType::Sub(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" - "),
+            CType::Mul(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" * "),
+            CType::Div(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" / "),
+            CType::Mod(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" % "),
+            CType::Pow(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" ** "),
+            CType::Min(ts) => format!(
+                "Min{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_strict_string(strict))
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Max(ts) => format!(
+                "Max{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_strict_string(strict))
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Neg(t) => format!("-{}", t.to_strict_string(strict)),
+            CType::Len(t) => format!("Len{{{}}}", t.to_strict_string(strict)),
+            CType::Size(t) => format!("Size{{{}}}", t.to_strict_string(strict)),
+            CType::FileStr(t) => format!("FileStr{{{}}}", t.to_strict_string(strict)),
+            CType::Env(ts) => format!(
+                "Env{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_strict_string(strict))
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::EnvExists(t) => format!("EnvExists{{{}}}", t.to_strict_string(strict)),
+            CType::TIf(t, ts) => format!(
+                "If{{{}, {}}}",
+                t.to_strict_string(strict),
+                ts.iter()
+                    .map(|t| t.to_strict_string(strict))
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::And(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" && "),
+            CType::Or(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" || "),
+            CType::Xor(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" ^ "),
+            CType::Not(t) => format!("!{}", t.to_strict_string(strict)),
+            CType::Nand(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" !& "),
+            CType::Nor(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" !| "),
+            CType::Xnor(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" !^ "),
+            CType::TEq(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" == "),
+            CType::Neq(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" != "),
+            CType::Lt(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" < "),
+            CType::Lte(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" <= "),
+            CType::Gt(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" > "),
+            CType::Gte(ts) => ts
+                .iter()
+                .map(|t| t.to_strict_string(strict))
+                .collect::<Vec<String>>()
+                .join(" >= "),
         }
     }
     pub fn to_functional_string(&self) -> String {
@@ -173,6 +328,168 @@ impl CType {
                 s.to_functional_string()
             ),
             CType::Array(t) => format!("Array{{{}}}", t.to_functional_string()),
+            CType::Fail(m) => format!("Fail{{{}}}", m),
+            CType::Add(ts) => format!(
+                "Add{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Sub(ts) => format!(
+                "Sub{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Mul(ts) => format!(
+                "Mul{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Div(ts) => format!(
+                "Div{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Mod(ts) => format!(
+                "Mod{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Pow(ts) => format!(
+                "Pow{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Min(ts) => format!(
+                "Min{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Max(ts) => format!(
+                "Max{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Neg(t) => format!("Neg{{{}}}", t.to_functional_string()),
+            CType::Len(t) => format!("Len{{{}}}", t.to_functional_string()),
+            CType::Size(t) => format!("Size{{{}}}", t.to_functional_string()),
+            CType::FileStr(t) => format!("FileStr{{{}}}", t.to_functional_string()),
+            CType::Env(ts) => format!(
+                "Env{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::EnvExists(t) => format!("EnvExists{{{}}}", t.to_functional_string()),
+            CType::TIf(t, ts) => format!(
+                "If{{{}, {}}}",
+                t.to_functional_string(),
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::And(ts) => format!(
+                "And{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Or(ts) => format!(
+                "Or{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Xor(ts) => format!(
+                "Xor{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Not(t) => format!("Not{{{}}}", t.to_functional_string()),
+            CType::Nand(ts) => format!(
+                "Nand{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Nor(ts) => format!(
+                "Nor{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Xnor(ts) => format!(
+                "Xnor{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::TEq(ts) => format!(
+                "Eq{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Neq(ts) => format!(
+                "Neq{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Lt(ts) => format!(
+                "Lt{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Lte(ts) => format!(
+                "Lte{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Gt(ts) => format!(
+                "Gt{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CType::Gte(ts) => format!(
+                "Gte{{{}}}",
+                ts.iter()
+                    .map(|t| t.to_functional_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
         }
     }
     pub fn to_callable_string(&self) -> String {
@@ -235,6 +552,38 @@ impl CType {
                 CType::Buffer(Box::new((*t).degroup()), Box::new((*s).degroup()))
             }
             CType::Array(t) => CType::Array(Box::new((*t).degroup())),
+            CType::Fail(m) => CType::Fail(m.clone()),
+            CType::Add(ts) => CType::Add(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Sub(ts) => CType::Sub(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Mul(ts) => CType::Mul(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Div(ts) => CType::Div(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Mod(ts) => CType::Mod(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Pow(ts) => CType::Pow(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Min(ts) => CType::Min(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Max(ts) => CType::Max(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Neg(t) => CType::Neg(Box::new((*t).degroup())),
+            CType::Len(t) => CType::Len(Box::new((*t).degroup())),
+            CType::Size(t) => CType::Size(Box::new((*t).degroup())),
+            CType::FileStr(t) => CType::FileStr(Box::new((*t).degroup())),
+            CType::Env(ts) => CType::Env(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::EnvExists(t) => CType::EnvExists(Box::new((*t).degroup())),
+            CType::TIf(t, ts) => CType::TIf(
+                Box::new((*t).degroup()),
+                ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>(),
+            ),
+            CType::And(ts) => CType::And(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Or(ts) => CType::Or(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Xor(ts) => CType::Xor(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Not(t) => CType::Not(Box::new((*t).degroup())),
+            CType::Nand(ts) => CType::Nand(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Nor(ts) => CType::Nor(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Xnor(ts) => CType::Xnor(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::TEq(ts) => CType::TEq(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Neq(ts) => CType::Neq(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Lt(ts) => CType::Lt(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Lte(ts) => CType::Lte(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Gt(ts) => CType::Gt(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
+            CType::Gte(ts) => CType::Gte(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>()),
         }
     }
     // Given a list of generic type names, a list of argument types provided, and the original type
@@ -491,6 +840,438 @@ impl CType {
                             }
                         } else {
                             generic_types.insert(g.clone(), CType::AnyOf(ts.clone()));
+                        }
+                    }
+                    (Some(CType::Fail(m1)), Some(CType::Fail(m2))) => {
+                        if m1 != m2 {
+                            return Err(
+                                "The two types want to fail in different ways. How bizarre!".into(),
+                            );
+                        }
+                    }
+                    (Some(CType::Add(ts1)), Some(CType::Add(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched add types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (
+                        Some(CType::Int(_) | CType::Float(_)),
+                        Some(
+                            CType::Add(_)
+                            | CType::Sub(_)
+                            | CType::Mul(_)
+                            | CType::Div(_)
+                            | CType::Mod(_)
+                            | CType::Pow(_)
+                            | CType::Min(_)
+                            | CType::Max(_)
+                            | CType::Neg(_)
+                            | CType::Len(_)
+                            | CType::Size(_),
+                        ),
+                    ) => {
+                        // TODO: This should allow us to constrain which generic values are
+                        // possible for each generic to infer on the right-hand-side, but for now
+                        // we're just going to ignore this path and require the components are
+                        // inferred separately in the type system
+                    }
+                    (
+                        Some(CType::Int(_) | CType::Bool(_)),
+                        Some(
+                            CType::And(_)
+                            | CType::Or(_)
+                            | CType::Xor(_)
+                            | CType::Not(_)
+                            | CType::Nand(_)
+                            | CType::Nor(_)
+                            | CType::Xnor(_),
+                        ),
+                    ) => {
+                        // TODO: Also skipping this for now
+                    }
+                    (
+                        Some(CType::Int(_) | CType::Float(_) | CType::TString(_) | CType::Bool(_)),
+                        Some(CType::TEq(_) | CType::Neq(_)),
+                    ) => {
+                        // TODO: Also skipping this for now
+                    }
+                    (
+                        Some(CType::Int(_) | CType::Float(_) | CType::TString(_)),
+                        Some(CType::Lt(_) | CType::Lte(_) | CType::Gt(_) | CType::Gte(_)),
+                    ) => {
+                        // TODO: Also skipping this for now
+                    }
+                    (Some(CType::Sub(ts1)), Some(CType::Sub(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched sub types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Mul(ts1)), Some(CType::Mul(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched mul types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Div(ts1)), Some(CType::Div(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched div types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Mod(ts1)), Some(CType::Mod(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched div types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Pow(ts1)), Some(CType::Pow(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched pow types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Min(ts1)), Some(CType::Min(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched min types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Max(ts1)), Some(CType::Max(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched max types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Neg(t1)), Some(CType::Neg(t2))) => {
+                        arg.push(t1);
+                        input.push(t2);
+                    }
+                    (Some(CType::Len(t1)), Some(CType::Len(t2))) => {
+                        arg.push(t1);
+                        input.push(t2);
+                    }
+                    (Some(CType::Size(t1)), Some(CType::Size(t2))) => {
+                        arg.push(t1);
+                        input.push(t2);
+                    }
+                    (Some(CType::FileStr(t1)), Some(CType::FileStr(t2))) => {
+                        arg.push(t1);
+                        input.push(t2);
+                    }
+                    (Some(CType::Env(ts1)), Some(CType::Env(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched env types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::EnvExists(t1)), Some(CType::EnvExists(t2))) => {
+                        arg.push(t1);
+                        input.push(t2);
+                    }
+                    (Some(CType::TIf(t1, ts1)), Some(CType::TIf(t2, ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched env types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        arg.push(t1);
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        input.push(t2);
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::And(ts1)), Some(CType::And(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched and types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Or(ts1)), Some(CType::Or(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched or types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Xor(ts1)), Some(CType::Xor(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched xor types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Not(t1)), Some(CType::Not(t2))) => {
+                        arg.push(t1);
+                        input.push(t2);
+                    }
+                    (Some(CType::Nand(ts1)), Some(CType::Nand(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched nand types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Nor(ts1)), Some(CType::Nor(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched nor types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Xnor(ts1)), Some(CType::Xnor(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched xnor types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::TEq(ts1)), Some(CType::TEq(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched eq types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Neq(ts1)), Some(CType::Neq(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched neq types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Lt(ts1)), Some(CType::Lt(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched lt types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Lte(ts1)), Some(CType::Lte(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched lte types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Gt(ts1)), Some(CType::Gt(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched gt types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
+                        }
+                    }
+                    (Some(CType::Gte(ts1)), Some(CType::Gte(ts2))) => {
+                        if ts1.len() != ts2.len() {
+                            return Err(format!(
+                                "Mismatched gte types {} and {} found during inference",
+                                a.unwrap().to_string(),
+                                i.unwrap().to_string()
+                            )
+                            .into());
+                        }
+                        for t1 in ts1 {
+                            arg.push(t1);
+                        }
+                        for t2 in ts2 {
+                            input.push(t2);
                         }
                     }
                     (Some(a), Some(CType::Infer(g, _))) => {
@@ -758,6 +1539,22 @@ impl CType {
                     name: constructor_fn_name.clone(),
                     args: vec![("arg0".to_string(), *b.clone())],
                     rettype: t.clone(),
+                    microstatements: Vec::new(),
+                    kind: FnKind::Derived,
+                });
+                fs.push(Function {
+                    name: "get".to_string(),
+                    args: vec![
+                        ("arg0".to_string(), t.clone()),
+                        (
+                            "arg1".to_string(),
+                            CType::Bound("i64".to_string(), "i64".to_string()),
+                        ),
+                    ],
+                    rettype: CType::Type(
+                        format!("Maybe_{}_", b.to_string()),
+                        Box::new(CType::Either(vec![*b.clone(), CType::Void])),
+                    ),
                     microstatements: Vec::new(),
                     kind: FnKind::Derived,
                 });
@@ -1062,7 +1859,8 @@ impl CType {
             | CType::Int(_)
             | CType::Float(_)
             | CType::Bool(_)
-            | CType::TString(_) => self.clone(),
+            | CType::TString(_)
+            | CType::Fail(_) => self.clone(),
             CType::Type(name, ct) => {
                 CType::Type(name.clone(), Box::new(ct.swap_subtype(old_type, new_type)))
             }
@@ -1105,6 +1903,142 @@ impl CType {
                 Box::new(size.swap_subtype(old_type, new_type)),
             ),
             CType::Array(t) => CType::Array(Box::new(t.swap_subtype(old_type, new_type))),
+            // For these when we swap, we check to see if we can "condense" them down into simpler
+            // types (eg `Add{N, 1}` swapping `N` for `3` should just yield `4`)
+            CType::Add(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::add(&a, &b))
+                .unwrap(),
+            CType::Sub(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::sub(&a, &b))
+                .unwrap(),
+            CType::Mul(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::mul(&a, &b))
+                .unwrap(),
+            CType::Div(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::div(&a, &b))
+                .unwrap(),
+            CType::Mod(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::cmod(&a, &b))
+                .unwrap(),
+            CType::Pow(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::pow(&a, &b))
+                .unwrap(),
+            CType::Min(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::min(&a, &b))
+                .unwrap(),
+            CType::Max(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::max(&a, &b))
+                .unwrap(),
+            CType::Neg(t) => CType::neg(&t.swap_subtype(old_type, new_type)),
+            CType::Len(t) => CType::len(&t.swap_subtype(old_type, new_type)),
+            CType::Size(t) => CType::size(&t.swap_subtype(old_type, new_type)),
+            CType::FileStr(t) => CType::filestr(&t.swap_subtype(old_type, new_type)),
+            CType::Env(ts) => {
+                if ts.len() == 1 {
+                    CType::env(&ts[0].swap_subtype(old_type, new_type))
+                } else if ts.len() == 2 {
+                    CType::envdefault(
+                        &ts[0].swap_subtype(old_type, new_type),
+                        &ts[1].swap_subtype(old_type, new_type),
+                    )
+                } else {
+                    CType::fail("Somehow gave Env{..} an incorrect number of args and caught during generic resolution")
+                }
+            }
+            CType::EnvExists(t) => CType::envexists(&t.swap_subtype(old_type, new_type)),
+            CType::TIf(t, ts) => {
+                if ts.len() == 1 {
+                    CType::tupleif(
+                        &t.swap_subtype(old_type, new_type),
+                        &ts[0].swap_subtype(old_type, new_type),
+                    )
+                } else if ts.len() == 2 {
+                    CType::cif(
+                        &t.swap_subtype(old_type, new_type),
+                        &ts[0].swap_subtype(old_type, new_type),
+                        &ts[1].swap_subtype(old_type, new_type),
+                    )
+                } else {
+                    CType::fail("Somehow gave If{..} an incorrect number of args and caught during generic resolution")
+                }
+            }
+            CType::And(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::and(&a, &b))
+                .unwrap(),
+            CType::Or(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::or(&a, &b))
+                .unwrap(),
+            CType::Xor(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::xor(&a, &b))
+                .unwrap(),
+            CType::Not(t) => CType::not(&t.swap_subtype(old_type, new_type)),
+            CType::Nand(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::nand(&a, &b))
+                .unwrap(),
+            CType::Nor(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::nor(&a, &b))
+                .unwrap(),
+            CType::Xnor(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::xnor(&a, &b))
+                .unwrap(),
+            CType::TEq(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::eq(&a, &b))
+                .unwrap(),
+            CType::Neq(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::neq(&a, &b))
+                .unwrap(),
+            CType::Lt(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::lt(&a, &b))
+                .unwrap(),
+            CType::Lte(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::lte(&a, &b))
+                .unwrap(),
+            CType::Gt(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::gt(&a, &b))
+                .unwrap(),
+            CType::Gte(ts) => ts
+                .iter()
+                .map(|t| t.swap_subtype(old_type, new_type))
+                .reduce(|a, b| CType::gte(&a, &b))
+                .unwrap(),
         }
     }
     // Special implementation for the tuple and either types since they *are* CTypes, but if one of
@@ -1174,18 +2108,20 @@ impl CType {
         } else {
             let arg1 = args.pop().unwrap().degroup();
             let arg0 = args.pop().unwrap().degroup();
-            match (arg0, arg1) {
+            match (&arg0, &arg1) {
+                (CType::Infer(..), _) => {
+                    CType::Buffer(Box::new(arg0.clone()), Box::new(arg1.clone()))
+                }
+                (_, CType::Infer(..)) => {
+                    CType::Buffer(Box::new(arg0.clone()), Box::new(arg1.clone()))
+                }
                 (anything, CType::Int(size)) => {
-                    if size < 0 {
+                    if *size < 0 {
                         CType::fail("The buffer size must be a positive integer")
                     } else {
-                        CType::Buffer(Box::new(anything.clone()), Box::new(CType::Int(size)))
+                        CType::Buffer(Box::new(anything.clone()), Box::new(CType::Int(*size)))
                     }
                 }
-                (anything, CType::Infer(n, t)) => CType::Buffer(
-                    Box::new(anything.clone()),
-                    Box::new(CType::Infer(n.clone(), t.clone())),
-                ),
                 _ => CType::fail("The buffer size must be a positive integer"),
             }
         }
@@ -1196,9 +2132,9 @@ impl CType {
         eprintln!("{}", message);
         std::process::exit(1);
     }
-    pub fn cfail(message: &CType) -> ! {
+    pub fn cfail(message: &CType) -> CType {
         match message {
-            CType::TString(s) => CType::fail(s),
+            CType::TString(s) => CType::Fail(s.clone()),
             _ => CType::fail("Fail passed a type that does not resolve into a message string"),
         }
     }
@@ -1206,9 +2142,8 @@ impl CType {
         match *t {
             CType::Int(v) => CType::Int(-v),
             CType::Float(v) => CType::Float(-v),
-            _ => CType::fail(
-                "Attempting to add non-integer or non-float types together at compile time",
-            ),
+            CType::Infer(..) => CType::Neg(Box::new(t.clone())),
+            _ => CType::fail("Attempting to negate non-integer or non-float types at compile time"),
         }
     }
     pub fn len(t: &CType) -> CType {
@@ -1224,17 +2159,21 @@ impl CType {
             CType::Array(_) => {
                 CType::fail("Cannot get a compile time length for a variable-length array")
             }
+            CType::Infer(..) => CType::Len(Box::new(t.clone())),
             _ => CType::Int(1),
         }
     }
-    pub fn size(_t: &CType) -> CType {
+    pub fn size(t: &CType) -> CType {
         // TODO: Implementing this might require all types be made C-style structs under the hood,
         // and probably some weird hackery to find out the size including padding on aligned
         // architectures, so I might take it back out before its actually implemented, but I can
         // think of several places where knowing the actual size of the type could be useful,
         // particularly for writing to disk or interfacing with network protocols, etc, so I'd
         // prefer to keep it and have some compile-time guarantees we don't normally see.
-        CType::fail("TODO: Implement Size{T}!")
+        match t {
+            CType::Infer(..) => CType::Size(Box::new(t.clone())),
+            _ => CType::fail("TODO: Implement Size{T}!"),
+        }
     }
     pub fn filestr(f: &CType) -> CType {
         match f {
@@ -1242,6 +2181,7 @@ impl CType {
                 Err(e) => CType::fail(&format!("Failed to read {}: {:?}", s, e)),
                 Ok(s) => CType::TString(s),
             },
+            CType::Infer(..) => CType::FileStr(Box::new(f.clone())),
             _ => CType::fail("FileStr{F} must be given a string path to load"),
         }
     }
@@ -1263,6 +2203,7 @@ impl CType {
                 // All TStrings are quoted. TODO: Alan supports single-quotes, be less weird here
                 Ok(s) => CType::TString(format!("\"{}\"", s.replace('"', "\\\""))),
             },
+            CType::Infer(..) => CType::Env(vec![k.clone()]),
             _ => CType::fail("Env{K} must be given a key as a string to load"),
         }
     }
@@ -1272,12 +2213,14 @@ impl CType {
                 Err(_) => CType::Bool(false),
                 Ok(_) => CType::Bool(true),
             },
+            CType::Infer(..) => CType::EnvExists(Box::new(k.clone())),
             _ => CType::fail("EnvExists{K} must be given a key as a string to check"),
         }
     }
     pub fn not(b: &CType) -> CType {
         match b {
             CType::Bool(b) => CType::Bool(!*b),
+            CType::Infer(..) => CType::Not(Box::new(b.clone())),
             _ => CType::fail("Not{B} must be provided a boolean type to invert"),
         }
     }
@@ -1285,8 +2228,14 @@ impl CType {
         match (a, b) {
             (&CType::Int(a), &CType::Int(b)) => CType::Int(if a < b { a } else { b }),
             (&CType::Float(a), &CType::Float(b)) => CType::Float(if a < b { a } else { b }),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_)) => {
+                CType::Min(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_), &CType::Infer(..)) => {
+                CType::Min(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail(
-                "Attempting to add non-integer or non-float types together at compile time",
+                "Attempting to min non-integer or non-float types together at compile time",
             ),
         }
     }
@@ -1294,8 +2243,14 @@ impl CType {
         match (a, b) {
             (&CType::Int(a), &CType::Int(b)) => CType::Int(if a > b { a } else { b }),
             (&CType::Float(a), &CType::Float(b)) => CType::Float(if a > b { a } else { b }),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_)) => {
+                CType::Max(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_), &CType::Infer(..)) => {
+                CType::Max(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail(
-                "Attempting to add non-integer or non-float types together at compile time",
+                "Attempting to max non-integer or non-float types together at compile time",
             ),
         }
     }
@@ -1303,6 +2258,12 @@ impl CType {
         match (a, b) {
             (&CType::Int(a), &CType::Int(b)) => CType::Int(a + b),
             (&CType::Float(a), &CType::Float(b)) => CType::Float(a + b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_)) => {
+                CType::Add(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_), &CType::Infer(..)) => {
+                CType::Add(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail(
                 "Attempting to add non-integer or non-float types together at compile time",
             ),
@@ -1312,6 +2273,12 @@ impl CType {
         match (a, b) {
             (&CType::Int(a), &CType::Int(b)) => CType::Int(a - b),
             (&CType::Float(a), &CType::Float(b)) => CType::Float(a - b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_)) => {
+                CType::Sub(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_), &CType::Infer(..)) => {
+                CType::Sub(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail(
                 "Attempting to subtract non-integer or non-float types together at compile time",
             ),
@@ -1321,6 +2288,12 @@ impl CType {
         match (a, b) {
             (&CType::Int(a), &CType::Int(b)) => CType::Int(a * b),
             (&CType::Float(a), &CType::Float(b)) => CType::Float(a * b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_)) => {
+                CType::Mul(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_), &CType::Infer(..)) => {
+                CType::Mul(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail(
                 "Attempting to multiply non-integer or non-float types together at compile time",
             ),
@@ -1330,6 +2303,12 @@ impl CType {
         match (a, b) {
             (&CType::Int(a), &CType::Int(b)) => CType::Int(a / b),
             (&CType::Float(a), &CType::Float(b)) => CType::Float(a / b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_)) => {
+                CType::Div(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_), &CType::Infer(..)) => {
+                CType::Div(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail(
                 "Attempting to divide non-integer or non-float types together at compile time",
             ),
@@ -1338,6 +2317,10 @@ impl CType {
     pub fn cmod(a: &CType, b: &CType) -> CType {
         match (a, b) {
             (&CType::Int(a), &CType::Int(b)) => CType::Int(a * b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_)) => {
+                CType::Mod(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_), &CType::Infer(..)) => CType::Mod(vec![a.clone(), b.clone()]),
             _ => CType::fail("Attempting to modulus non-integer types together at compile time"),
         }
     }
@@ -1348,6 +2331,12 @@ impl CType {
                 None => CType::fail("Compile time exponentiation too large"),
             }),
             (&CType::Float(a), &CType::Float(b)) => CType::Float(a.powf(b)),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_)) => {
+                CType::Pow(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_), &CType::Infer(..)) => {
+                CType::Pow(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail(
                 "Attempting to divide non-integer or non-float types together at compile time",
             ),
@@ -1359,6 +2348,7 @@ impl CType {
                 true => a.clone(),
                 false => b.clone(),
             },
+            CType::Infer(..) => CType::TIf(Box::new(c.clone()), vec![a.clone(), b.clone()]),
             _ => CType::fail("If{C, A, B} must be given a boolean value as the condition"),
         }
     }
@@ -1381,6 +2371,7 @@ impl CType {
                     ),
                 }
             }
+            CType::Infer(..) => CType::TIf(Box::new(c.clone()), vec![t.clone()]),
             _ => CType::fail("The first type provided to If{C, T} must be a boolean type"),
         }
     }
@@ -1390,6 +2381,9 @@ impl CType {
                 Err(_) => CType::TString(def.clone()),
                 Ok(v) => CType::TString(v),
             },
+            (CType::Infer(..), CType::TString(_))
+            | (CType::TString(_), CType::Infer(..))
+            | (CType::Infer(..), CType::Infer(..)) => CType::Env(vec![k.clone(), d.clone()]),
             _ => CType::fail("Env{K, D} must be provided a string for each type"),
         }
     }
@@ -1397,6 +2391,12 @@ impl CType {
         match (a, b) {
             (CType::Int(a), CType::Int(b)) => CType::Int(*a & *b),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(*a && *b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Bool(_)) => {
+                CType::And(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Bool(_), &CType::Infer(..)) => {
+                CType::And(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail(
                 "And{A, B} must be provided two values of the same type, either integer or boolean",
             ),
@@ -1406,6 +2406,12 @@ impl CType {
         match (a, b) {
             (CType::Int(a), CType::Int(b)) => CType::Int(*a | *b),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(*a || *b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Bool(_)) => {
+                CType::Or(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Bool(_), &CType::Infer(..)) => {
+                CType::Or(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail(
                 "Or{A, B} must be provided two values of the same type, either integer or boolean",
             ),
@@ -1415,6 +2421,12 @@ impl CType {
         match (a, b) {
             (CType::Int(a), CType::Int(b)) => CType::Int(*a ^ *b),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(*a ^ *b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Bool(_)) => {
+                CType::Xor(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Bool(_), &CType::Infer(..)) => {
+                CType::Xor(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail(
                 "Or{A, B} must be provided two values of the same type, either integer or boolean",
             ),
@@ -1424,6 +2436,12 @@ impl CType {
         match (a, b) {
             (CType::Int(a), CType::Int(b)) => CType::Int(!(*a & *b)),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(!(*a && *b)),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Bool(_)) => {
+                CType::Nand(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Bool(_), &CType::Infer(..)) => {
+                CType::Nand(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail("Nand{A, B} must be provided two values of the same type, either integer or boolean")
         }
     }
@@ -1431,6 +2449,12 @@ impl CType {
         match (a, b) {
             (CType::Int(a), CType::Int(b)) => CType::Int(!(*a | *b)),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(!(*a || *b)),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Bool(_)) => {
+                CType::Nor(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Bool(_), &CType::Infer(..)) => {
+                CType::Nor(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail(
                 "Nor{A, B} must be provided two values of the same type, either integer or boolean",
             ),
@@ -1440,6 +2464,12 @@ impl CType {
         match (a, b) {
             (CType::Int(a), CType::Int(b)) => CType::Int(!(*a ^ *b)),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(!(*a ^ *b)),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Bool(_)) => {
+                CType::Xnor(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Bool(_), &CType::Infer(..)) => {
+                CType::Xnor(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail("Xnor{A, B} must be provided two values of the same type, either integer or boolean")
         }
     }
@@ -1449,6 +2479,12 @@ impl CType {
             (CType::Float(a), CType::Float(b)) => CType::Bool(*a == *b),
             (CType::TString(a), CType::TString(b)) => CType::Bool(*a == *b),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(*a == *b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_) | &CType::TString(_) | &CType::Bool(_)) => {
+                CType::TEq(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_) | &CType::TString(_) | &CType::Bool(_), &CType::Infer(..)) => {
+                CType::TEq(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail("Eq{A, B} must be provided two values of the same type, one of: integer, float, string, boolean"),
         }
     }
@@ -1458,6 +2494,12 @@ impl CType {
             (CType::Float(a), CType::Float(b)) => CType::Bool(*a != *b),
             (CType::TString(a), CType::TString(b)) => CType::Bool(*a != *b),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(*a != *b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_) | &CType::TString(_) | &CType::Bool(_)) => {
+                CType::Neq(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_) | &CType::TString(_) | &CType::Bool(_), &CType::Infer(..)) => {
+                CType::Neq(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail("Neq{A, B} must be provided two values of the same type, one of: integer, float, string, boolean"),
         }
     }
@@ -1466,6 +2508,12 @@ impl CType {
             (CType::Int(a), CType::Int(b)) => CType::Bool(*a < *b),
             (CType::Float(a), CType::Float(b)) => CType::Bool(*a < *b),
             (CType::TString(a), CType::TString(b)) => CType::Bool(*a < *b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_) | &CType::TString(_)) => {
+                CType::Lt(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_) | &CType::TString(_), &CType::Infer(..)) => {
+                CType::Lt(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail("Lt{A, B} must be provided two values of the same type, one of: integer, float, string"),
         }
     }
@@ -1474,6 +2522,12 @@ impl CType {
             (CType::Int(a), CType::Int(b)) => CType::Bool(*a <= *b),
             (CType::Float(a), CType::Float(b)) => CType::Bool(*a <= *b),
             (CType::TString(a), CType::TString(b)) => CType::Bool(*a <= *b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_) | &CType::TString(_)) => {
+                CType::Lte(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_) | &CType::TString(_), &CType::Infer(..)) => {
+                CType::Lte(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail("Lte{A, B} must be provided two values of the same type, one of: integer, float, string"),
         }
     }
@@ -1482,6 +2536,12 @@ impl CType {
             (CType::Int(a), CType::Int(b)) => CType::Bool(*a > *b),
             (CType::Float(a), CType::Float(b)) => CType::Bool(*a > *b),
             (CType::TString(a), CType::TString(b)) => CType::Bool(*a > *b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_) | &CType::TString(_)) => {
+                CType::Gt(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_) | &CType::TString(_), &CType::Infer(..)) => {
+                CType::Gt(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail("Gt{A, B} must be provided two values of the same type, one of: integer, float, string"),
         }
     }
@@ -1490,6 +2550,12 @@ impl CType {
             (CType::Int(a), CType::Int(b)) => CType::Bool(*a >= *b),
             (CType::Float(a), CType::Float(b)) => CType::Bool(*a >= *b),
             (CType::TString(a), CType::TString(b)) => CType::Bool(*a >= *b),
+            (&CType::Infer(..), &CType::Infer(..) | &CType::Int(_) | &CType::Float(_) | &CType::TString(_)) => {
+                CType::Gte(vec![a.clone(), b.clone()])
+            }
+            (&CType::Int(_) | &CType::Float(_) | &CType::TString(_), &CType::Infer(..)) => {
+                CType::Gte(vec![a.clone(), b.clone()])
+            }
             _ => CType::fail("Gte{A, B} must be provided two values of the same type, one of: integer, float, string"),
         }
     }

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -23,7 +23,7 @@ export ctype AnyOf{A, B}; // The AnyOf type is kinda like a Tuple, in that all s
 export ctype Buffer{T, S}; // A buffer type, a pre-allocated, fixed-length array of the specified type the specified amount
 export ctype Array{T}; // An array type, a variable-length array of the specified type the specified amount. This would usually be an stdlib type built in the language itself, but we're just going to re-use the one in the platform language
 
-// The following `ctype`s don't represent data but instead represent transforms that convert into one of the many ctypes above. (I did not expect to need so many of them.) I was originally thinking of making these `cfn` functions, but I don't think the distinction is useful or something users need to worry about, especially as the latter half of the above ctypes are "function-like" so these are marked as `ctype`s, too
+// The following `ctype`s don't represent data but instead represent transforms that convert into one of the many ctypes above. (I did not expect to need so many of them.)
 export ctype Fail{M}; // A special type that if ever encountered at compile time causes the compilation to fail with the specified error message. Useful with conditional types
 export ctype Add{A, B}; // Combines the Int or Float types together at compile time into a new Int or Float. Fails if an Int and Float are mixed.
 export ctype Sub{A, B}; // Same, but subtracts them
@@ -71,8 +71,8 @@ export type infix Tuple as , precedence 0; // A, B, C, ... The tuple type combin
 export type infix Field as : precedence 1; // Foo: Bar, let's you specify a property access label for the type, useful for syntactic sugar on a tuple type and the Either type (eventually).
 export type infix Either as | precedence 0; // A | B, the type has a singular value from only one of the types at once. `Result` is just `Either{T, Error}` and `Option` is just `Either{T, ()}` (or `Either{T, void}`, however we want to represent it, also might go with `Fallible` and `Maybe` instead of `Result` and `Option` as those feel more descriptive of what they are.
 export type infix AnyOf as & precedence 0; // A & B, which can be passed to a function that takes A or B as necessary.
-export type infix Buffer as [ precedence 2; // Technically allows `Foo[3` by itself to be valid syntax, but...
-export type postfix Group as ] precedence 2; // Technically not necessary, but allows for `Foo[3]` to do the "right thing" and become a buffer of size 3, with a singular useless Group being wrapped around it (and then unwrapped on type generation). The only "bad" thing here is `Group` gets special behavior, matching the `(...)` syntax, so there's two ways to invoke a Group via symbols.
+export type infix Buffer as [ precedence 1; // Technically allows `Foo[3` by itself to be valid syntax, but...
+export type postfix Group as ] precedence 1; // Technically not necessary, but allows for `Foo[3]` to do the "right thing" and become a buffer of size 3, with a singular useless Group being wrapped around it (and then unwrapped on type generation). The only "bad" thing here is `Group` gets special behavior, matching the `(...)` syntax, so there's two ways to invoke a Group via symbols.
 export type postfix Array as [] precedence 4; // Allows `Foo[]` to do the right thing
 export type postfix Maybe as ? precedence 4; // Allows `Foo?` for nullable types. Should this have a precedence of 5?
 export type postfix Fallible as ! precedence 4; // Allows `Foo!` for fallible types. Same question on the precedence.
@@ -373,6 +373,7 @@ export fn has{T}(a: Array{T}, v: T) -> bool binds hasarray;
 export fn has{T}(a: Array{T}, f: (T) -> bool) -> bool binds hasfnarray;
 export fn find{T}(a: Array{T}, f: (T) -> bool) -> Maybe{T} binds findarray;
 export fn every{T}(a: Array{T}, f: (T) -> bool) -> bool binds everyarray;
+export fn concat{T}(a: Array{T}, b: Array{T}) -> Array{T} binds concatarray;
 
 /// Buffer related bindings
 export fn len{T, S}(T[S]) -> i64 = {S}();
@@ -384,6 +385,16 @@ export fn has{T, S}(a: Buffer{T, S}, v: T) -> bool binds hasbuffer;
 export fn has{T, S}(a: Buffer{T, S}, f: (T) -> bool) -> bool binds hasfnbuffer;
 export fn find{T, S}(a: Buffer{T, S}, f: (T) -> bool) -> Maybe{T} binds findbuffer;
 export fn every{T, S}(a: Buffer{T, S}, f: (T) -> bool) -> bool binds everybuffer;
+fn concatInner{T, S, N}(o: Buffer{T, S + N}, a: Buffer{T, S}, b: Buffer{T, N}) -> void binds concatbuffer;
+export fn concat{T, S, N}(a: Buffer{T, S}, b: Buffer{T, N}) -> Buffer{T, S + N} {
+  // I can't bind directly into Rust because Rust can't add const integer type parameters together.
+  // It's *theoretically* possible to generate a new Rust function in each case with the required
+  // sizes, but it will be really difficult, so I'm implementing this for now with the intent to
+  // eventually replace it.
+  let o = {T[S + N]}(a[0].getOrExit);
+  concatInner(o, a, b);
+  return o;
+}
 
 /// Process exit-related bindings
 export fn ExitCode(e: i8) -> ExitCode binds to_exit_code_i8;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -1819,15 +1819,24 @@ fn everyarray<T>(a: &Vec<T>, f: fn(&T) -> bool) -> bool {
     return true;
 }
 
+/// `concatarray` returns a new vector composed of the elements of the input vectors
+#[inline(always)]
+fn concatarray<T: std::clone::Clone>(a: &Vec<T>, b: &Vec<T>) -> Vec<T> {
+    let mut out = Vec::new();
+    for v in a {
+        out.push(v.clone());
+    }
+    for v in b {
+        out.push(v.clone());
+    }
+    out
+}
+
 /// `mapbuffer_onearg` runs the provided single-argument function on each element of the buffer,
 /// returning a new buffer
 #[inline(always)]
-fn mapbuffer_onearg<A, const N: usize, B: std::marker::Copy>(v: &[A; N], m: fn(&A) -> B) -> [B; N] {
-    let mut out = [m(&v[0]); N];
-    for i in 1..N {
-        out[i] = m(&v[i]);
-    }
-    out
+fn mapbuffer_onearg<A, const N: usize, B>(v: &[A; N], m: fn(&A) -> B) -> [B; N] {
+    std::array::from_fn(|i| m(&v[i]))
 }
 
 /// `mapbuffer_twoarg` runs the provided two-argument (value, index) function on each element of the
@@ -1922,6 +1931,19 @@ fn everybuffer<T, const S: usize>(a: &[T; S], f: fn(&T) -> bool) -> bool {
         }
     }
     return true;
+}
+
+/// `concatbuffer` mutates the first buffer given with the values of the other two. It depends on
+/// the provided buffer to be the right size to fit the data from both of the other buffers.
+#[inline(always)]
+fn concatbuffer<T: std::clone::Clone, const S: usize, const N: usize, const O: usize>(
+    o: &mut [T; O],
+    a: &[T; S],
+    b: &[T; N],
+) {
+    for (i, v) in a.iter().chain(b).enumerate() {
+        o[i] = v.clone();
+    }
 }
 
 struct GPU {


### PR DESCRIPTION
In order to properly infer `A + B` in the type system, `Add` needed to be able to be lazily evaluated, so a *lot* of types were added to the `CType` enum in order to get this working. Also, I forgot to add `get` support for Buffers, and probably a few other things.
