### PR TITLE
Implement 'cond' for basic conditionals

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -1532,6 +1532,14 @@ to barto bar3
 
 // Conditionals
 
+test!(cond_fn => r#"
+    export fn main {
+        cond(1 == 0, fn = print('What!?'), fn = print('Math is sane...'));
+        // cond(1 == 2, fn () -> string = 'Uhh...').print;
+    }"#;
+    stdout "Math is sane...\n";
+);
+
 test_ignore!(basic_conditionals => r#"
     fn bar() {
       print('bar!');

--- a/src/program/function.rs
+++ b/src/program/function.rs
@@ -16,15 +16,6 @@ pub struct Function {
 }
 
 impl Function {
-    pub fn placeholder(name: String, args: Vec<(String, CType)>, rettype: CType) -> Function {
-        Function {
-            name,
-            args,
-            rettype,
-            microstatements: vec![],
-            kind: FnKind::Normal,
-        }
-    }
     pub fn from_ast(
         scope: &mut Scope,
         program: &mut Program,
@@ -359,46 +350,17 @@ impl Function {
         }?;
         let microstatements = {
             let mut ms = Vec::new();
-            let mut call_scope = scope.child(program);
             for (name, typen) in &args {
                 ms.push(Microstatement::Arg {
                     name: name.clone(),
                     typen: typen.clone(),
                 });
-                if let CType::Function(i, o) = typen {
-                    let args = match &**i {
-                        CType::Tuple(ts) => {
-                            let mut out = vec![];
-                            for (i, t) in ts.iter().enumerate() {
-                                match t {
-                                    CType::Field(n, t) => {
-                                        out.push((n.clone(), *t.clone()));
-                                    }
-                                    other => {
-                                        out.push((format!("arg{}", i), other.clone()));
-                                    }
-                                }
-                            }
-                            out
-                        }
-                        CType::Void => vec![],
-                        other => {
-                            vec![("arg0".to_string(), other.clone())]
-                        }
-                    };
-                    let rettype = *o.clone();
-                    // Allow the argument to be callable within the function
-                    call_scope.functions.insert(
-                        name.clone(),
-                        vec![Function::placeholder(name.clone(), args, rettype)],
-                    );
-                }
             }
             // We can't generate the rest of the microstatements while the generic function is
             // still generic
             if function_ast.optgenerics.is_none() {
                 for statement in &statements {
-                    ms = statement_to_microstatements(statement, &mut call_scope, program, ms)?;
+                    ms = statement_to_microstatements(statement, scope, program, ms)?;
                 }
             }
             ms
@@ -474,34 +436,6 @@ impl Function {
                             name: name.clone(),
                             typen: typen.clone(),
                         });
-                        if let CType::Function(i, o) = typen {
-                            let args = match &**i {
-                                CType::Tuple(ts) => {
-                                    let mut out = vec![];
-                                    for (i, t) in ts.iter().enumerate() {
-                                        match t {
-                                            CType::Field(n, t) => {
-                                                out.push((n.clone(), *t.clone()));
-                                            }
-                                            other => {
-                                                out.push((format!("arg{}", i), other.clone()));
-                                            }
-                                        }
-                                    }
-                                    out
-                                }
-                                CType::Void => vec![],
-                                other => {
-                                    vec![("arg0".to_string(), other.clone())]
-                                }
-                            };
-                            let rettype = *o.clone();
-                            // Allow the argument to be callable within the function
-                            scope.functions.insert(
-                                name.clone(),
-                                vec![Function::placeholder(name.clone(), args, rettype)],
-                            );
-                        }
                     }
                     ms
                 };
@@ -570,37 +504,7 @@ impl Function {
                             name: name.clone(),
                             typen: typen.clone(),
                         });
-                        if let CType::Function(i, o) = typen {
-                            let args = match &**i {
-                                CType::Tuple(ts) => {
-                                    let mut out = vec![];
-                                    for (i, t) in ts.iter().enumerate() {
-                                        match t {
-                                            CType::Field(n, t) => {
-                                                out.push((n.clone(), *t.clone()));
-                                            }
-                                            other => {
-                                                out.push((format!("arg{}", i), other.clone()));
-                                            }
-                                        }
-                                    }
-                                    out
-                                }
-                                CType::Void => vec![],
-                                other => {
-                                    vec![("arg0".to_string(), other.clone())]
-                                }
-                            };
-                            let rettype = *o.clone();
-                            // Allow the argument to be callable within the function
-                            inner_scope.functions.insert(
-                                name.clone(),
-                                vec![Function::placeholder(name.clone(), args, rettype)],
-                            );
-                        }
                     }
-                    // We can't generate the rest of the microstatements while the generic function is
-                    // still generic
                     for statement in statements {
                         ms =
                             statement_to_microstatements(statement, &mut inner_scope, program, ms)?;

--- a/src/program/microstatement.rs
+++ b/src/program/microstatement.rs
@@ -61,7 +61,11 @@ impl Microstatement {
                     .map(|(_, t)| t.clone())
                     .collect::<Vec<CType>>();
                 let fn_type = CType::Function(
-                    Box::new(CType::Tuple(arg_types)),
+                    Box::new(if arg_types.is_empty() {
+                        CType::Void
+                    } else {
+                        CType::Tuple(arg_types)
+                    }),
                     Box::new(function.rettype.clone()),
                 );
                 Ok(fn_type)

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -552,6 +552,8 @@ export fn nor(a: bool, b: bool) -> bool binds norbool;
 export fn xnor(a: bool, b: bool) -> bool binds xnorbool;
 export fn eq(a: bool, b: bool) -> bool binds eqbool;
 export fn neq(a: bool, b: bool) -> bool binds neqbool;
+export fn cond{T}(c: bool, t: () -> T, f: () -> T) -> T binds condbool;
+export fn cond{T}(c: bool, t: () -> T) -> Maybe{T} = cond(c, fn = Maybe{T}(t()), fn = Maybe{T}(void));
 
 /// Array related bindings
 export fn len{T}(a: T[]) -> i64 binds lenarray;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -2579,6 +2579,17 @@ fn neqbool(a: &bool, b: &bool) -> bool {
     *a != *b
 }
 
+/// `condbool` executes the true function on true, and the false function on false, returning the
+/// value returned by either function
+#[inline(always)]
+fn condbool<T>(c: &bool, t: fn() -> T, f: fn() -> T) -> T {
+    if *c {
+        t()
+    } else {
+        f()
+    }
+}
+
 /// Array-related functions
 
 /// `getarray` returns a value from an array at the location specified


### PR DESCRIPTION
This only has the bound `cond` function that executes either the `true` or the `false` branch working.

The wrapper function that accepts only a `true` branch and returns a `Maybe{T}` doesn't work yet because there's a bug in the `Scope` implementation that I have finally figured out is much larger than I anticipated. I need to potentially rework how `Scope` works to a large degree in order to get Rust to accept it. (Creating a child scope actually creates two scopes, one that is registered in the scope tree and the one that is returned; mutating the returned one doesn't affect the one in the tree and so adding arguments to the scope as callable functions does not work.)

That will be a different PR because it would be confusing, otherwise.
