### PR TITLE
Buffer Rc and id

### DIFF
--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -630,18 +630,21 @@ export fn elapsed(i: Instant) -> Duration binds elapsed;
 
 /// GPU-related bindings
 export type BufferUsages binds wgpu::BufferUsages;
+export type GBuffer binds Rc<wgpu::Buffer>;
+export type GPGPU binds GPGPU;
 export fn mapReadBuffer() -> BufferUsages binds map_read_buffer_type;
 export fn storageBuffer() -> BufferUsages binds storage_buffer_type;
-export type GBuffer binds wgpu::Buffer;
 export fn GBuffer(usage: BufferUsages, vals: Array{i32}) -> GBuffer binds create_buffer_init;
 export fn GBuffer(usage: BufferUsages, size: i64) -> GBuffer binds create_empty_buffer;
 export fn GBuffer(vals: Array{i32}) -> GBuffer = GBuffer(storageBuffer(), vals);
 export fn GBuffer(size: i64) -> GBuffer = GBuffer(storageBuffer(), size);
-export type GPGPU binds GPGPU;
+export fn id(b: GBuffer) -> string binds buffer_id;
 export fn GPGPU(source: string, buffers: Array{Array{GBuffer}}, maxGlobalId: i64[3]) -> GPGPU binds GPGPU_new;
 export fn GPGPU(source: string, buffer: GBuffer) -> GPGPU binds GPGPU_new_easy;
 export fn run(gg: GPGPU) binds gpu_run;
 export fn read{T}(b: GBuffer) -> Array{T} binds read_buffer;
+
+
 
 /// Stdout/stderr-related bindings
 // TODO: Rework this to just print anything that can be converted to `string` via interfaces
@@ -691,4 +694,4 @@ export infix shl as << precedence 2;
 export infix shr as >> precedence 2;
 export infix wrl as <<< precedence 2;
 export infix wrr as >>> precedence 2;
-export infix set as = precedence 0
+export infix set as = precedence 0;


### PR DESCRIPTION
While planning out how to generate the shader code from Alan code, I realized that it might be possible to do it in pure Alan code, but I would need to have a few things set up in the language. I also realized an issue with the GPGPU code that hasn't shown up only because I've only really tested the `GPGPU_new_easy` function. This is the first of a few PRs to get the groundwork done.

The issue with GPGPU code is that the codegen for Alan right now assumes that *everything* can be `clone`d, and `wgpu::Buffer` cannot, so this PR has changed the `GBuffer` binding of `wgpu::Buffer` to instead bind `Rc<wgpu::Buffer>` to give us cloning capabilities.

I also realized that shader generation depends on not only constructing a sequence of operations that will return some value for each global id input to the shader function, but also being able to uniquely reference the buffers in the generated code and then generate an array of these buffers without accidentally duplicating any of them. This requires an `id` function for buffers, which is included in this PR, as well, since it was surprisingly easy, as well as a `HashMap` that these `id: buffer` pairs can be placed into, which will be a follow-up PR.
