### PR TITLE
Only test once

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ divan = "0.1.14"
 [[bench]]
 name = "map"
 harness = false
+
+[[bin]]
+name = "alan"
+test = false


### PR DESCRIPTION
Since the `bin` and `lib` paths in `cargo test` run *exactly the same test suite*. CI has always run the test twice in a row.

This hasn't really been a big deal for my x86 Linux machines, but the little ARM machine has always slowed down the CI job, and with more and more GPU-oriented tests being added, it will only get worse more quickly than before, so I finally felt the need to figure out how to stop the duplicate test runs.
