### PR TITLE
Refactor all mutations of a Scope to be done with full ownership rather than mutable references

### DIFF
--- a/src/program/import.rs
+++ b/src/program/import.rs
@@ -18,12 +18,12 @@ pub struct Import {
 }
 
 impl Import {
-    pub fn from_ast(
+    pub fn from_ast<'a>(
         program: &mut Program,
         path: String,
-        scope: &mut Scope,
+        mut scope: Scope<'a>,
         import_ast: &parse::ImportStatement,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<Scope<'a>, Box<dyn std::error::Error>> {
         match &import_ast {
             parse::ImportStatement::Standard(s) => {
                 // First, get the path for the code
@@ -43,7 +43,7 @@ impl Import {
                     import_type: ImportType::Standard(ln_file.clone(), import_name),
                 };
                 scope.imports.insert(ln_file, i);
-                Ok(())
+                Ok(scope)
             }
             parse::ImportStatement::From(f) => {
                 let ln_file = f.dependency.resolve(path)?;
@@ -68,7 +68,7 @@ impl Import {
                     import_type: ImportType::Fields(field_vec),
                 };
                 scope.imports.insert(ln_file, i);
-                Ok(())
+                Ok(scope)
             }
         }
     }

--- a/src/program/operatormapping.rs
+++ b/src/program/operatormapping.rs
@@ -23,11 +23,11 @@ pub enum OperatorMapping {
 }
 
 impl OperatorMapping {
-    pub fn from_ast(
-        scope: &mut Scope,
+    pub fn from_ast<'a>(
+        mut scope: Scope<'a>,
         operatormapping_ast: &parse::OperatorMapping,
         is_export: bool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<Scope<'a>, Box<dyn std::error::Error>> {
         let opmap = match operatormapping_ast.fix {
             parse::Fix::Prefix(_) => OperatorMapping::Prefix {
                 level: operatormapping_ast
@@ -68,15 +68,15 @@ impl OperatorMapping {
             // to the scope to cause compilation to crash *if* something tries to use this, and if
             // we don't get a boolean at all or we get multiple inner values in the generic call,
             // we bail out immediately because of a syntax error.
-            let generic_call = withtypeoperatorslist_to_ctype(&generics.typecalllist, scope)?;
+            let generic_call = withtypeoperatorslist_to_ctype(&generics.typecalllist, &scope)?;
             match generic_call {
                 CType::Bool(b) => match b {
-                    false => return Ok(()),
+                    false => return Ok(scope),
                     true => { /* Do nothing */ }
                 },
                 CType::Type(_, c) => match *c {
                     CType::Bool(b) => match b {
-                        false => return Ok(()),
+                        false => return Ok(scope),
                         true => { /* Do nothing */ }
                     },
                     _ => {
@@ -116,6 +116,6 @@ impl OperatorMapping {
             },
             opmap,
         );
-        Ok(())
+        Ok(scope)
     }
 }

--- a/src/program/scope.rs
+++ b/src/program/scope.rs
@@ -530,10 +530,8 @@ impl<'a> Scope<'a> {
         // otherwise
         let is_normal = self.resolve_normal_function(function, args).is_some();
         if is_normal {
-            match self.resolve_normal_function(function, args) {
-                None => None,
-                Some(f) => Some((self, f)),
-            }
+            self.resolve_normal_function(function, args)
+                .map(|f| (self, f))
         } else {
             match self.resolve_function_generic_args(function, args) {
                 Some(gs) => self.resolve_generic_function(function, &gs, args),

--- a/src/program/typeoperatormapping.rs
+++ b/src/program/typeoperatormapping.rs
@@ -23,11 +23,11 @@ pub enum TypeOperatorMapping {
 }
 
 impl TypeOperatorMapping {
-    pub fn from_ast(
-        scope: &mut Scope,
+    pub fn from_ast<'a>(
+        mut scope: Scope<'a>,
         typeoperatormapping_ast: &parse::TypeOperatorMapping,
         is_export: bool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<Scope<'a>, Box<dyn std::error::Error>> {
         let opmap = match typeoperatormapping_ast.fix {
             parse::Fix::Prefix(_) => TypeOperatorMapping::Prefix {
                 level: typeoperatormapping_ast
@@ -68,15 +68,15 @@ impl TypeOperatorMapping {
             // to the scope to cause compilation to crash *if* something tries to use this, and if
             // we don't get a boolean at all or we get multiple inner values in the generic call,
             // we bail out immediately because of a syntax error.
-            let generic_call = withtypeoperatorslist_to_ctype(&generics.typecalllist, scope)?;
+            let generic_call = withtypeoperatorslist_to_ctype(&generics.typecalllist, &scope)?;
             match generic_call {
                 CType::Bool(b) => match b {
-                    false => return Ok(()),
+                    false => return Ok(scope),
                     true => { /* Do nothing */ }
                 },
                 CType::Type(_, c) => match *c {
                     CType::Bool(b) => match b {
-                        false => return Ok(()),
+                        false => return Ok(scope),
                         true => { /* Do nothing */ }
                     },
                     _ => {
@@ -102,6 +102,6 @@ impl TypeOperatorMapping {
             scope.exports.insert(name.clone(), Export::TypeOpMap);
         }
         scope.typeoperatormappings.insert(name, opmap);
-        Ok(())
+        Ok(scope)
     }
 }


### PR DESCRIPTION
This PR doesn't change any of the logic in the microstatements to fix known bugs with it, but simply refactors things to use full ownership. A lot of weird contortion in there will be reduced to this simpler kind of contortion in a follow-up PR.

This is to deal with an issue with the borrow checker being unable to recognize that a mutable reference has "died" at the end of a function call because it's single-threaded code that can't have given that reference to another thread to then mutate whatever it feels like. It feels like it'd be really nice to be able to say that the mutable reference doesn't live past the function call in question, but I can't figure out how to do that, so instead I'm passing ownership of the `Scope` to the function that mutates it, and then it passes back both the desired value and the `Scope` back so I can continue mutating it. Inelegant, but it works.
