### PR TITLE
Minor `gFor` update

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -766,8 +766,8 @@ test!(hello_gpu => r#"
 test!(hello_gpu_new => r#"
     export fn main {
       let b = GBuffer(filled(2.i32, 4));
-      let id = gFor(4);
-      let compute = b[id.x].store(b[id.x] * id.x.gi32);
+      let idx = gFor(4);
+      let compute = b[idx].store(b[idx] * idx.gi32);
       compute.build.run;
       b.read{i32}.print;
     }"#;

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -983,7 +983,7 @@ export fn gFor(x: u32, y: u32, z: u32) -> gvec3u {
 }
 export fn gFor{T}(x: T, y: T, z: T) -> gvec3u = gFor(x.u32, y.u32, z.u32);
 export fn gFor{T}(x: T, y: T) -> gvec3u = gFor(x.u32, y.u32, 1.u32);
-export fn gFor{T}(x: T) -> gvec3u = gFor(x.u32, 1.u32, 1.u32);
+export fn gFor{T}(x: T) -> gu32 = gFor(x.u32, 1.u32, 1.u32).x;
 
 // Matrix types
 export type gmat2x2f = WgpuType{"mat2x2f"};


### PR DESCRIPTION
I realized that the single-argument `gFor` would be more intuitive to also return access only to the `x` value, instead of a vector.
