### PR TITLE
Prefer normal functions if one is defined

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -767,8 +767,7 @@ test!(hello_gpu_new => r#"
     export fn main {
       let b = GBuffer(filled(2.i32, 4));
       let id = gFor(4);
-      // TODO: `save` should be `store`, but there's a function resolution bug
-      let compute = b[id.x].save(b[id.x] * id.x.gi32);
+      let compute = b[id.x].store(b[id.x] * id.x.gi32);
       compute.build.run;
       b.read{i32}.print;
     }"#;

--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -25,6 +25,7 @@ macro_rules! test {
                     }
                 };
                 std::env::set_var("ALAN_TARGET", "test");
+                std::thread::sleep(std::time::Duration::from_millis(10)); // Race condition?
                 match crate::compile::build(filename.to_string()) {
                     Ok(_) => { /* Do nothing */ }
                     Err(e) => {

--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -25,7 +25,6 @@ macro_rules! test {
                     }
                 };
                 std::env::set_var("ALAN_TARGET", "test");
-                std::thread::sleep(std::time::Duration::from_millis(10)); // Race condition?
                 match crate::compile::build(filename.to_string()) {
                     Ok(_) => { /* Do nothing */ }
                     Err(e) => {

--- a/src/program/scope.rs
+++ b/src/program/scope.rs
@@ -506,14 +506,11 @@ impl<'a> Scope<'a> {
     }
 
     pub fn resolve_function(&'a mut self, function: &String, args: &[CType]) -> Option<&Function> {
-        // We should prefer the "normal" function, it it matches, use it, otherwise try to go with
+        // We should prefer the "normal" function, if it matches, use it, otherwise try to go with
         // a generic function, if possible.
         // TODO: This boolean *shouldn't* be necessary, but I can't convince the borrow checker
         // otherwise
-        let is_normal = match self.resolve_normal_function(function, args) {
-            Some(_) => true,
-            None => false,
-        };
+        let is_normal = self.resolve_normal_function(function, args).is_some();
         if is_normal {
             self.resolve_normal_function(function, args)
         } else {

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -1191,8 +1191,7 @@ export fn get(gb: GBuffer, i: gu32) -> gi32 {
   return gi32(statement, i.statements, buffers);
 }
 
-// TODO: This is supposed to be named `store` but it's not resolving properly
-export fn save(a: gi32, b: gi32) -> gi32 {
+export fn store(a: gi32, b: gi32) -> gi32 {
     let statement = a.varName.concat(" = ").concat(b.varName);
     let statements = a.statements.concat(b.statements).concat(Dict(statement, statement));
     let buffers = a.buffers.union(b.buffers);


### PR DESCRIPTION
So the reason why my custom `store` function wasn't being used is because the generic function `store{T}(a: T, b: T) -> T` matches *all* types when the stored value is the same type as the original value, and the way `resolve_function` worked before (because the borrow checker made that the easiest way to implement it), it would first see if any generic function can resolve for the desired function and use that, then if not, it would check if there's a "normal" function that would do. This worked most of the time because there was never a generic function that also matched a "normal" function within the codebase, yet, but if there's ever a match for both generic and normal, the normal function, which had to be handwritten by the developer, should be preferred, so this PR reverses that and then updates the new gpu test back to the desired `store` syntax (desired because it should also work with `=`, but a bit confusing here as written as a `let` assignment as well, so I stuck with the method syntax).
