### PR TITLE
Closure functions actually enclose outer-scope variables

### DIFF
--- a/benches/bench.ln
+++ b/benches/bench.ln
@@ -14,76 +14,64 @@ fn bench(l: i64) {
   v2[0];
   t2.elapsed.print;
   let t3 = now();
-  let b = GBuffer(storageBuffer(), v);
-  let plan = GPGPU("
-    @group(0)
-    @binding(0)
-    var<storage, read_write> vals: array<i32>;
+  // My laptop GPU can't handle a billion i32s in a single buffer, so that case is split in two
+  cond(l <= 100_000_000, fn {
+    let b = GBuffer(storageBuffer(), v);
+    let plan = GPGPU("
+      @group(0)
+      @binding(0)
+      var<storage, read_write> vals: array<i32>;
 
-    @compute
-    @workgroup_size(1)
-    fn main(@builtin(global_invocation_id) id: vec3<u32>) {
-      let i = id.x + 65535 * id.y + 4294836225 * id.z;
-      let l = arrayLength(&vals);
-      if i > l { return; }
-      vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
-    }
-  ", b);
-  plan.run;
-  let v3 = b.read{i32};
-  v3[0];
-  t3.elapsed.print;
-}
+      @compute
+      @workgroup_size(1)
+      fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+        let i = id.x + 65535 * id.y + 4294836225 * id.z;
+        let l = arrayLength(&vals);
+        if i > l { return; }
+        vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+      }
+    ", b);
+    plan.run;
+    let v3 = b.read{i32};
+    v3[0];
+  }, fn {
+    let v2 = filled(2.i32, 500_000_000);
+    let b = GBuffer(storageBuffer(), v2);
+    let plan = GPGPU("
+      @group(0)
+      @binding(0)
+      var<storage, read_write> vals: array<i32>;
 
-// Until I have conditionals working, I need to do this kind of tomfoolery
-fn bench_billion {
-  let v = filled(2.i32, 1_000_000_000);
-  v.len.print;
-  let t1 = now();
-  let v1 = v.map(double);
-  v1[0];
-  t1.elapsed.print;
-  let t2 = now();
-  let v2 = v.parmap(double);
-  v2[0];
-  t2.elapsed.print;
-  let v2 = filled(2.i32, 500_000_000);
-  let t3 = now();
-  let b = GBuffer(storageBuffer(), v2);
-  let plan = GPGPU("
-    @group(0)
-    @binding(0)
-    var<storage, read_write> vals: array<i32>;
+      @compute
+      @workgroup_size(1)
+      fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+        let i = id.x + 65535 * id.y + 4294836225 * id.z;
+        let l = arrayLength(&vals);
+        if i > l { return; }
+        vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+      }
+    ", b);
+    plan.run;
+    b.read{i32};
+    let b = GBuffer(storageBuffer(), v2);
+    let plan = GPGPU("
+      @group(0)
+      @binding(0)
+      var<storage, read_write> vals: array<i32>;
 
-    @compute
-    @workgroup_size(1)
-    fn main(@builtin(global_invocation_id) id: vec3<u32>) {
-      let i = id.x + 65535 * id.y + 4294836225 * id.z;
-      let l = arrayLength(&vals);
-      if i > l { return; }
-      vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
-    }
-  ", b);
-  plan.run;
-  b.read{i32};
-  let b = GBuffer(storageBuffer(), v2);
-  let plan = GPGPU("
-    @group(0)
-    @binding(0)
-    var<storage, read_write> vals: array<i32>;
-
-    @compute
-    @workgroup_size(1)
-    fn main(@builtin(global_invocation_id) id: vec3<u32>) {
-      let i = id.x + 65535 * id.y + 4294836225 * id.z;
-      let l = arrayLength(&vals);
-      if i > l { return; }
-      vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
-    }
-  ", b);
-  plan.run;
-  let v3 = b.read{i32};
-  v3[0];
+      @compute
+      @workgroup_size(1)
+      fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+        let i = id.x + 65535 * id.y + 4294836225 * id.z;
+        let l = arrayLength(&vals);
+        if i > l { return; }
+        vals[id.x + 65535 * id.y + 4294836225 * id.z] = vals[id.x + 65535 * id.y + 4294836225 * id.z] * 2;
+      }
+    ", b);
+    plan.run;
+    let v3 = b.read{i32};
+    v3[0];
+  });
   t3.elapsed.print;
 }
 
@@ -97,7 +85,5 @@ export fn main {
   bench(1_000_000);
   bench(10_000_000);
   bench(100_000_000);
-  // Commented out because it crashes on my laptop GPU. Try swapping which is commented on your's!
-  // bench(1_000_000_000);
-  bench_billion();
+  bench(1_000_000_000);
 }

--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -137,7 +137,7 @@ pub fn from_microstatement(
             let mut arg_types = Vec::new();
             let mut arg_type_strs = Vec::new();
             for arg in args {
-                let arg_type = arg.get_type()?;
+                let arg_type = arg.get_type();
                 let (_, o) = typen::generate(&arg_type, out)?;
                 out = o;
                 arg_types.push(arg_type.clone());
@@ -183,7 +183,7 @@ pub fn from_microstatement(
                         // If the argument is itself a function, this is the only place in Rust
                         // where you can't pass by reference, so we check the type and change
                         // the argument output accordingly.
-                        let arg_type = arg.get_type()?;
+                        let arg_type = arg.get_type();
                         match arg_type {
                             CType::Function(..) => argstrs.push(a.to_string()),
                             _ => argstrs.push(format!("&mut {}", a)),
@@ -202,7 +202,7 @@ pub fn from_microstatement(
                         // If the argument is itself a function, this is the only place in Rust
                         // where you can't pass by reference, so we check the type and change
                         // the argument output accordingly.
-                        let arg_type = arg.get_type()?;
+                        let arg_type = arg.get_type();
                         match arg_type {
                             CType::Function(..) => argstrs.push(a.to_string()),
                             _ => argstrs.push(format!("&mut {}", a)),
@@ -225,7 +225,7 @@ pub fn from_microstatement(
                         // If the argument is itself a function, this is the only place in Rust
                         // where you can't pass by reference, so we check the type and change
                         // the argument output accordingly.
-                        let arg_type = arg.get_type()?;
+                        let arg_type = arg.get_type();
                         match arg_type {
                             CType::Function(..) => argstrs.push(a.to_string()),
                             _ => argstrs.push(format!("&mut {}", a)),
@@ -734,7 +734,7 @@ pub fn from_microstatement(
                 // If the argument is itself a function, this is the only place in Rust
                 // where you can't pass by reference, so we check the type and change
                 // the argument output accordingly.
-                let arg_type = arg.get_type()?;
+                let arg_type = arg.get_type();
                 match arg_type {
                     CType::Function(..) => argstrs.push(a.to_string()),
                     _ => argstrs.push(format!("&mut {}", a)),

--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -58,7 +58,7 @@ pub fn from_microstatement(
             }
             Ok((
                 format!(
-                    "|{}| {{\n        {};\n    }}",
+                    "move |{}| {{\n        {};\n    }}",
                     arg_names.join(", "),
                     inner_statements.join(";\n        ")
                 ),

--- a/src/program/microstatement.rs
+++ b/src/program/microstatement.rs
@@ -48,17 +48,17 @@ pub enum Microstatement {
 }
 
 impl Microstatement {
-    pub fn get_type(&self) -> Result<CType, Box<dyn std::error::Error>> {
+    pub fn get_type(&self) -> CType {
         match self {
-            Self::Value { typen, .. } => Ok(typen.clone()),
-            Self::Array { typen, .. } => Ok(typen.clone()),
-            Self::Arg { typen, .. } => Ok(typen.clone()),
+            Self::Value { typen, .. } => typen.clone(),
+            Self::Array { typen, .. } => typen.clone(),
+            Self::Arg { typen, .. } => typen.clone(),
             Self::Assignment { value, .. } => value.get_type(),
             Self::Return { value } => match value {
                 Some(v) => v.get_type(),
-                None => Ok(CType::Void),
+                None => CType::Void,
             },
-            Self::FnCall { function, args: _ } => Ok(function.rettype.clone()),
+            Self::FnCall { function, args: _ } => function.rettype.clone(),
             Self::Closure { function } => {
                 // TODO: Just have Function store this
                 let arg_types = function
@@ -74,9 +74,9 @@ impl Microstatement {
                     }),
                     Box::new(function.rettype.clone()),
                 );
-                Ok(fn_type)
+                fn_type
             }
-            Self::VarCall { typen, .. } => Ok(typen.clone()),
+            Self::VarCall { typen, .. } => typen.clone(),
         }
     }
 }
@@ -339,7 +339,9 @@ pub fn baseassignablelist_to_microstatements(
                     // Microstatment::Assignment, but Rust doesn't seem to know that, so force
                     // it.
                     Some(m) => match m {
-                        Microstatement::Assignment { value, .. } => value.get_type(),
+                        Microstatement::Assignment { value, .. } => {
+                            Ok::<CType, Box<dyn std::error::Error>>(value.get_type())
+                        }
                         Microstatement::Arg { typen, .. } => Ok(typen.clone()),
                         _ => unreachable!(),
                     },
@@ -398,7 +400,7 @@ pub fn baseassignablelist_to_microstatements(
                 }
                 // TODO: Currently assuming all array values are the same type, should check that
                 // better
-                let inner_type = array_vals[0].get_type()?;
+                let inner_type = array_vals[0].get_type();
                 let inner_type_str = inner_type.to_callable_string();
                 let array_type_name = format!("Array_{}_", inner_type_str);
                 let array_type = CType::Array(Box::new(inner_type));
@@ -608,6 +610,24 @@ pub fn baseassignablelist_to_microstatements(
                         typen: typen.clone(),
                     });
                 }
+                // TODO: Figure out *which* captured variables are actually being used, so we don't
+                // make useless `clone`s (though LLVM is probably saving us from this lunacy, based
+                // on the benchmark results)
+                let mut closure_vars = Vec::new();
+                for ms in &microstatements {
+                    match ms {
+                        Microstatement::Assignment { name, .. }
+                        | Microstatement::Arg { name, .. } => {
+                            closure_vars.push(Microstatement::Arg {
+                                name: name.clone(),
+                                typen: ms.get_type(),
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+                microstatements.append(&mut closure_vars);
+
                 for statement in &statements {
                     microstatements =
                         statement_to_microstatements(statement, &mut inner_scope, microstatements)?;
@@ -639,7 +659,7 @@ pub fn baseassignablelist_to_microstatements(
                     }
                     let mut arg_types = Vec::new();
                     for m in &array_accessor_microstatements {
-                        arg_types.push(m.get_type()?);
+                        arg_types.push(m.get_type());
                     }
                     let function = {
                         let mut temp_scope_2 = temp_scope.child();
@@ -688,7 +708,7 @@ pub fn baseassignablelist_to_microstatements(
                     constant_accessor_microstatements.push(microstatements.pop().unwrap());
                     let mut arg_types = Vec::new();
                     for m in &constant_accessor_microstatements {
-                        arg_types.push(m.get_type()?);
+                        arg_types.push(m.get_type());
                     }
                     let function = {
                         let mut temp_scope_2 = temp_scope.child();
@@ -744,7 +764,7 @@ pub fn baseassignablelist_to_microstatements(
                 }
                 let mut arg_types = Vec::new();
                 for arg in &arg_microstatements {
-                    arg_types.push(arg.get_type()?);
+                    arg_types.push(arg.get_type());
                 }
                 // We create a type on-the-fly from the contents the GnCall block. It's given a
                 // name based on the CType tree with all non-`a-zA-Z0-9_` chars replaced with `-`
@@ -821,7 +841,7 @@ pub fn baseassignablelist_to_microstatements(
                 }
                 let mut arg_types = Vec::new();
                 for arg in &arg_microstatements {
-                    arg_types.push(arg.get_type()?);
+                    arg_types.push(arg.get_type());
                 }
                 // Look for closure functions in the microstatement array first to see if that's
                 // what should be called, scanning in reverse order to find the most recent
@@ -957,7 +977,7 @@ pub fn baseassignablelist_to_microstatements(
                 }
                 let mut arg_types = Vec::new();
                 for arg in &arg_microstatements {
-                    arg_types.push(arg.get_type()?);
+                    arg_types.push(arg.get_type());
                 }
                 let generics = {
                     let mut generic_string = g.to_string();

--- a/src/program/microstatement.rs
+++ b/src/program/microstatement.rs
@@ -66,15 +66,14 @@ impl Microstatement {
                     .iter()
                     .map(|(_, t)| t.clone())
                     .collect::<Vec<CType>>();
-                let fn_type = CType::Function(
+                CType::Function(
                     Box::new(if arg_types.is_empty() {
                         CType::Void
                     } else {
                         CType::Tuple(arg_types)
                     }),
                     Box::new(function.rettype.clone()),
-                );
-                fn_type
+                )
             }
             Self::VarCall { typen, .. } => typen.clone(),
         }

--- a/src/program/microstatement.rs
+++ b/src/program/microstatement.rs
@@ -609,24 +609,6 @@ pub fn baseassignablelist_to_microstatements(
                         typen: typen.clone(),
                     });
                 }
-                // TODO: Figure out *which* captured variables are actually being used, so we don't
-                // make useless `clone`s (though LLVM is probably saving us from this lunacy, based
-                // on the benchmark results)
-                let mut closure_vars = Vec::new();
-                for ms in &microstatements {
-                    match ms {
-                        Microstatement::Assignment { name, .. }
-                        | Microstatement::Arg { name, .. } => {
-                            closure_vars.push(Microstatement::Arg {
-                                name: name.clone(),
-                                typen: ms.get_type(),
-                            });
-                        }
-                        _ => {}
-                    }
-                }
-                microstatements.append(&mut closure_vars);
-
                 for statement in &statements {
                     microstatements =
                         statement_to_microstatements(statement, &mut inner_scope, microstatements)?;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -2600,7 +2600,7 @@ fn neqbool(a: &bool, b: &bool) -> bool {
 /// `condbool` executes the true function on true, and the false function on false, returning the
 /// value returned by either function
 #[inline(always)]
-fn condbool<T>(c: &bool, t: impl Fn() -> T, f: impl Fn() -> T) -> T {
+fn condbool<T>(c: &bool, mut t: impl FnMut() -> T, mut f: impl FnMut() -> T) -> T {
     if *c {
         t()
     } else {
@@ -2652,14 +2652,14 @@ fn vec_len<A>(v: &Vec<A>) -> i64 {
 /// `map_onearg` runs the provided single-argument function on each element of the vector,
 /// returning a new vector
 #[inline(always)]
-fn map_onearg<A, B>(v: &Vec<A>, m: fn(&A) -> B) -> Vec<B> {
+fn map_onearg<A, B>(v: &Vec<A>, mut m: impl FnMut(&A) -> B) -> Vec<B> {
     v.iter().map(|val| m(val)).collect::<Vec<B>>()
 }
 
 /// `map_twoarg` runs the provided two-argument (value, index) function on each element of the
 /// vector, returning a new vector
 #[inline(always)]
-fn map_twoarg<A, B>(v: &Vec<A>, m: fn(&A, i64) -> B) -> Vec<B> {
+fn map_twoarg<A, B>(v: &Vec<A>, mut m: impl FnMut(&A, i64) -> B) -> Vec<B> {
     v.iter()
         .enumerate()
         .map(|(i, val)| m(val, i as i64))
@@ -2752,7 +2752,7 @@ fn parmap_onearg<
 /// `filter_onearg` runs the provided single-argument function on each element of the vector,
 /// returning a new vector
 #[inline(always)]
-fn filter_onearg<A: std::clone::Clone>(v: &Vec<A>, f: fn(&A) -> bool) -> Vec<A> {
+fn filter_onearg<A: std::clone::Clone>(v: &Vec<A>, mut f: impl FnMut(&A) -> bool) -> Vec<A> {
     v.iter()
         .filter(|val| f(val))
         .map(|val| val.clone())
@@ -2762,7 +2762,7 @@ fn filter_onearg<A: std::clone::Clone>(v: &Vec<A>, f: fn(&A) -> bool) -> Vec<A> 
 /// `filter_twoarg` runs the provided function each element of the vector plus its index,
 /// returning a new vector
 #[inline(always)]
-fn filter_twoarg<A: std::clone::Clone>(v: &Vec<A>, f: fn(&A, i64) -> bool) -> Vec<A> {
+fn filter_twoarg<A: std::clone::Clone>(v: &Vec<A>, mut f: impl FnMut(&A, i64) -> bool) -> Vec<A> {
     v.iter()
         .enumerate()
         .filter(|(i, val)| f(val, *i as i64))
@@ -2772,7 +2772,7 @@ fn filter_twoarg<A: std::clone::Clone>(v: &Vec<A>, f: fn(&A, i64) -> bool) -> Ve
 
 /// `reduce_sametype` runs the provided function to reduce the vector into a singular value
 #[inline(always)]
-fn reduce_sametype<A: std::clone::Clone>(v: &Vec<A>, f: fn(&A, &A) -> A) -> Option<A> {
+fn reduce_sametype<A: std::clone::Clone>(v: &Vec<A>, mut f: impl FnMut(&A, &A) -> A) -> Option<A> {
     // The built-in iter `reduce` is awkward for our use case
     if v.len() == 0 {
         None
@@ -2793,7 +2793,7 @@ fn reduce_sametype<A: std::clone::Clone>(v: &Vec<A>, f: fn(&A, &A) -> A) -> Opti
 fn reduce_difftype<A: std::clone::Clone, B: std::clone::Clone>(
     v: &Vec<A>,
     i: &B,
-    f: fn(&B, &A) -> B,
+    mut f: impl FnMut(&B, &A) -> B,
 ) -> B {
     let mut out = i.clone();
     for i in 0..v.len() {
@@ -2823,7 +2823,7 @@ fn hasarray<T: std::cmp::PartialEq>(a: &Vec<T>, v: &T) -> bool {
 
 /// `hasfnarray` returns true if the check function returns true for any element of the vector
 #[inline(always)]
-fn hasfnarray<T>(a: &Vec<T>, f: fn(&T) -> bool) -> bool {
+fn hasfnarray<T>(a: &Vec<T>, mut f: impl FnMut(&T) -> bool) -> bool {
     for v in a {
         if f(v) {
             return true;
@@ -2834,7 +2834,7 @@ fn hasfnarray<T>(a: &Vec<T>, f: fn(&T) -> bool) -> bool {
 
 /// `findarray` returns the first value from the vector that matches the check function, if any
 #[inline(always)]
-fn findarray<T: std::clone::Clone>(a: &Vec<T>, f: fn(&T) -> bool) -> Option<T> {
+fn findarray<T: std::clone::Clone>(a: &Vec<T>, mut f: impl FnMut(&T) -> bool) -> Option<T> {
     for v in a {
         if f(v) {
             return Some(v.clone());
@@ -2845,7 +2845,7 @@ fn findarray<T: std::clone::Clone>(a: &Vec<T>, f: fn(&T) -> bool) -> Option<T> {
 
 /// `everyarray` returns true if every value in the vector matches the check function
 #[inline(always)]
-fn everyarray<T>(a: &Vec<T>, f: fn(&T) -> bool) -> bool {
+fn everyarray<T>(a: &Vec<T>, mut f: impl FnMut(&T) -> bool) -> bool {
     for v in a {
         if !f(v) {
             return false;
@@ -2877,7 +2877,7 @@ fn getbuffer<T: std::clone::Clone, const S: usize>(b: &[T; S], i: &i64) -> Optio
 /// `mapbuffer_onearg` runs the provided single-argument function on each element of the buffer,
 /// returning a new buffer
 #[inline(always)]
-fn mapbuffer_onearg<A, const N: usize, B>(v: &[A; N], m: fn(&A) -> B) -> [B; N] {
+fn mapbuffer_onearg<A, const N: usize, B>(v: &[A; N], mut m: impl FnMut(&A) -> B) -> [B; N] {
     std::array::from_fn(|i| m(&v[i]))
 }
 
@@ -2886,7 +2886,7 @@ fn mapbuffer_onearg<A, const N: usize, B>(v: &[A; N], m: fn(&A) -> B) -> [B; N] 
 #[inline(always)]
 fn mapbuffer_twoarg<A, const N: usize, B: std::marker::Copy>(
     v: &[A; N],
-    m: fn(&A, &i64) -> B,
+    mut m: impl FnMut(&A, &i64) -> B,
 ) -> [B; N] {
     let mut out = [m(&v[0], &0); N];
     for i in 1..N {
@@ -2900,7 +2900,7 @@ fn mapbuffer_twoarg<A, const N: usize, B: std::marker::Copy>(
 #[inline(always)]
 fn reducebuffer_sametype<A: std::clone::Clone, const S: usize>(
     b: &[A; S],
-    f: fn(&A, &A) -> A,
+    mut f: impl FnMut(&A, &A) -> A,
 ) -> Option<A> {
     // The built-in iter `reduce` is awkward for our use case
     if b.len() == 0 {
@@ -2922,7 +2922,7 @@ fn reducebuffer_sametype<A: std::clone::Clone, const S: usize>(
 fn reducebuffer_difftype<A: std::clone::Clone, const S: usize, B: std::clone::Clone>(
     b: &[A; S],
     i: &B,
-    f: fn(&B, &A) -> B,
+    mut f: impl FnMut(&B, &A) -> B,
 ) -> B {
     let mut out = i.clone();
     for i in 0..b.len() {
@@ -2944,7 +2944,7 @@ fn hasbuffer<T: std::cmp::PartialEq, const S: usize>(a: &[T; S], v: &T) -> bool 
 
 /// `hasfnbuffer` returns true if the check function returns true for any element of the array
 #[inline(always)]
-fn hasfnbuffer<T, const S: usize>(a: &[T; S], f: fn(&T) -> bool) -> bool {
+fn hasfnbuffer<T, const S: usize>(a: &[T; S], mut f: impl FnMut(&T) -> bool) -> bool {
     for v in a {
         if f(v) {
             return true;
@@ -2955,7 +2955,10 @@ fn hasfnbuffer<T, const S: usize>(a: &[T; S], f: fn(&T) -> bool) -> bool {
 
 /// `findbuffer` returns the first value from the buffer that matches the check function, if any
 #[inline(always)]
-fn findbuffer<T: std::clone::Clone, const S: usize>(a: &[T; S], f: fn(&T) -> bool) -> Option<T> {
+fn findbuffer<T: std::clone::Clone, const S: usize>(
+    a: &[T; S],
+    mut f: impl FnMut(&T) -> bool,
+) -> Option<T> {
     for v in a {
         if f(v) {
             return Some(v.clone());
@@ -2966,7 +2969,7 @@ fn findbuffer<T: std::clone::Clone, const S: usize>(a: &[T; S], f: fn(&T) -> boo
 
 /// `everybuffer` returns true if every value in the array matches the check function
 #[inline(always)]
-fn everybuffer<T, const S: usize>(a: &[T; S], f: fn(&T) -> bool) -> bool {
+fn everybuffer<T, const S: usize>(a: &[T; S], mut f: impl FnMut(&T) -> bool) -> bool {
     for v in a {
         if !f(v) {
             return false;


### PR DESCRIPTION
This fixes an issue with closures actually using variables from the outer scope by making sure they're available as owned values within the closure. This is a super trivial implementation that just `clone`s everything from the outer scope, but it works, and appears to have the unused `clone`s deleted during LLVMs optimization passes (probably just dropping all unused variables in their entirety?) "If it's stupid but it works..."
