### PR TITLE
Remove redundant 'concat' implementation

### DIFF
--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -373,7 +373,6 @@ export fn has{T}(a: Array{T}, v: T) -> bool binds hasarray;
 export fn has{T}(a: Array{T}, f: (T) -> bool) -> bool binds hasfnarray;
 export fn find{T}(a: Array{T}, f: (T) -> bool) -> Maybe{T} binds findarray;
 export fn every{T}(a: Array{T}, f: (T) -> bool) -> bool binds everyarray;
-export fn concat{T}(a: Array{T}, b: Array{T}) -> Array{T} binds concatarray;
 
 /// Buffer related bindings
 export fn len{T, S}(T[S]) -> i64 = {S}();

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -1819,19 +1819,6 @@ fn everyarray<T>(a: &Vec<T>, f: fn(&T) -> bool) -> bool {
     return true;
 }
 
-/// `concatarray` returns a new vector composed of the elements of the input vectors
-#[inline(always)]
-fn concatarray<T: std::clone::Clone>(a: &Vec<T>, b: &Vec<T>) -> Vec<T> {
-    let mut out = Vec::new();
-    for v in a {
-        out.push(v.clone());
-    }
-    for v in b {
-        out.push(v.clone());
-    }
-    out
-}
-
 /// `mapbuffer_onearg` runs the provided single-argument function on each element of the buffer,
 /// returning a new buffer
 #[inline(always)]


### PR DESCRIPTION
In the last PR I somehow forgot that I had already implemented `concat` for Arrays, so I implemented it again. This removes the new duplicate implementation.
