### PR TITLE
Better enum construction for void type values

### DIFF
--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -358,6 +358,15 @@ pub fn from_microstatement(
                             }
                             _ => {}
                         }
+                    } else if function.args.len() == 0 {
+                        let inner_ret_type = match &function.rettype.degroup() {
+                            CType::Field(_, t) => *t.clone(),
+                            CType::Type(_, t) => *t.clone(),
+                            t => t.clone(),
+                        };
+                        if let CType::Either(_) = inner_ret_type {
+                            return Ok(("None".to_string(), out));
+                        }
                     }
                     let ret_type = &function.rettype.degroup();
                     let ret_name = ret_type.to_callable_string();

--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -358,7 +358,7 @@ pub fn from_microstatement(
                             }
                             _ => {}
                         }
-                    } else if function.args.len() == 0 {
+                    } else if function.args.is_empty() {
                         let inner_ret_type = match &function.rettype.degroup() {
                             CType::Field(_, t) => *t.clone(),
                             CType::Type(_, t) => *t.clone(),

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -157,7 +157,7 @@ pub fn generate(
             CType::Either(_) => {
                 let res = generate(t, out)?;
                 out = res.1;
-                out.insert(name.clone(), ctype_to_rtype(typen, false)?);
+                out.insert(t.to_callable_string(), ctype_to_rtype(typen, false)?);
                 Ok((name.clone(), out))
             }
             _ => Ok((ctype_to_rtype(t, true)?, out)),

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -1693,6 +1693,16 @@ impl CType {
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,
                     });
+                    if let CType::Void = &e {
+                        // Have a zero-arg constructor function produce the void type, if possible.
+                        fs.push(Function {
+                            name: constructor_fn_name.clone(),
+                            args: vec![],
+                            rettype: t.clone(),
+                            microstatements: Vec::new(),
+                            kind: FnKind::Derived,
+                        });
+                    }
                     // Create the accessor function, the name of the function will
                     // depend on the kind of type this is
                     match e {

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -150,7 +150,6 @@ export fn store{T}(a: T, b: T) -> T binds storeswap;
 export fn getOr{T}(v: Maybe{T}, d: T) -> T binds maybe_get_or;
 export fn getOr{T}(v: Fallible{T}, d: T) -> T binds fallible_get_or;
 export fn getOr{T, U}(v: U, d: T) -> T = {T}(v).getOr(d);
-export fn none{T}() -> Maybe{T} binds maybe_none;
 export fn error{T}(m: string) -> Fallible{T} binds fallible_error;
 export fn exists{T}(v: Maybe{T}) -> bool binds maybe_exists;
 
@@ -567,7 +566,7 @@ export fn xnor(a: bool, b: bool) -> bool binds xnorbool;
 export fn eq(a: bool, b: bool) -> bool binds eqbool;
 export fn neq(a: bool, b: bool) -> bool binds neqbool;
 export fn cond{T}(c: bool, t: () -> T, f: () -> T) -> T binds condbool;
-export fn cond{T}(c: bool, t: () -> T) -> Maybe{T} = cond(c, fn = Maybe{T}(t()), fn = none{T}());
+export fn cond{T}(c: bool, t: () -> T) -> Maybe{T} = cond(c, fn = Maybe{T}(t()), fn = Maybe{T}());
 
 /// Array related bindings
 export fn get{T}(a: T[], i: i64) -> Maybe{T} binds getarray;
@@ -591,7 +590,7 @@ export fn find{T}(a: Array{T}, f: (T) -> bool) -> Maybe{T} binds findarray;
 // TODO: The `if` syntactic sugar will make these `cond` calls much nicer (though so would return
 // type inference, to be honest)
 export fn index{T}(a: Array{T}, v: T) -> Maybe{i64} = a.reduce(
-  none{i64}(),
+  Maybe{i64}(),
   fn (out: Maybe{i64}, val: T, idx: i64) -> Maybe{i64} = cond(
     out.exists,
     fn () -> Maybe{i64} = out,
@@ -603,7 +602,7 @@ export fn index{T}(a: Array{T}, v: T) -> Maybe{i64} = a.reduce(
   )
 );
 export fn index{T}(a: Array{T}, f: (T) -> bool) -> Maybe{i64} = a.reduce(
-  none{i64}(),
+  Maybe{i64}(),
   fn (out: Maybe{i64}, val: T, idx: i64) -> Maybe{i64} = cond(
     out.exists,
     fn () -> Maybe{i64} = out,
@@ -611,7 +610,7 @@ export fn index{T}(a: Array{T}, f: (T) -> bool) -> Maybe{i64} = a.reduce(
       f(val),
       fn () -> i64 = idx)));
 export fn index{T}(a: Array{T}, f: (T, i64) -> bool) -> Maybe{i64} = a.reduce(
-  none{i64}(),
+  Maybe{i64}(),
   fn (out: Maybe{i64}, val: T, idx: i64) -> Maybe{i64} = cond(
     out.exists,
     fn () -> Maybe{i64} = out,

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -107,12 +107,6 @@ fn fallible_get_or<T: std::clone::Clone>(v: &Result<T, AlanError>, d: &T) -> T {
     }
 }
 
-/// `maybe_none` creates a None for the given maybe type
-#[inline(always)]
-fn maybe_none<T>() -> Option<T> {
-    None
-}
-
 /// `fallible_error` create an Err for the given fallible type
 #[inline(always)]
 fn fallible_error<T>(m: &String) -> Result<T, AlanError> {


### PR DESCRIPTION
This feels more "Alan" to me (there's no special function to make a void-value Either type anymore, just call the normal constructor function with no values), simplifies the codebase a bit, and fixes a bug in the rust codegen.
