### PR TITLE
Implement auto-wrapping for sum type reassignment

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -2638,6 +2638,13 @@ test!(either => r#"
       print(someI64.i64);
       print(someI64.getOr(0));
       print(someI64.getOr('text'));
+
+      let either = strOrI64(3);
+      either.string.print;
+      either.i64.print;
+      either = 'text';
+      either.string.print;
+      either.i64.print;
     }"#;
     stdout r#"string
 void
@@ -2647,6 +2654,10 @@ void
 3
 3
 text
+void
+3
+text
+void
 "#;
 );
 

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -1693,6 +1693,17 @@ impl CType {
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,
                     });
+                    // Create a store fn to re-assign-and-auto-wrap a value
+                    fs.push(Function {
+                        name: "store".to_string(),
+                        args: vec![
+                            ("arg0".to_string(), t.clone()),
+                            ("arg1".to_string(), e.clone()),
+                        ],
+                        rettype: t.clone(),
+                        microstatements: Vec::new(),
+                        kind: FnKind::Derived,
+                    });
                     if let CType::Void = &e {
                         // Have a zero-arg constructor function produce the void type, if possible.
                         fs.push(Function {


### PR DESCRIPTION
Resolves #836

The entirety of the derived function generation inside of `lntors` definitely needs reworking. It's a rat's nest...
