### PR TITLE
Implement type binding via generic types instead of special syntax

### DIFF
--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -27,11 +27,8 @@ pub fn ctype_to_rtype(
                                     ctype_to_rtype(v, in_function_type)?
                                 ));
                             }
-                            CType::Type(n, _) | CType::ResolvedBoundGeneric(n, ..) => {
-                                enum_type_strs.push(format!("{}({})", n, n));
-                            }
-                            CType::Bound(n, r) => {
-                                enum_type_strs.push(format!("{}({})", n, r));
+                            CType::Type(n, t) => {
+                                enum_type_strs.push(format!("{}({})", n, ctype_to_rtype(&**t, in_function_type)?));
                             }
                             CType::Group(g) => {
                                 enum_type_strs.push(ctype_to_rtype(g, in_function_type)?);
@@ -63,29 +60,29 @@ pub fn ctype_to_rtype(
                     }
                     Ok(format!("({})", out.join(", ")))
                 }
+                CType::Binds(n) => Ok(format!("{}", n)),
                 _ => Ok("".to_string()), // TODO: Is this correct?
             }
         }
         CType::Generic(name, args, _) => Ok(format!("{}<{}>", name, args.join(", "))),
-        CType::Bound(_, name) => Ok(name.clone()),
-        CType::BoundGeneric(name, args, _) => Ok(format!("{}<{}>", name, args.join(", "))),
-        CType::ResolvedBoundGeneric(_name, argstrs, args, binding) => {
-            let mut args_rtype = Vec::new();
+        CType::Binds(name) => Ok(name.clone()),
+        CType::BindsGeneric(name, args) => {
+            let mut out_args = Vec::new();
             for arg in args {
-                args_rtype.push(ctype_to_rtype(arg, in_function_type)?);
+                out_args.push(ctype_to_rtype(arg, in_function_type)?);
             }
-            // TODO: Get a real Rust type parser and do this better
-            let mut out_str = binding.clone();
-            for i in 0..argstrs.len() {
-                out_str = out_str.replace(&argstrs[i], &args_rtype[i]);
-            }
-            Ok(out_str.to_string())
+            Ok(format!("{}<{}>", name, out_args.join(", ")))
         }
         CType::IntrinsicGeneric(name, _) => Ok(name.clone()), // How would this even be reached?
         CType::Int(i) => Ok(i.to_string()),
         CType::Float(f) => Ok(f.to_string()),
         CType::Bool(b) => Ok(b.to_string()),
-        CType::TString(s) => Ok(s.replace(['"', '\''], "_")),
+        CType::TString(s) => Ok(s.chars().map(|c| match c {
+            '0'..='9' => c,
+            'a'..='z' => c,
+            'A'..='Z' => c,
+            _ => '_',
+        }).collect::<String>()),
         CType::Group(g) => Ok(format!("({})", ctype_to_rtype(g, in_function_type)?)),
         CType::Function(i, o) => {
             if let CType::Void = **i {
@@ -123,16 +120,11 @@ pub fn ctype_to_rtype(
             // Special handling to convert `Either{T, void}` to `Option<T>` and `Either{T, Error}`
             // to `Result<T, AlanError>`
             if ts.len() == 2 {
-                if let CType::Void = &ts[1] {
-                    Ok(format!("Option<{}>", ctype_to_rtype(&ts[0], in_function_type)?))
-                } else if let CType::Bound(name, rustname) = &ts[1] {
-                    if name == "Error" {
-                        Ok(format!("Result<{}, {}>", ctype_to_rtype(&ts[0], in_function_type)?, rustname))
-                    } else {
-                        Ok(CType::Either(ts.clone()).to_callable_string())
-                    }
-                } else {
-                    Ok(CType::Either(ts.clone()).to_callable_string())
+                match &ts[1] {
+                    CType::Void => Ok(format!("Option<{}>", ctype_to_rtype(&ts[0], in_function_type)?)),
+                    CType::Binds(rustname) if rustname == "AlanError" => Ok(format!("Result<{}, {}>", ctype_to_rtype(&ts[0], in_function_type)?, rustname)),
+                    CType::Type(_, t) if matches!(&**t, CType::Binds(rustname) if rustname == "AlanError") => Ok(format!("Result<{}, {}>", ctype_to_rtype(&ts[0], in_function_type)?, "AlanError")),
+                    _ => Ok(CType::Either(ts.clone()).to_callable_string()),
                 }
             } else {
                 Ok(CType::Either(ts.clone()).to_callable_string())
@@ -164,7 +156,7 @@ pub fn generate(
         // assuming no bugs in the standard library) so they do not alter the generated source
         // output, while the `Structlike` type requires a new struct to be created and inserted
         // into the source definition, potentially inserting inner types as needed
-        CType::Bound(_name, rtype) => Ok((rtype.clone(), out)),
+        CType::Binds(rtype) => Ok((rtype.clone(), out)),
         // TODO: The complexity of this function indicates more fundamental issues in the type
         // generation. This needs a rethink and rewrite.
         CType::Type(name, t) => match &**t {

--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -28,7 +28,7 @@ pub fn ctype_to_rtype(
                                 ));
                             }
                             CType::Type(n, t) => {
-                                enum_type_strs.push(format!("{}({})", n, ctype_to_rtype(&**t, in_function_type)?));
+                                enum_type_strs.push(format!("{}({})", n, ctype_to_rtype(t, in_function_type)?));
                             }
                             CType::Group(g) => {
                                 enum_type_strs.push(ctype_to_rtype(g, in_function_type)?);
@@ -60,7 +60,7 @@ pub fn ctype_to_rtype(
                     }
                     Ok(format!("({})", out.join(", ")))
                 }
-                CType::Binds(n) => Ok(format!("{}", n)),
+                CType::Binds(n) => Ok(n.clone()),
                 _ => Ok("".to_string()), // TODO: Is this correct?
             }
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -950,20 +950,10 @@ test!(typebaselist =>
         }),
     ];
 );
-named_and!(typecreate: TypeCreate =>
+named_and!(typedef: TypeDef =>
     a: String as eq,
     b: String as whitespace,
     typeassignables: Vec<WithTypeOperators> as typeassignables,
-);
-named_and!(typebind: TypeBind =>
-    binds: String as binds,
-    a: String as whitespace,
-    othertype: String as one_or_more!(not!(";")),
-    semicolon: String as semicolon,
-);
-named_or!(typedef: TypeDef =>
-    TypeCreate: TypeCreate as typecreate,
-    TypeBind: TypeBind as typebind,
 );
 named_and!(types: Types =>
     typen: String as typen,
@@ -978,8 +968,8 @@ named_and!(types: Types =>
 test!(types =>
     pass "type Foo = bar: string;";
     pass "type Foo = Bar";
-    pass "type Result{T, Error} binds Result<T, Error>;";
-    pass "type ExitCode binds std::process::ExitCode;";
+    pass "type Result{T, Error} = BindsGeneric{'Result', T, Error};";
+    pass "type ExitCode = Binds{'std::process::ExitCode'};";
     pass "type{Windows} Path = driveLetter: string, pathsegments: Array{string};";
 );
 named_and!(ctypes: CTypes =>

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -495,7 +495,7 @@ impl CType {
             CType::Int(_) | CType::Float(_) => format!("_{}", self.to_functional_string()),
             CType::Type(n, t) => match **t {
                 CType::Int(_) | CType::Float(_) => format!("_{}", self.to_functional_string()),
-                CType::Binds(_) => format!("{}", n),
+                CType::Binds(_) => n.clone(),
                 _ => self.to_functional_string(),
             },
             _ => self.to_functional_string(),
@@ -625,7 +625,7 @@ impl CType {
                         .into());
                     }
                     (Some(CType::Binds(n1)), Some(CType::Binds(n2))) => {
-                        if !(n1 == n2) {
+                        if n1 != n2 {
                             return Err(format!(
                                 "Mismatched bound types {} and {} during inference",
                                 n1, n2
@@ -2164,6 +2164,7 @@ impl CType {
         let base_type = args[0].clone();
         if let CType::TString(base) = base_type {
             let mut out_vec = Vec::new();
+            #[allow(clippy::needless_range_loop)] // It's not needless
             for i in 1..args.len() {
                 out_vec.push(args[i].clone());
             }

--- a/src/program/function.rs
+++ b/src/program/function.rs
@@ -307,11 +307,11 @@ impl Function {
                                         opttypegenerics: None,
                                     },
                                     c: "".to_string(),
-                                    typedef: parse::TypeDef::TypeCreate(parse::TypeCreate {
+                                    typedef: parse::TypeDef {
                                         a: "=".to_string(),
                                         b: "".to_string(),
                                         typeassignables: returntypeassignables,
-                                    }),
+                                    },
                                     optsemicolon: ";".to_string(),
                                 };
                                 CType::from_ast(scope, &parse_type, false)?;

--- a/src/program/microstatement.rs
+++ b/src/program/microstatement.rs
@@ -290,13 +290,19 @@ pub fn baseassignablelist_to_microstatements(
                 match c {
                     parse::Constants::Bool(b) => {
                         prior_value = Some(Microstatement::Value {
-                            typen: CType::Bound("bool".to_string(), "bool".to_string()),
+                            typen: CType::Type(
+                                "bool".to_string(),
+                                Box::new(CType::Binds("bool".to_string())),
+                            ),
                             representation: b.clone(),
                         });
                     }
                     parse::Constants::Strn(s) => {
                         prior_value = Some(Microstatement::Value {
-                            typen: CType::Bound("string".to_string(), "String".to_string()),
+                            typen: CType::Type(
+                                "string".to_string(),
+                                Box::new(CType::Binds("String".to_string())),
+                            ),
                             representation: if s.starts_with('"') {
                                 s.clone()
                             } else {
@@ -313,7 +319,10 @@ pub fn baseassignablelist_to_microstatements(
                             prior_value = Some(Microstatement::Value {
                                 // TODO: Replace this with the `CType::Float` and have built-ins
                                 // that accept them
-                                typen: CType::Bound("f64".to_string(), "f64".to_string()),
+                                typen: CType::Type(
+                                    "f64".to_string(),
+                                    Box::new(CType::Binds("f64".to_string())),
+                                ),
                                 representation: r.clone(),
                             });
                         }
@@ -321,7 +330,10 @@ pub fn baseassignablelist_to_microstatements(
                             prior_value = Some(Microstatement::Value {
                                 // TODO: Replace this with `CType::Int` and have built-ins that
                                 // accept them
-                                typen: CType::Bound("i64".to_string(), "i64".to_string()),
+                                typen: CType::Type(
+                                    "i64".to_string(),
+                                    Box::new(CType::Binds("i64".to_string())),
+                                ),
                                 representation: i.clone(),
                             });
                         }
@@ -559,13 +571,11 @@ pub fn baseassignablelist_to_microstatements(
                                                 opttypegenerics: None,
                                             },
                                             c: "".to_string(),
-                                            typedef: parse::TypeDef::TypeCreate(
-                                                parse::TypeCreate {
-                                                    a: "=".to_string(),
-                                                    b: "".to_string(),
-                                                    typeassignables: returntypeassignables,
-                                                },
-                                            ),
+                                            typedef: parse::TypeDef {
+                                                a: "=".to_string(),
+                                                b: "".to_string(),
+                                                typeassignables: returntypeassignables,
+                                            },
                                             optsemicolon: ";".to_string(),
                                         };
                                         CType::from_ast(&mut inner_scope, &parse_type, false)?;
@@ -761,11 +771,11 @@ pub fn baseassignablelist_to_microstatements(
                         opttypegenerics: None,
                     },
                     c: "".to_string(),
-                    typedef: parse::TypeDef::TypeCreate(parse::TypeCreate {
+                    typedef: parse::TypeDef {
                         a: "=".to_string(),
                         b: "".to_string(),
                         typeassignables: g.typecalllist.clone(),
-                    }),
+                    },
                     optsemicolon: ";".to_string(),
                 };
                 CType::from_ast(scope, &parse_type, false)?;
@@ -1049,7 +1059,7 @@ pub fn baseassignablelist_to_microstatements(
                                 opttypegenerics: None,
                             },
                             c: "".to_string(),
-                            typedef: parse::TypeDef::TypeCreate(parse::TypeCreate {
+                            typedef: parse::TypeDef {
                                 a: "=".to_string(),
                                 b: "".to_string(),
                                 typeassignables: vec![parse::WithTypeOperators::TypeBaseList(
@@ -1058,7 +1068,7 @@ pub fn baseassignablelist_to_microstatements(
                                         parse::TypeBase::GnCall(g.clone()),
                                     ],
                                 )],
-                            }),
+                            },
                             optsemicolon: ";".to_string(),
                         };
                         let t = CType::from_ast(&mut temp_scope, &parse_type, false)?;
@@ -1466,7 +1476,6 @@ pub fn statement_to_microstatements(
             microstatements,
         )?),
         parse::Statement::ArrayAssignment(arrayassignment) => {
-            println!("Hi!");
             let mut args = Vec::new();
             let mut ms = baseassignablelist_to_microstatements(
                 &[arrayassignment.name.clone()],

--- a/src/program/scope.rs
+++ b/src/program/scope.rs
@@ -90,14 +90,14 @@ impl<'a> Scope<'a> {
                             // (from the root scope) and can't be hidden, as all code will need these
                             // to construct their own types.
                             match c.name.as_str() {
-                                "Type" | "Generic" | "Bound" | "BoundGeneric" | "Int" | "Float"
-                                | "Bool" | "String" => { /* Do nothing for the 'structural' types */ }
-                                g @ ("Group" | "Array" | "Fail" | "Neg" | "Len" | "Size" | "FileStr"
+                                "Type" | "Generic" | "Int" | "Float" | "Bool" | "String" => { /* Do nothing for the 'structural' types */ }
+                                g @ ("Binds" | "Group" | "Array" | "Fail" | "Neg" | "Len" | "Size" | "FileStr"
                                 | "Env" | "EnvExists" | "Not") => CType::from_generic(&mut s, g, 1),
-                                g @ ("Function" | "Tuple" | "Field" | "Either" | "AnyOf" | "Buffer" | "Add"
+                                g @ ("Function" | "Field" | "Buffer" | "Add"
                                 | "Sub" | "Mul" | "Div" | "Mod" | "Pow" | "Min" | "Max" | "If" | "And" | "Or"
                                 | "Xor" | "Nand" | "Nor" | "Xnor" | "Eq" | "Neq" | "Lt" | "Lte"
                                 | "Gt" | "Gte") => CType::from_generic(&mut s, g, 2),
+                                g @ ("BindsGeneric" | "Tuple" | "Either" | "AnyOf") => CType::from_generic(&mut s, g, 0), // Not kosher in Rust land, but 0 means "as many as we want"
                                 // TODO: Also add support for three arg `If` and `Env` with a
                                 // default property via overloading types
                                 unknown => {

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -8,8 +8,8 @@
 // Declaration of the types the compiler-time type system is built on
 export ctype Type; // Any kind of concrete type
 export ctype Generic; // Any type that is a generic type (not yet realized into a concrete type)
-export ctype Bound; // A direct reference into the platform language's type system equivalent to a concrete type
-export ctype BoundGeneric; // A direct reference into the platform language's generic type system
+export ctype Binds{T}; // A direct reference into the platform language's type system equivalen to a concrete type
+export ctype BindsGeneric{T, N}; // A direct reference into the platform language's generic type system
 export ctype Int; // An integer used *to define a type*, like the length of a fixed array
 export ctype Float; // A float used to define a type. I have no idea why you'd want this, yet
 export ctype Bool; // A bool used to define a type. Heavily used for conditional compilation
@@ -58,7 +58,7 @@ export ctype Gte{A, B}; // Returns true if A is greater than or equal to B
 
 // Defining derived types
 export type void = ();
-export type Error binds AlanError;
+export type Error = Binds{"AlanError"};
 export type Fallible{T} = Either{T, Error};
 export type Maybe{T} = Either{T, ()};
 export type Test = Eq{Env{"ALAN_TARGET"}, "test"};
@@ -98,38 +98,38 @@ export type infix Gt as > precedence 1;
 export type infix Gte as >= precedence 1;
 
 // Binding the integer types
-export type i8 binds i8;
-export type i16 binds i16;
-export type i32 binds i32;
-export type i64 binds i64;
-export type u8 binds u8;
-export type u16 binds u16;
-export type u32 binds u32;
-export type u64 binds u64;
+export type i8 = Binds{"i8"};
+export type i16 = Binds{"i16"};
+export type i32 = Binds{"i32"};
+export type i64 = Binds{"i64"};
+export type u8 = Binds{"u8"};
+export type u16 = Binds{"u16"};
+export type u32 = Binds{"u32"};
+export type u64 = Binds{"u64"};
 
 // Binding the float types
-export type f32 binds f32;
-export type f64 binds f64;
+export type f32 = Binds{"f32"};
+export type f64 = Binds{"f64"};
 
 // Binding the string types
-export type string binds String;
+export type string = Binds{"String"};
 
 // Binding the boolean types
-export type bool binds bool;
+export type bool = Binds{"bool"};
 
 // Binding the exit code type
-export type ExitCode binds std::process::ExitCode;
+export type ExitCode = Binds{"std::process::ExitCode"};
 
 // Binding the time types
-export type Instant binds std::time::Instant;
-export type Duration binds std::time::Duration;
+export type Instant = Binds{"std::time::Instant"};
+export type Duration = Binds{"std::time::Duration"};
 
 // Binding the uuid type
-export type uuid binds uuid::Uuid;
+export type uuid = Binds{"uuid::Uuid"};
 
 // Binding the Dict and Set types
-export type Dict{K, V} binds OrderedHashMap<K, V>;
-export type Set{V} binds std::collections::HashSet<V>;
+export type Dict{K, V} = BindsGeneric{"OrderedHashMap", K, V};
+export type Set{V} = BindsGeneric{"std::collections::HashSet", V};
 
 /// Functions for (potentially) every type
 export fn clone{T}(v: T) -> T binds clone;
@@ -722,9 +722,9 @@ export fn string(uuid) -> string binds uuidstring;
 
 // The base bindings to create buffers of memory on the GPU, construct a plan for a compute shader,
 // execute it, and read the buffer back to the CPU
-export type BufferUsages binds wgpu::BufferUsages;
-export type GBuffer binds GBuffer;
-export type GPGPU binds GPGPU;
+export type BufferUsages = Binds{"wgpu::BufferUsages"};
+export type GBuffer = Binds{"GBuffer"};
+export type GPGPU = Binds{"GPGPU"};
 export fn mapReadBuffer() -> BufferUsages binds map_read_buffer_type;
 export fn storageBuffer() -> BufferUsages binds storage_buffer_type;
 export fn GBuffer(usage: BufferUsages, vals: Array{i32}) -> GBuffer binds create_buffer_init;


### PR DESCRIPTION
This actually *simplifies* a lot of code by working this way. There will be a follow-up PR for function binding, hopefully tomorrow.
