### PR TITLE
Fix negation precedence

### DIFF
--- a/src/program/microstatement.rs
+++ b/src/program/microstatement.rs
@@ -1124,8 +1124,7 @@ pub fn withoperatorslist_to_microstatements(
     // are associated, then put those results in the same "slot" as before and check again. Because
     // users can define these operators, that makes it theoretically possible for the same operator
     // to be used in both an infix or prefix manner, or with different precedence levels, depending
-    // on the types of the data involved, which makes things *really* complicated here. TODO:
-    // Actually implement that complexity, for now, just pretend operators have only one binding.
+    // on the types of the data involved, which makes things *really* complicated here.
     let mut queue = withoperatorslist.clone();
     while !queue.is_empty() {
         let mut largest_operator_level: i8 = -1;
@@ -1152,8 +1151,12 @@ pub fn withoperatorslist_to_microstatements(
                     let local_level = match local_op {
                         Some(o) => match o {
                             OperatorMapping::Prefix { level, .. } => {
-                                match queue.get(i.wrapping_add(1)) {
-                                    Some(parse::WithOperators::BaseAssignableList(_)) => *level,
+                                match (queue.get(i.wrapping_sub(1)), queue.get(i.wrapping_add(1))) {
+                                    (None, Some(parse::WithOperators::BaseAssignableList(_)))
+                                    | (
+                                        Some(parse::WithOperators::Operators(_)),
+                                        Some(parse::WithOperators::BaseAssignableList(_)),
+                                    ) => *level,
                                     _ => -1,
                                 }
                             }
@@ -1167,8 +1170,12 @@ pub fn withoperatorslist_to_microstatements(
                                 }
                             }
                             OperatorMapping::Postfix { level, .. } => {
-                                match queue.get(i.wrapping_sub(1)) {
-                                    Some(parse::WithOperators::BaseAssignableList(_)) => *level,
+                                match (queue.get(i.wrapping_sub(1)), queue.get(i.wrapping_add(1))) {
+                                    (Some(parse::WithOperators::BaseAssignableList(_)), None)
+                                    | (
+                                        Some(parse::WithOperators::BaseAssignableList(_)),
+                                        Some(parse::WithOperators::Operators(_)),
+                                    ) => *level,
                                     _ => -1,
                                 }
                             }

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -1327,14 +1327,9 @@ export fn eprint{T}(v: Maybe{T}) binds eprintln_maybe;
 export fn eprint{T}(v: T) binds eprintln;
 
 /// Built-in operator definitions
-// TODO: New plan is to make operators only map to one function per symbol and *kind* of operator,
-// so you can have an infix and prefix operator with the same symbol linked to different functions,
-// but you can't have an infix operator of the same symbol linked to multiple functions. This does
-// produce some ambiguity of what kind of operator an operator is, but should still be unambiguous
-// to humans to "read" the symbol as whatever kind of function it represents.
 export infix add as + precedence 3;
 export infix sub as - precedence 3;
-export prefix neg as - precedence 2;
+export prefix neg as - precedence 6;
 export infix mul as * precedence 4;
 export infix div as / precedence 4;
 export infix mod as % precedence 4;


### PR DESCRIPTION
I noticed that the negation precedence was all wrong (it should be the highest precedence so it attaches its negation to the nearest variable only).

I also removed a TODO that was already done but the notice was forgotten about.
