### PR TITLE
Create a benchmark for raw memory filling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ divan = "0.1.14"
 name = "map"
 harness = false
 
+[[bench]]
+name = "fill"
+harness = false
+
 [[bin]]
 name = "alan"
 test = false

--- a/benches/fill.rs
+++ b/benches/fill.rs
@@ -1,0 +1,73 @@
+use std::fs::{remove_file, write};
+use std::process::{Command, Output};
+
+use alan::compile::compile;
+
+macro_rules! build {
+    ( $name:ident => $code:expr ) => {
+        let filename = format!("{}.ln", stringify!($name));
+        write(&filename, $code)?;
+        compile(filename.to_string())?;
+    };
+}
+
+macro_rules! run {
+    ( $name:ident ) => {
+        #[divan::bench(max_time = 60)]
+        fn $name() -> Result<Output, std::io::Error> {
+            Command::new(format!("./{}", stringify!($name))).output()
+        }
+    };
+}
+
+macro_rules! clean {
+    ( $name:ident ) => {
+        let sourcefile = format!("{}.ln", stringify!($name));
+        let executable = if cfg!(windows) {
+            format!("{}.exe", stringify!($name))
+        } else {
+            format!("{}", stringify!($name))
+        };
+        remove_file(&sourcefile)?;
+        remove_file(&executable)?;
+    };
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    build!(t01_fill_100 => r#"
+        export fn main { let v = filled(5, 100); v[0].print; }
+    "#);
+    build!(t02_fill_100_000 => r#"
+        export fn main { let v = filled(5, 100_000); v[0].print; }
+    "#);
+    build!(t03_fill_100_000_000 => r#"
+        export fn main { let v = filled(5, 100_000_000); v[0].print; }
+    "#);
+    divan::main();
+    clean!(t01_fill_100);
+    clean!(t02_fill_100_000);
+    clean!(t03_fill_100_000_000);
+    Ok(())
+}
+
+run!(t01_fill_100);
+run!(t02_fill_100_000);
+run!(t03_fill_100_000_000);
+
+#[divan::bench(max_time = 60)]
+fn t04_vec_100() -> Result<(), std::io::Error> {
+    let v = vec![5; 100];
+    write("/dev/null", format!("{}", v[0]))
+}
+
+#[divan::bench(max_time = 60)]
+fn t05_vec_100_000() -> Result<(), std::io::Error> {
+    let v = vec![5; 100_000];
+    write("/dev/null", format!("{}", v[0]))
+}
+
+#[divan::bench(max_time = 60)]
+fn t06_vec_100_000_000() -> Result<(), std::io::Error> {
+    let v = vec![5; 100_000_000];
+    write("/dev/null", format!("{}", v[0]))
+}


### PR DESCRIPTION
There is an old branch that I had hand-written a benchmark *based on* the output of the Alan compiler, but it'd be better to turn it into a real benchmark.

The first two levels of the benchmark show the process spawning overhead rather than the actual memory-writing performance, but the third level of each have near identical performances, demonstrating that, at least for writing a bunch of identical values into RAM, Alan doesn't add any overhead versus Rust.

I intend to add more benchmarks over time, especially as the language reaches a (for now) feature-complete state and I can start digging into potential bottlenecks, and this helps demonstrate how (you apparently *can* have multiple `[[bench]]` sections in your `Cargo.toml` file; that was not explained anywhere in the documentation for divan).
