### PR TITLE
Drop special assignment syntax in the language

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1026,8 +1026,7 @@ impl BaseAssignable {
                         .join(""))
                     .collect::<Vec<String>>()
                     .join(", ")
-            )
-            .to_string(),
+            ),
             BaseAssignable::FnCall(fc) => format!(
                 "({})",
                 fc.assignablelist
@@ -1039,8 +1038,7 @@ impl BaseAssignable {
                         .join(""))
                     .collect::<Vec<String>>()
                     .join(", ")
-            )
-            .to_string(),
+            ),
             BaseAssignable::GnCall(gc) => format!(
                 "{{{}}}",
                 gc.typecalllist
@@ -1048,8 +1046,7 @@ impl BaseAssignable {
                     .map(|ta| ta.to_string())
                     .collect::<Vec<String>>()
                     .join("")
-            )
-            .to_string(),
+            ),
             BaseAssignable::Variable(v) => v.clone(),
             BaseAssignable::MethodSep(_) => ".".to_string(),
             BaseAssignable::Constants(c) => c.to_string(),
@@ -1144,17 +1141,6 @@ named_and!(letdeclaration: LetDeclaration =>
 named_or!(declarations: Declarations =>
     Const: ConstDeclaration as constdeclaration,
     Let: LetDeclaration as letdeclaration,
-);
-named_and!(assignments: Assignments =>
-    var: Vec<BaseAssignable> as baseassignablelist,
-    a: String as optwhitespace,
-    eq: String as eq,
-    b: String as optwhitespace,
-    assignables: Vec<WithOperators> as assignables,
-    semicolon: String as semicolon,
-);
-test!(assignments =>
-    pass "hm.lookup = Array{Array{int64}}(Array{int64}()) * lookupLen;" => "";
 );
 named_and!(retval: RetVal =>
     assignables: Vec<WithOperators> as assignables,
@@ -1251,7 +1237,6 @@ named_and!(assignablestatement: AssignableStatement =>
 named_or!(statement: Statement =>
     Declarations: Declarations as declarations,
     Returns: Returns as returns,
-    Assignments: Assignments as assignments,
     Conditional: Conditional as conditional,
     Assignables: AssignableStatement as assignablestatement,
     A: String as whitespace,

--- a/src/program/microstatement.rs
+++ b/src/program/microstatement.rs
@@ -1323,6 +1323,12 @@ pub fn statement_to_microstatements(
     match statement {
         // This is just whitespace, so we do nothing here
         parse::Statement::A(_) => Ok(microstatements),
+        parse::Statement::Declarations(declarations) => Ok(declarations_to_microstatements(
+            declarations,
+            scope,
+            program,
+            microstatements,
+        )?),
         parse::Statement::Assignables(assignable) => Ok(assignablestatement_to_microstatements(
             assignable,
             scope,
@@ -1335,13 +1341,6 @@ pub fn statement_to_microstatements(
             program,
             microstatements,
         )?),
-        parse::Statement::Declarations(declarations) => Ok(declarations_to_microstatements(
-            declarations,
-            scope,
-            program,
-            microstatements,
-        )?),
-        parse::Statement::Assignments(_assignments) => Err("Implement me".into()),
         parse::Statement::Conditional(_condtitional) => Err("Implement me".into()),
     }
 }

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -460,31 +460,32 @@ export fn eprint{T}(v: T) binds eprintln;
 // but you can't have an infix operator of the same symbol linked to multiple functions. This does
 // produce some ambiguity of what kind of operator an operator is, but should still be unambiguous
 // to humans to "read" the symbol as whatever kind of function it represents.
-export infix add as + precedence 2;
-export infix sub as - precedence 2;
-//export prefix neg as - precedence 1; // TODO: Rework operator storage and selection
-export infix mul as * precedence 3;
-export infix div as / precedence 3;
-export infix mod as % precedence 3;
-// export infix template as % precedence 3;
-export infix pow as ** precedence 4;
-export infix and as & precedence 3;
-export infix and as && precedence 3;
-export infix or as | precedence 2;
-export infix or as || precedence 2;
-export infix xor as ^ precedence 2;
-export prefix not as ! precedence 4;
-export infix nand as !& precedence 3;
-export infix nor as !| precedence 2;
-export infix xnor as !^ precedence 2;
-export infix eq as == precedence 0;
-export infix neq as != precedence 0;
-export infix lt as < precedence 0;
-export infix lte as <= precedence 0;
-export infix gt as > precedence 0;
-export infix gte as >= precedence 0;
-export prefix len as # precedence 0; // TODO: Is this useful?
-export infix shl as << precedence 1;
-export infix shr as >> precedence 1;
-export infix wrl as <<< precedence 1;
-export infix wrr as >>> precedence 1;
+export infix add as + precedence 3;
+export infix sub as - precedence 3;
+//export prefix neg as - precedence 2; // TODO: Rework operator storage and selection
+export infix mul as * precedence 4;
+export infix div as / precedence 4;
+export infix mod as % precedence 4;
+// export infix template as % precedence 4;
+export infix pow as ** precedence 5;
+export infix and as & precedence 4;
+export infix and as && precedence 4;
+export infix or as | precedence 3;
+export infix or as || precedence 3;
+export infix xor as ^ precedence 3;
+export prefix not as ! precedence 5;
+export infix nand as !& precedence 4;
+export infix nor as !| precedence 3;
+export infix xnor as !^ precedence 3;
+export infix eq as == precedence 1;
+export infix neq as != precedence 1;
+export infix lt as < precedence 1;
+export infix lte as <= precedence 1;
+export infix gt as > precedence 1;
+export infix gte as >= precedence 1;
+export prefix len as # precedence 1; // TODO: Is this useful?
+export infix shl as << precedence 2;
+export infix shr as >> precedence 2;
+export infix wrl as <<< precedence 2;
+export infix wrr as >>> precedence 2;
+export infix set as = precedence 0


### PR DESCRIPTION
This sets up the language to just have `=` be an operator for `set`. Work needs to be done in the lower layer of the language to be primarily reference-based and insert variable assignments as necessary for Rust's ownership model, but that will happen later.
