### PR TITLE
Make error construction consistent with other types

### DIFF
--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -150,7 +150,7 @@ export fn store{T}(a: T, b: T) -> T binds storeswap;
 export fn getOr{T}(v: Maybe{T}, d: T) -> T binds maybe_get_or;
 export fn getOr{T}(v: Fallible{T}, d: T) -> T binds fallible_get_or;
 export fn getOr{T, U}(v: U, d: T) -> T = {T}(v).getOr(d);
-export fn error{T}(m: string) -> Fallible{T} binds fallible_error;
+export fn Error{T}(m: string) -> Fallible{T} binds fallible_error;
 export fn exists{T}(v: Maybe{T}) -> bool binds maybe_exists;
 
 /// Signed Integer-related functions and function bindings


### PR DESCRIPTION
While writing the documentation I realized that error construction was inconsistent with other types because the constructor function name did not match the type name.
