### PR TITLE
Get basic reassignment working and implement type 'tagging'

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -1717,34 +1717,22 @@ test!(object_literals => r#"
     }"#;
     stdout "foo!\ntrue\n";
 );
-test_ignore!(object_and_array_reassignment => r#"
-    type Foo {
-      bar: bool
-    }
+test!(object_and_array_reassignment => r#"
+    type Foo =
+      bar: bool;
 
     export fn main {
-      let test = new Array{int64} [ 1, 2, 3 ];
+      let test = [ 1, 2, 3 ];
       print(test[0]);
-      test.set(0, 0);
+      test.store(0, 0);
       print(test[0]);
 
-      let test2 = new Array{Foo} [
-        new Foo {
-          bar: true
-        },
-        new Foo {
-          bar: false
-        }
-      ];
-      let test3 = test2[0] || new Foo {
-        bar: false
-      };
+      let test2 = [Foo(true), Foo(false)];
+      let test3 = test2[0].getOr(Foo(false));
       print(test3.bar);
       test3.bar = false;
-      test2.set(0, test3); // TODO: is the a better way to do nested updates?
-      const test4 = test2[0] || new Foo {
-        bar: true
-      };
+      test2.store(0, test3); // TODO: is the a better way to do nested updates?
+      const test4 = test2[0].getOr(Foo(true));
       print(test4.bar);
     }"#;
     stdout "1\n0\ntrue\nfalse\n";
@@ -2056,6 +2044,7 @@ test!(basic_dict => r#"
       print(test.vals.map(string).join(', '));
       print(test.len);
       print(test.get('foo'));
+      test['bar'].print;
     }"#;
     stdout r#"key: foo
 val: 1
@@ -2067,6 +2056,7 @@ foo, bar, baz
 1, 2, 99
 3
 1
+2
 "#;
 );
 test!(keyval_array_to_dict => r#"
@@ -2168,7 +2158,7 @@ test_compile_error!(invalid_generics => r#"
       let stringBox = box{string}(true, 'str');
       stringBox.val = 8;
     }"#;
-    error "Could not find a function with a call signature of set(string, i64)";
+    error "Could not find a function with a call signature of store(string, i64)";
 ); // TODO: Make a better error message
 
 // Interfaces
@@ -2602,19 +2592,28 @@ test!(user_types_and_generics => r#"
 
     type foo2 = foo{i64, f64};
 
+    type tagged{A, B} =
+      tag: A,
+      value: B;
+
+    type taggedInt = tagged{"integer", i64};
+
     export fn main {
       let a = foo{string, i64}('bar', 0);
       let b = foo{i64, bool}(0, true);
       let c = foo2(0, 1.23);
       let d = foo{i64, f64}(1, 3.14);
       let e = {i64?}(2);
+      let f = taggedInt(5);
       print(a.bar);
       print(b.bar);
       print(c.bar);
       print(d.bar);
       print(e.i64);
+      print(f.tag);
+      print(f.value);
     }"#;
-    stdout "bar\n0\n0\n1\n2\n";
+    stdout "bar\n0\n0\n1\n2\ninteger\n5\n";
 );
 /* Pending multi-file support
  *

--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -306,13 +306,13 @@ pub fn from_microstatement(
                                 let accessor_field = ts
                                     .iter()
                                     .filter(|t1| match t1 {
-                                        CType::Field(_, t2) => match &**t2 {
+                                        CType::Field(_, t2) => !matches!(
+                                            &**t2,
                                             CType::TString(_)
-                                            | CType::Int(_)
-                                            | CType::Float(_)
-                                            | CType::Bool(_) => false,
-                                            _ => true,
-                                        },
+                                                | CType::Int(_)
+                                                | CType::Float(_)
+                                                | CType::Bool(_)
+                                        ),
                                         CType::TString(_)
                                         | CType::Int(_)
                                         | CType::Float(_)
@@ -735,13 +735,13 @@ pub fn from_microstatement(
                                     == ts
                                         .iter()
                                         .filter(|t| match t {
-                                            CType::Field(_, t) => match &**t {
+                                            CType::Field(_, t) => !matches!(
+                                                &**t,
                                                 CType::Int(_)
-                                                | CType::Float(_)
-                                                | CType::Bool(_)
-                                                | CType::TString(_) => false,
-                                                _ => true,
-                                            },
+                                                    | CType::Float(_)
+                                                    | CType::Bool(_)
+                                                    | CType::TString(_),
+                                            ),
                                             CType::Int(_)
                                             | CType::Float(_)
                                             | CType::Bool(_)

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -71,7 +71,7 @@ pub fn ctype_to_rtype(
         CType::Int(i) => Ok(i.to_string()),
         CType::Float(f) => Ok(f.to_string()),
         CType::Bool(b) => Ok(b.to_string()),
-        CType::TString(s) => Ok(s.clone()),
+        CType::TString(s) => Ok(s.replace(['"', '\''], "_")),
         CType::Group(g) => Ok(format!("({})", ctype_to_rtype(g, in_function_type)?)),
         CType::Function(i, o) => {
             if let CType::Void = **i {

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -1453,12 +1453,10 @@ impl CType {
                 let mut args = Vec::new();
                 // Create accessor functions for static tag values in the tuple, if any exist
                 for ti in ts.iter().filter(|t1| match t1 {
-                    CType::Field(_, t2) => match &**t2 {
-                        CType::TString(_) | CType::Int(_) | CType::Float(_) | CType::Bool(_) => {
-                            true
-                        }
-                        _ => false,
-                    },
+                    CType::Field(_, t2) => matches!(
+                        &**t2,
+                        CType::TString(_) | CType::Int(_) | CType::Float(_) | CType::Bool(_)
+                    ),
                     CType::TString(_) | CType::Int(_) | CType::Float(_) | CType::Bool(_) => true,
                     _ => false,
                 }) {
@@ -1544,13 +1542,10 @@ impl CType {
                 for (i, ti) in ts
                     .iter()
                     .filter(|t1| match t1 {
-                        CType::Field(_, t2) => match &**t2 {
-                            CType::TString(_)
-                            | CType::Int(_)
-                            | CType::Float(_)
-                            | CType::Bool(_) => false,
-                            _ => true,
-                        },
+                        CType::Field(_, t2) => !matches!(
+                            &**t2,
+                            CType::TString(_) | CType::Int(_) | CType::Float(_) | CType::Bool(_)
+                        ),
                         CType::TString(_) | CType::Int(_) | CType::Float(_) | CType::Bool(_) => {
                             false
                         }

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -1451,7 +1451,113 @@ impl CType {
                 // that is marked as a field, we also want to create an accessor
                 // function for it to simulate structs better.
                 let mut args = Vec::new();
-                for (i, ti) in ts.iter().enumerate() {
+                // Create accessor functions for static tag values in the tuple, if any exist
+                for ti in ts.iter().filter(|t1| match t1 {
+                    CType::Field(_, t2) => match &**t2 {
+                        CType::TString(_) | CType::Int(_) | CType::Float(_) | CType::Bool(_) => {
+                            true
+                        }
+                        _ => false,
+                    },
+                    CType::TString(_) | CType::Int(_) | CType::Float(_) | CType::Bool(_) => true,
+                    _ => false,
+                }) {
+                    match ti {
+                        CType::Field(n, f) => {
+                            match &**f {
+                                CType::TString(s) => {
+                                    // Create an accessor function for this value, but do not add
+                                    // it to the args array to construct it. The accessor function
+                                    // will return this value as a string.
+                                    let string =
+                                        CType::Bound("string".to_string(), "String".to_string());
+                                    fs.push(Function {
+                                        name: n.clone(),
+                                        args: vec![("arg0".to_string(), t.clone())],
+                                        rettype: string.clone(),
+                                        microstatements: vec![Microstatement::Value {
+                                            typen: string,
+                                            representation: s.clone(),
+                                        }],
+                                        kind: FnKind::Static,
+                                    });
+                                }
+                                CType::Int(i) => {
+                                    // Create an accessor function for this value, but do not add
+                                    // it to the args array to construct it. The accessor function
+                                    // will return this value as an i64.
+                                    let int64 = CType::Bound("i64".to_string(), "i64".to_string());
+                                    fs.push(Function {
+                                        name: n.clone(),
+                                        args: vec![("arg0".to_string(), t.clone())],
+                                        rettype: int64.clone(),
+                                        microstatements: vec![Microstatement::Value {
+                                            typen: int64,
+                                            representation: format!("{}", i),
+                                        }],
+                                        kind: FnKind::Static,
+                                    });
+                                }
+                                CType::Float(f) => {
+                                    // Create an accessor function for this value, but do not add
+                                    // it to the args array to construct it. The accessor function
+                                    // will return this value as an f64.
+                                    let float64 =
+                                        CType::Bound("f64".to_string(), "f64".to_string());
+                                    fs.push(Function {
+                                        name: n.clone(),
+                                        args: vec![("arg0".to_string(), t.clone())],
+                                        rettype: float64.clone(),
+                                        microstatements: vec![Microstatement::Value {
+                                            typen: float64,
+                                            representation: format!("{}", f),
+                                        }],
+                                        kind: FnKind::Static,
+                                    });
+                                }
+                                CType::Bool(b) => {
+                                    // Create an accessor function for this value, but do not add
+                                    // it to the args array to construct it. The accessor function
+                                    // will return this value as a bool.
+                                    let booln =
+                                        CType::Bound("bool".to_string(), "bool".to_string());
+                                    fs.push(Function {
+                                        name: n.clone(),
+                                        args: vec![("arg0".to_string(), t.clone())],
+                                        rettype: booln.clone(),
+                                        microstatements: vec![Microstatement::Value {
+                                            typen: booln,
+                                            representation: match b {
+                                                true => "true".to_string(),
+                                                false => "false".to_string(),
+                                            },
+                                        }],
+                                        kind: FnKind::Static,
+                                    });
+                                }
+                                _ => { /* Do nothing */ }
+                            }
+                        }
+                        _ => { /* Do nothing */ }
+                    }
+                }
+                for (i, ti) in ts
+                    .iter()
+                    .filter(|t1| match t1 {
+                        CType::Field(_, t2) => match &**t2 {
+                            CType::TString(_)
+                            | CType::Int(_)
+                            | CType::Float(_)
+                            | CType::Bool(_) => false,
+                            _ => true,
+                        },
+                        CType::TString(_) | CType::Int(_) | CType::Float(_) | CType::Bool(_) => {
+                            false
+                        }
+                        _ => true,
+                    })
+                    .enumerate()
+                {
                     match ti {
                         CType::Field(n, f) => {
                             // Create an accessor function
@@ -1475,9 +1581,100 @@ impl CType {
                                 microstatements: Vec::new(),
                                 kind: FnKind::Derived,
                             });
-                            println!("fs {:?}", fs);
                             args.push((format!("arg{}", i), otherwise.clone()));
                         }
+                    }
+                }
+                // Define the constructor function
+                fs.push(Function {
+                    name: constructor_fn_name.clone(),
+                    args,
+                    rettype: t.clone(),
+                    microstatements: Vec::new(),
+                    kind: FnKind::Derived,
+                });
+            }
+            CType::Field(n, f) => {
+                // This is a "baby tuple" of just one value. So we follow the Tuple logic, but
+                // simplified.
+                let mut args = Vec::new();
+                match &**f {
+                    CType::TString(s) => {
+                        // Create an accessor function for this value, but do not add
+                        // it to the args array to construct it. The accessor function
+                        // will return this value as a string.
+                        let string = CType::Bound("string".to_string(), "String".to_string());
+                        fs.push(Function {
+                            name: n.clone(),
+                            args: vec![("arg0".to_string(), t.clone())],
+                            rettype: string.clone(),
+                            microstatements: vec![Microstatement::Value {
+                                typen: string,
+                                representation: s.clone(),
+                            }],
+                            kind: FnKind::Static,
+                        });
+                    }
+                    CType::Int(i) => {
+                        // Create an accessor function for this value, but do not add
+                        // it to the args array to construct it. The accessor function
+                        // will return this value as an i64.
+                        let int64 = CType::Bound("i64".to_string(), "i64".to_string());
+                        fs.push(Function {
+                            name: n.clone(),
+                            args: vec![("arg0".to_string(), t.clone())],
+                            rettype: int64.clone(),
+                            microstatements: vec![Microstatement::Value {
+                                typen: int64,
+                                representation: format!("{}", i),
+                            }],
+                            kind: FnKind::Static,
+                        });
+                    }
+                    CType::Float(f) => {
+                        // Create an accessor function for this value, but do not add
+                        // it to the args array to construct it. The accessor function
+                        // will return this value as an f64.
+                        let float64 = CType::Bound("f64".to_string(), "f64".to_string());
+                        fs.push(Function {
+                            name: n.clone(),
+                            args: vec![("arg0".to_string(), t.clone())],
+                            rettype: float64.clone(),
+                            microstatements: vec![Microstatement::Value {
+                                typen: float64,
+                                representation: format!("{}", f),
+                            }],
+                            kind: FnKind::Static,
+                        });
+                    }
+                    CType::Bool(b) => {
+                        // Create an accessor function for this value, but do not add
+                        // it to the args array to construct it. The accessor function
+                        // will return this value as a bool.
+                        let booln = CType::Bound("bool".to_string(), "bool".to_string());
+                        fs.push(Function {
+                            name: n.clone(),
+                            args: vec![("arg0".to_string(), t.clone())],
+                            rettype: booln.clone(),
+                            microstatements: vec![Microstatement::Value {
+                                typen: booln,
+                                representation: match b {
+                                    true => "true".to_string(),
+                                    false => "false".to_string(),
+                                },
+                            }],
+                            kind: FnKind::Static,
+                        });
+                    }
+                    otherwise => {
+                        fs.push(Function {
+                            name: n.clone(),
+                            args: vec![("arg0".to_string(), t.clone())],
+                            rettype: *f.clone(),
+                            microstatements: Vec::new(),
+                            kind: FnKind::Derived,
+                        });
+                        args.push(("arg0".to_string(), otherwise.clone()));
                     }
                 }
                 // Define the constructor function
@@ -1750,6 +1947,7 @@ impl CType {
             }
         }
         scope.types.insert(name, t.clone());
