### PR TITLE
Array and Buffer (kinda) 'repeat' implemented

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -1474,10 +1474,10 @@ test!(array_map => r#"
     }"#;
     stdout "1, 2, 3, 4, 5\n2, 4, 6, 8, 10\n";
 );
-test_ignore!(array_repeat_and_map_lin => r#"
+test!(array_repeat => r#"
     export fn main {
-      const arr = [1, 2, 3] * 3;
-      const out = arr.mapLin(fn (x: int64) -> string = x.string).join(', ');
+      const arr = [1, 2, 3].repeat(3);
+      const out = arr.map(fn (x: i64) -> string = x.string).join(', ');
       print(out);
     }"#;
     stdout "1, 2, 3, 1, 2, 3, 1, 2, 3\n";
@@ -1609,6 +1609,14 @@ test!(buffer_concat => r#"
         test.concat(test2).map(string).join(', ').print;
     }"#;
     stdout "1, 1, 2, 3, 5, 8, 4, 5, 6\n";
+);
+test!(buffer_repeat => r#"
+    export fn main {
+      const buf = {i64[3]}(1, 2, 3).repeat(3);
+      const out = buf.map(string).join(', ');
+      print(out);
+    }"#;
+    stdout "1, 2, 3, 1, 2, 3, 1, 2, 3\n";
 );
 
 // Hashing

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -385,6 +385,7 @@ export fn has{T}(a: Array{T}, v: T) -> bool binds hasarray;
 export fn has{T}(a: Array{T}, f: (T) -> bool) -> bool binds hasfnarray;
 export fn find{T}(a: Array{T}, f: (T) -> bool) -> Maybe{T} binds findarray;
 export fn every{T}(a: Array{T}, f: (T) -> bool) -> bool binds everyarray;
+export fn repeat{T}(a: Array{T}, c: i64) -> Array{T} binds repeatarray;
 
 /// Buffer related bindings
 export fn len{T, S}(T[S]) -> i64 = {S}();
@@ -406,6 +407,9 @@ export fn concat{T, S, N}(a: Buffer{T, S}, b: Buffer{T, N}) -> Buffer{T, S + N} 
   concatInner(o, a, b);
   return o;
 }
+// TODO: Be able to resolve explicit integer constant values as the integer type so it can be
+// grabbed by the type inference system. For now, repeat for buffers outputs an array, instead.
+export fn repeat{T, S}(b: Buffer{T, S}, c: i64) -> Array{T} binds repeatbuffertoarray;
 
 /// Process exit-related bindings
 export fn ExitCode(e: i8) -> ExitCode binds to_exit_code_i8;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -1857,6 +1857,18 @@ fn everyarray<T>(a: &Vec<T>, f: fn(&T) -> bool) -> bool {
     return true;
 }
 
+/// `repeatarray` returns a new array with the original array repeated N times
+#[inline(always)]
+fn repeatarray<T: std::clone::Clone>(a: &Vec<T>, c: &i64) -> Vec<T> {
+    let mut out = Vec::new();
+    for _ in 0..*c {
+        for v in a {
+            out.push(v.clone());
+        }
+    }
+    out
+}
+
 /// `mapbuffer_onearg` runs the provided single-argument function on each element of the buffer,
 /// returning a new buffer
 #[inline(always)]
@@ -1969,6 +1981,18 @@ fn concatbuffer<T: std::clone::Clone, const S: usize, const N: usize, const O: u
     for (i, v) in a.iter().chain(b).enumerate() {
         o[i] = v.clone();
     }
+}
+
+/// `repeatbuffertoarray` returns a new array with the original buffer repeated N times
+#[inline(always)]
+fn repeatbuffertoarray<T: std::clone::Clone, const S: usize>(a: &[T; S], c: &i64) -> Vec<T> {
+    let mut out = Vec::new();
+    for _ in 0..*c {
+        for v in a {
+            out.push(v.clone());
+        }
+    }
+    out
 }
 
 struct GPU {


### PR DESCRIPTION
As noted in one of the comments, the type system can't currently handle repeating buffers an arbitrary number of times because the value is a runtime value. The type system needs to be improved to be able to distinguish the literal `3` from a variable `three` that may or may not have the value `3` inside of it before this can be improved.

Then we can have both the current implementation for runtime variables, which *has* to convert into an array to have a static type, and a new implementation for static values that can convert into a buffer on the other side, as well.
