### PR TITLE
Implement `exists{T}` and `void{T}` functions

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -231,6 +231,14 @@ test!(scientific_notation => r#"
 "#;
     stdout "true\ntrue\ntrue\n";
 );
+test!(void_values => r#"
+    export fn main {
+        5.print;
+        5.void.print;
+        void().print; // TODO: `void.print` should work, too. Figure out why it isn't
+    }"#;
+    stdout "5\nvoid\nvoid\n";
+);
 
 // Printing Tests
 
@@ -2465,6 +2473,17 @@ test_ignore!(basic_interfaces => r#"
 */
 
 // Maybe, Result, and Either
+
+test!(maybe_exists => r#"
+    export fn main {
+        const maybe5 = Maybe{i64}(5);
+        maybe5.exists.print;
+        const intOrStr = {i64 | string}("It's a string!");
+        intOrStr.i64.exists.print;
+        intOrStr.string.exists.print;
+    }"#;
+    stdout "true\nfalse\ntrue\n";
+);
 
 test_ignore!(maybe => r#"
     fn fiver(val: float64) {

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -135,6 +135,12 @@ export fn clone{T}(v: T) -> T binds clone;
 export fn hash{T}(v: Array{T}) -> i64 binds hasharray;
 export fn hash(v: string) -> i64 binds hashstring;
 export fn hash{T}(v: T) -> i64 binds hash;
+export fn void{T}(v: T) -> void {
+  0; // TODO: Eliminate the need for this
+}
+export fn void {
+  0; // TODO: Eliminate the need for this
+}
 
 /// Fallible, Maybe, and Either functions
 export fn getOr{T}(v: Maybe{T}, d: T) -> T binds maybe_get_or;
@@ -142,6 +148,7 @@ export fn getOr{T}(v: Fallible{T}, d: T) -> T binds fallible_get_or;
 export fn getOr{T, U}(v: U, d: T) -> T = {T}(v).getOr(d);
 export fn none{T}() -> Maybe{T} binds maybe_none;
 export fn error{T}(m: string) -> Fallible{T} binds fallible_error;
+export fn exists{T}(v: Maybe{T}) -> bool binds maybe_exists;
 
 /// Signed Integer-related functions and function bindings
 export fn i8(i: i8) -> i8 = i;
@@ -644,6 +651,7 @@ export fn print{T}(v: Maybe{T}) binds println_maybe;
 export fn print{T}(v: Array{T}) binds print_vec;
 export fn print{T, N}(v: Buffer{T, N}) binds print_buffer;
 export fn print{T}(v: Array{Fallible{T}}) binds print_vec_result;
+export fn print(v: void) binds println_void;
 export fn print{T}(v: T) binds println;
 export fn eprint{T}(v: Fallible{T}) binds eprintln_result;
 export fn eprint{T}(v: Maybe{T}) binds eprintln_maybe;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -108,6 +108,12 @@ fn fallible_error<T>(m: &String) -> Result<T, AlanError> {
     Err(m.clone().into())
 }
 
+/// `maybe_exists` returns a boolean on whether or not the Maybe has a value
+#[inline(always)]
+fn maybe_exists<T>(v: &Option<T>) -> bool {
+    v.is_some()
+}
+
 /// Signed Integer-related functions
 
 /// `stringtoi8` tries to convert a string into an i8
@@ -3310,6 +3316,12 @@ fn println_maybe<A: std::fmt::Display>(a: &Option<A>) {
         Some(o) => println!("{}", o),
         None => println!("void"),
     };
+}
+
+/// `println_void` prints "void" if called
+#[inline(always)]
+fn println_void(void: &()) {
+    println!("void");
 }
 
 /// `eprintln` is a simple function that prints basically anything


### PR DESCRIPTION
Resolves #755.

The `exists{T}` function for `Maybe{T}` types returns a boolean on whether or not the `Maybe` has a `T` value inside or not. With it we can accomplish something similar to the `is{T}` concept for `Either` types.

`myEitherType.is{mySubtype}` was the goal, but now we get `myEitherType.mySubtype.exists`. Still pretty legible, not as "English-like" as the desired syntax.

The `void{T}` function that consumes any input type and returns a `void` isn't really related to this, but I decided to implement it at the same time because why not? It is not *currently* useful, but I am currently leaning towards *any* statement that doesn't have a resulting value of `void` is a compilation error as the value has not been consumed. This would be an easy way to enforce handling `Fallible` types coming from functions you've called, requiring you to *at least* write `myFallibleFnCall(args).void;` to clear out compiler error, making it a kind of code smell, and an indicator that some sort of side-effect is happening here.

That enforcement is a bigger task, assuming I implement it, but the function itself was pretty easy, though I had to work around a bug that functions without a function body at all don't parse right now. That should also be fixed, and I'm going to create an issue for that, at least.