+        scope.types.insert(t.to_callable_string(), t.clone());
         if !fs.is_empty() {
             let mut name_fn_pairs = HashMap::new();
             for f in fs {
@@ -1777,7 +1975,8 @@ impl CType {
     pub fn from_ctype(scope: &mut Scope, name: String, ctype: CType) {
         scope.exports.insert(name.clone(), Export::Type);
         let (_, fs) = ctype.to_functions(name.clone());
-        scope.types.insert(name, ctype);
+        scope.types.insert(name, ctype.clone());
+        scope.types.insert(ctype.to_callable_string(), ctype);
         if !fs.is_empty() {
             let mut name_fn_pairs = HashMap::new();
             for f in fs {
@@ -3126,7 +3325,7 @@ pub fn typebaselist_to_ctype(
                             }
                         }
                     }
-                    None => CType::fail(&format!("{} is not a valid generic type name", var)),
+                    None => CType::fail(&format!("{} is not a valid type name", var)),
                 })
             }
             parse::TypeBase::GnCall(_) => { /* We always process GnCall in the Variable path */ }

--- a/src/program/fnkind.rs
+++ b/src/program/fnkind.rs
@@ -10,4 +10,5 @@ pub enum FnKind {
     BoundGeneric(Vec<(String, CType)>, String),
     Derived,
     DerivedVariadic,
+    Static,
 }

--- a/src/program/function.rs
+++ b/src/program/function.rs
@@ -391,7 +391,11 @@ impl Function {
         generic_types: Vec<CType>,
     ) -> Result<&'a Function, Box<dyn std::error::Error>> {
         match &generic_function.kind {
-            FnKind::Normal | FnKind::Bind(_) | FnKind::Derived | FnKind::DerivedVariadic => {
+            FnKind::Normal
+            | FnKind::Bind(_)
+            | FnKind::Derived
+            | FnKind::DerivedVariadic
+            | FnKind::Static => {
                 Err("Should be impossible. Attempted to realize a non-generic function".into())
             }
             FnKind::BoundGeneric(gen_args, generic_fn_string) => {

--- a/src/program/scope.rs
+++ b/src/program/scope.rs
@@ -305,7 +305,8 @@ impl<'a> Scope<'a> {
                     FnKind::Normal
                     | FnKind::Bind(_)
                     | FnKind::Derived
-                    | FnKind::DerivedVariadic => None,
+                    | FnKind::DerivedVariadic
+                    | FnKind::Static => None,
                     FnKind::Generic(gs, _) | FnKind::BoundGeneric(gs, _) => {
                         Some(gs.iter().map(|(g, _)| g.clone()).collect::<Vec<String>>())
                     }
@@ -404,9 +405,11 @@ impl<'a> Scope<'a> {
         let mut generic_fs = Vec::new();
         for f in &fs {
             match &f.kind {
-                FnKind::Normal | FnKind::Bind(_) | FnKind::Derived | FnKind::DerivedVariadic => {
-                    /* Do nothing */
-                }
+                FnKind::Normal
+                | FnKind::Bind(_)
+                | FnKind::Derived
+                | FnKind::DerivedVariadic
+                | FnKind::Static => { /* Do nothing */ }
                 FnKind::Generic(g, _) | FnKind::BoundGeneric(g, _) => {
                     // TODO: Check interface constraints once interfaces exist
                     if g.len() != generic_types.len() {
@@ -569,7 +572,7 @@ impl<'a> Scope<'a> {
                         return None;
                     }
                 }
-                FnKind::Normal | FnKind::Bind(_) | FnKind::Derived => {
+                FnKind::Normal | FnKind::Bind(_) | FnKind::Derived | FnKind::Static => {
                     if args.len() != f.args.len() {
                         continue;
                     }
@@ -665,7 +668,7 @@ impl<'a> Scope<'a> {
                         return Some(f);
                     }
                 }
-                FnKind::Normal | FnKind::Bind(_) | FnKind::Derived => {
+                FnKind::Normal | FnKind::Bind(_) | FnKind::Derived | FnKind::Static => {
                     if args.len() != f.args.len() {
                         continue;
                     }

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -141,6 +141,7 @@ export fn hash(v: string) -> i64 binds hashstring;
 export fn hash{T}(v: T) -> i64 binds hash;
 export fn void{T}(v: T) -> void {}
 export fn void() -> void {}
+export fn store{T}(a: T, b: T) -> T binds storeswap;
 
 /// Fallible, Maybe, and Either functions
 export fn getOr{T}(v: Maybe{T}, d: T) -> T binds maybe_get_or;
@@ -740,4 +741,4 @@ export infix shl as << precedence 2;
 export infix shr as >> precedence 2;
 export infix wrl as <<< precedence 2;
 export infix wrr as >>> precedence 2;
-export infix set as = precedence 0;
+export infix store as = precedence 0;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -79,6 +79,12 @@ fn hashstring(v: &String) -> i64 {
     hasher.finish() as i64
 }
 
+/// `storeswap` swaps the input and output
+#[inline(always)]
+fn storeswap<T: std::clone::Clone>(a: &mut T, b: &mut T) -> T {
+    std::mem::replace(a, b.clone())
+}
+
 /// Fallible, Maybe, and Either functions
 
 /// `maybe_get_or` gets the Option's value or returns the default if not present.


### PR DESCRIPTION
I also had to fix some bugs with type resolution to get this working. There was a more fundamental issue with type resolution that was fixed by also registering the ctype `to_callable_string` as a typename in the scope.
