### PR TITLE
Add the Prop{T, P} type function and use it for some GPGPU functions

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -911,7 +911,6 @@ named_or!(typebase: TypeBase =>
     GnCall: GnCall as gncall,
     TypeGroup: TypeGroup as typegroup,
     Constants: Constants as constants,
-    MethodSep: String as and!(optwhitespace, dot, optwhitespace),
     Variable: String as variable,
 );
 impl TypeBase {
@@ -929,7 +928,6 @@ impl TypeBase {
             )
             .to_string(),
             TypeBase::Variable(v) => v.clone(),
-            TypeBase::MethodSep(_) => ".".to_string(),
             TypeBase::Constants(c) => c.to_string(),
         }
     }

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -2289,19 +2289,16 @@ impl CType {
             CType::Tuple(ts) | CType::Either(ts) => match p {
                 CType::TString(s) => {
                     for inner in ts {
-                        match inner {
-                            CType::Field(n, f) => {
-                                if n == s {
-                                    return *f.clone();
-                                }
+                        if let CType::Field(n, f) = inner {
+                            if n == s {
+                                return *f.clone();
                             }
-                            _ => {}
                         }
                     }
                     CType::fail(&format!("Property {} not found on type {:?}", s, t))
                 }
                 CType::Int(i) => {
-                    if (i as usize) < ts.len() && i >= 0 {
+                    if (0..ts.len()).contains(&(i as usize)) {
                         ts[i as usize].clone()
                     } else {
                         CType::fail(&format!("{} is out of bounds for type {:?}", i, t))
@@ -2332,7 +2329,7 @@ impl CType {
                         }
                     }
                     CType::Int(i) => {
-                        if i >= 0 && i < 2 {
+                        if (0..2).contains(&i) {
                             tf[i as usize].clone()
                         } else {
                             CType::fail("Only true or false (or 1 or 0) are valid for accessing the types from an If{C, A, B} type")

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -26,6 +26,7 @@ pub enum CType {
     Tuple(Vec<CType>),
     Field(String, Box<CType>),
     Either(Vec<CType>),
+    Prop(Box<CType>, Box<CType>),
     AnyOf(Vec<CType>),
     Buffer(Box<CType>, Box<CType>),
     Array(Box<CType>),
@@ -121,6 +122,11 @@ impl CType {
                 .map(|t| t.to_strict_string(strict))
                 .collect::<Vec<String>>()
                 .join(" | "),
+            CType::Prop(t, p) => format!(
+                "{}.{}",
+                t.to_strict_string(strict),
+                p.to_strict_string(strict)
+            ),
             CType::AnyOf(ts) => ts
                 .iter()
                 .map(|t| t.to_strict_string(strict))
@@ -311,6 +317,11 @@ impl CType {
                     .map(|t| t.to_functional_string())
                     .collect::<Vec<String>>()
                     .join(", ")
+            ),
+            CType::Prop(t, p) => format!(
+                "Prop{{{}, {}}}",
+                t.to_functional_string(),
+                p.to_functional_string()
             ),
             CType::AnyOf(ts) => format!(
                 "AnyOf{{{}}}",
@@ -536,6 +547,7 @@ impl CType {
             CType::Either(ts) => {
                 CType::Either(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>())
             }
+            CType::Prop(t, p) => CType::Prop(Box::new(t.degroup()), Box::new(p.degroup())),
             CType::AnyOf(ts) => {
                 CType::AnyOf(ts.iter().map(|t| t.degroup()).collect::<Vec<CType>>())
             }
@@ -1789,6 +1801,37 @@ impl CType {
                     kind: FnKind::Normal,
                 });
             }
+            CType::Bool(b) => {
+                fs.push(Function {
+                    name: constructor_fn_name.clone(),
+                    args: Vec::new(),
+                    rettype: CType::Binds("bool".to_string()),
+                    microstatements: vec![Microstatement::Return {
+                        value: Some(Box::new(Microstatement::Value {
+                            typen: CType::Binds("bool".to_string()),
+                            representation: match b {
+                                true => "true".to_string(),
+                                false => "false".to_string(),
+                            },
+                        })),
+                    }],
+                    kind: FnKind::Normal,
+                });
+            }
+            CType::TString(s) => {
+                fs.push(Function {
+                    name: constructor_fn_name.clone(),
+                    args: Vec::new(),
+                    rettype: CType::Binds("String".to_string()),
+                    microstatements: vec![Microstatement::Return {
+                        value: Some(Box::new(Microstatement::Value {
+                            typen: CType::Binds("String".to_string()),
+                            representation: format!("\"{}\"", s.replace("\"", "\\\"")),
+                        })),
+                    }],
+                    kind: FnKind::Normal,
+                });
+            }
             _ => {} // Don't do anything for other types
         }
         (t, fs)
@@ -2003,6 +2046,10 @@ impl CType {
                     .map(|t| t.swap_subtype(old_type, new_type))
                     .collect::<Vec<CType>>(),
             ),
+            CType::Prop(t, p) => CType::Prop(
+                Box::new(t.swap_subtype(old_type, new_type)),
+                Box::new(p.swap_subtype(old_type, new_type)),
+            ),
             CType::AnyOf(ts) => CType::AnyOf(
                 ts.iter()
                     .map(|t| t.swap_subtype(old_type, new_type))
@@ -2204,6 +2251,93 @@ impl CType {
         }
         CType::Either(out_vec)
     }
+    pub fn prop(t: CType, p: CType) -> CType {
+        // Checking the p property type first if it's to be inferred because short-circuiting on
+        // that will simplify follow-up logic
+        if let CType::Infer(..) = &p {
+            return CType::Prop(Box::new(t), Box::new(p));
+        }
+        match t.clone() {
+            CType::Infer(..) => CType::Prop(Box::new(t), Box::new(p)),
+            CType::Type(_, t) => CType::prop(*t, p),
+            CType::Group(t) => CType::prop(*t, p),
+            CType::Field(n, f) => match p {
+                CType::TString(s) => {
+                    if n == s {
+                        *f.clone()
+                    } else {
+                        CType::fail(&format!("Property {} not found on type {:?}", s, &t))
+                    }
+                }
+                otherwise => CType::fail(&format!(
+                    "The property must be a name when directly applied to a field, not {:?}",
+                    otherwise,
+                )),
+            },
+            CType::Tuple(ts) | CType::Either(ts) => match p {
+                CType::TString(s) => {
+                    for inner in ts {
+                        match inner {
+                            CType::Field(n, f) => {
+                                if n == s {
+                                    return *f.clone();
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    CType::fail(&format!("Property {} not found on type {:?}", s, t))
+                }
+                CType::Int(i) => {
+                    if (i as usize) < ts.len() && i >= 0 {
+                        ts[i as usize].clone()
+                    } else {
+                        CType::fail(&format!("{} is out of bounds for type {:?}", i, t))
+                    }
+                }
+                otherwise => CType::fail(&format!(
+                    "Properties must be a name or integer location, not {:?}",
+                    otherwise,
+                )),
+            },
+            CType::TIf(_, tf) => {
+                match p {
+                    CType::TString(s) => {
+                        // TODO: Is this path reachable?
+                        if s == "true" {
+                            tf[0].clone()
+                        } else if s == "false" {
+                            tf[1].clone()
+                        } else {
+                            CType::fail("Only true or false (or 1 or 0) are valid for accessing the types from an If{C, A, B} type")
+                        }
+                    }
+                    CType::Bool(b) => {
+                        if b {
+                            tf[0].clone()
+                        } else {
+                            tf[1].clone()
+                        }
+                    }
+                    CType::Int(i) => {
+                        if i >= 0 && i < 2 {
+                            tf[i as usize].clone()
+                        } else {
+                            CType::fail("Only true or false (or 1 or 0) are valid for accessing the types from an If{C, A, B} type")
+                        }
+                    }
+                    otherwise => CType::fail(&format!(
+                        "Properties must be a name or integer location, not {:?}",
+                        otherwise,
+                    )),
+                }
+            }
+            otherwise => CType::fail(&format!(
+                "Properties cannot be accessed from type {:?}",
+                otherwise
+            )),
+        }
+    }
     pub fn anyof(args: Vec<CType>) -> CType {
         let mut out_vec = Vec::new();
         for arg in args {
@@ -2218,8 +2352,6 @@ impl CType {
         }
         CType::Either(out_vec)
     }
-    // Special implementation for the field type, too. Right now for easier parsing the key needs
-    // to be quoted. TODO: remove this restriction
     pub fn field(mut args: Vec<CType>) -> CType {
         if args.len() != 2 {
             CType::fail("Field{K, V} only accepts two sub-types")
@@ -2914,70 +3046,6 @@ pub fn typebaselist_to_ctype(
         let typebase = &typebaselist[i];
         let nexttypebase = typebaselist.get(i + 1);
         match typebase {
-            parse::TypeBase::MethodSep(_) => {
-                // The `MethodSep` symbol doesn't do anything on its own, it only validates that
-                // the syntax before and after it is sane
-                if prior_value.is_none() {
-                    return Err(format!(
-                        "Cannot start a statement with a property access: {}",
-                        typebaselist
-                            .iter()
-                            .map(|tb| tb.to_string())
-                            .collect::<Vec<String>>()
-                            .join("")
-                    )
-                    .into());
-                }
-                match nexttypebase {
-                    None => {
-                        return Err(format!(
-                            "Cannot end a statement with a property access: {}",
-                            typebaselist
-                                .iter()
-                                .map(|tb| tb.to_string())
-                                .collect::<Vec<String>>()
-                                .join("")
-                        )
-                        .into());
-                    }
-                    Some(next) => match next {
-                        parse::TypeBase::GnCall(_) => {
-                            return Err(format!(
-                                "A generic function call is not a property: {}",
-                                typebaselist
-                                    .iter()
-                                    .map(|tb| tb.to_string())
-                                    .collect::<Vec<String>>()
-                                    .join("")
-                            )
-                            .into());
-                        }
-                        parse::TypeBase::TypeGroup(_) => {
-                            return Err(format!(
-                                "A parenthetical grouping is not a property: {}",
-                                typebaselist
-                                    .iter()
-                                    .map(|tb| tb.to_string())
-                                    .collect::<Vec<String>>()
-                                    .join("")
-                            )
-                            .into());
-                        }
-                        parse::TypeBase::MethodSep(_) => {
-                            return Err(format!(
-                                "Too many `.` symbols for the method access: {}",
-                                typebaselist
-                                    .iter()
-                                    .map(|tb| tb.to_string())
-                                    .collect::<Vec<String>>()
-                                    .join("")
-                            )
-                            .into());
-                        }
-                        _ => {}
-                    },
-                }
-            }
             parse::TypeBase::Constants(c) => {
                 // With constants, there are a few situations where they are allowed:
                 // 1) When they're used within a `GnCall` as the sole value passed in
@@ -2990,10 +3058,6 @@ pub fn typebaselist_to_ctype(
                 // function type, it returns the input or output type (function types could
                 // internally have been a struct-like type with two fields, but they're special for
                 // now)
-                // Similarly, the only thing that can follow a constant value is a `MethodSep` to
-                // be used for a method-syntax function call and all others are errors. The
-                // "default" path is for a typebaselist with a length of one containing only the
-                // constant.
                 if let Some(next) = nexttypebase {
                     match next {
                         parse::TypeBase::Variable(_) => {
@@ -3008,7 +3072,6 @@ pub fn typebaselist_to_ctype(
                         parse::TypeBase::Constants(_) => {
                             return Err(format!("A constant cannot be directly before another constant without an operator between them: {}", typebaselist.iter().map(|tb| tb.to_string()).collect::<Vec<String>>().join("")).into());
                         }
-                        parse::TypeBase::MethodSep(_) => {} // The only allowed follow-up
                     }
                 }
                 if prior_value.is_none() {
@@ -3131,6 +3194,34 @@ pub fn typebaselist_to_ctype(
                         // to `Field` as a `Label` and turn this logic into something regularized
                         // For now, we're just special-casing the `Field` built-in generic type.
                         match &t {
+                            CType::IntrinsicGeneric(p, 2) if p == "Prop" => {
+                                match nexttypebase {
+                                    None => {},
+                                    Some(next) => match next {
+                                        parse::TypeBase::GnCall(g) => {
+                                            // There should be only two args, the first arg is
+                                            // coerced from a variable to a string, the second arg
+                                            // is treated like normal
+                                            if g.typecalllist.len() != 3 {
+                                                CType::fail("The Field generic type accepts only two parameters");
+                                            }
+                                            args.push(withtypeoperatorslist_to_ctype(&vec![g.typecalllist[0].clone()], scope)?);
+                                            match g.typecalllist[0].to_string().parse::<i128>() {
+                                                Ok(i) => args.push(CType::Int(i)),
+                                                Err(_) => {
+                                                    let argstr = g.typecalllist[2].to_string();
+                                                    match argstr.as_str() {
+                                                        "true" => args.push(CType::Bool(true)),
+                                                        "false" => args.push(CType::Bool(false)),
+                                                        _ => args.push(CType::TString(argstr))
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        _ => CType::fail("Cannot follow method style syntax without an operator in between"),
+                                    }
+                                }
+                            }
                             CType::IntrinsicGeneric(f, 2) if f == "Field" => {
                                 match nexttypebase {
                                     None => {},
@@ -3145,7 +3236,6 @@ pub fn typebaselist_to_ctype(
                                             args.push(CType::TString(g.typecalllist[0].to_string()));
                                             args.push(withtypeoperatorslist_to_ctype(&vec![g.typecalllist[2].clone()], scope)?);
                                         }
-                                        parse::TypeBase::MethodSep(_) => {},
                                         _ => CType::fail("Cannot follow method style syntax without an operator in between"),
                                     }
                                 }
@@ -3179,7 +3269,6 @@ pub fn typebaselist_to_ctype(
                                                 args.push(withtypeoperatorslist_to_ctype(&arg_block, scope)?);
                                             }
                                         }
-                                        parse::TypeBase::MethodSep(_) => {},
                                         _ => CType::fail("Cannot follow method style syntax without an operator in between"),
                                     }
                                 }
@@ -3232,10 +3321,9 @@ pub fn typebaselist_to_ctype(
                                             Box::new(args[1].clone()),
                                         ),
                                         "Tuple" => CType::tuple(args.clone()),
-                                        // TODO: Field should ideally not require string
-                                        // quoting
                                         "Field" => CType::field(args.clone()),
                                         "Either" => CType::either(args.clone()),
+                                        "Prop" => CType::prop(args[0].clone(), args[1].clone()),
                                         "AnyOf" => CType::anyof(args.clone()),
                                         "Buffer" => CType::buffer(args.clone()),
                                         "Array" => CType::Array(Box::new(args[0].clone())),
@@ -3275,16 +3363,6 @@ pub fn typebaselist_to_ctype(
                                     }
                                 }
                             }
-                            /*CType::BoundGeneric(name, argstrs, binding) => {
-                                // We turn this into a `ResolvedBoundGeneric` for the lower layer
-                                // of the compiler to make sense of
-                                CType::ResolvedBoundGeneric(
-                                    name.clone(),
-                                    argstrs.clone(),
-                                    args,
-                                    binding.clone(),
-                                )
-                            }*/
                             others => {
                                 // If we hit this branch, then the `args` vector needs to have a
                                 // length of zero, and then we just bubble up the type as-is

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -1972,6 +1972,18 @@ impl CType {
         if !fs.is_empty() {
             let mut name_fn_pairs = HashMap::new();
             for f in fs {
+                // We need to similarly load all of the return types from the functions created by
+                // this from_ctype call if they don't already exist
+                let mut contains_rettype = false;
+                for t in scope.types.values() {
+                    if f.rettype.to_callable_string() == t.to_callable_string() {
+                        contains_rettype = true;
+                    }
+                }
+                if !contains_rettype {
+                    scope =
+                        CType::from_ctype(scope, f.rettype.to_callable_string(), f.rettype.clone());
+                }
                 if name_fn_pairs.contains_key(&f.name) {
                     let v: &mut Vec<Function> = name_fn_pairs.get_mut(&f.name).unwrap();
                     v.push(f.clone());

--- a/src/program/function.rs
+++ b/src/program/function.rs
@@ -425,6 +425,10 @@ impl Function {
                         })
                     })
                     .collect::<Vec<(String, CType)>>();
+                // Make sure all argument types exist within the generic function call scope
+                for (_, arg) in &args {
+                    scope = CType::from_ctype(scope, arg.to_callable_string(), arg.clone());
+                }
                 let rettype = {
                     let mut a = generic_function.rettype.clone();
                     for ((_, o), n) in gen_args.iter().zip(generic_types.iter()) {
@@ -486,6 +490,10 @@ impl Function {
                         })
                     })
                     .collect::<Vec<(String, CType)>>();
+                // Make sure all argument types exist within the generic function call scope
+                for (_, arg) in &args {
+                    scope = CType::from_ctype(scope, arg.to_callable_string(), arg.clone());
+                }
                 let rettype = {
                     let mut a = generic_function.rettype.clone();
                     for ((_, o), n) in gen_args.iter().zip(generic_types.iter()) {

--- a/src/program/scope.rs
+++ b/src/program/scope.rs
@@ -416,7 +416,7 @@ impl<'a> Scope<'a> {
     }
 
     pub fn resolve_generic_function(
-        mut self,
+        self,
         function: &String,
         generic_types: &[CType],
         args: &[CType],
@@ -528,8 +528,7 @@ impl<'a> Scope<'a> {
             let temp_scope = self.child();
             match Function::from_generic_function(temp_scope, generic_f, generic_types.to_vec()) {
                 Err(_) => return None, // TODO: Should this be a panic?
-                Ok((temp_scope, realized_f)) => {
-                    merge!(self, temp_scope);
+                Ok((_, realized_f)) => {
                     return Some((self, realized_f));
                 }
             }

--- a/src/program/scope.rs
+++ b/src/program/scope.rs
@@ -95,7 +95,7 @@ impl<'a> Scope<'a> {
                                 "Type" | "Generic" | "Int" | "Float" | "Bool" | "String" => { /* Do nothing for the 'structural' types */ }
                                 g @ ("Binds" | "Group" | "Array" | "Fail" | "Neg" | "Len" | "Size" | "FileStr"
                                 | "Env" | "EnvExists" | "Not") => s = CType::from_generic(s, g, 1),
-                                g @ ("Function" | "Field" | "Buffer" | "Add"
+                                g @ ("Function" | "Field" | "Prop" | "Buffer" | "Add"
                                 | "Sub" | "Mul" | "Div" | "Mod" | "Pow" | "Min" | "Max" | "If" | "And" | "Or"
                                 | "Xor" | "Nand" | "Nor" | "Xnor" | "Eq" | "Neq" | "Lt" | "Lte"
                                 | "Gt" | "Gte") => s = CType::from_generic(s, g, 2),

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -19,6 +19,7 @@ export ctype Function{I, O}; // A function type, indicating the input and output
 export ctype Tuple{A, B}; // A tuple of two (or more) types in a single compound type
 export ctype Field{L, V}; // Labeling a type with a property name. Useful to turn tuples into structs
 export ctype Either{A, B}; // An either type, allowing the value to be from *one* of the specified types, kinda like Rust enums
+export ctype Prop{T, P}; // Extracts the inner type from the outer type by the property name or number
 export ctype AnyOf{A, B}; // The AnyOf type is kinda like a Tuple, in that all sub-types are present, but it only *resolves* into one of these types above it. Useful for choosing the "best" integer, or a particular function by name.
 export ctype Buffer{T, S}; // A buffer type, a pre-allocated, fixed-length array of the specified type the specified amount
 export ctype Array{T}; // An array type, a variable-length array of the specified type the specified amount. This would usually be an stdlib type built in the language itself, but we're just going to re-use the one in the platform language
@@ -70,6 +71,7 @@ export type infix Function as -> precedence 3; // I -> O, where I is the input a
 export type infix Tuple as , precedence 0; // A, B, C, ... The tuple type combines with other tuple types to become a larger tuple type. To have a tuple of tuples, you need to `Group` the inner tuple, eg `(a, b), c`
 export type infix Field as : precedence 1; // Foo: Bar, let's you specify a property access label for the type, useful for syntactic sugar on a tuple type and the Either type (eventually).
 export type infix Either as | precedence 0; // A | B, the type has a singular value from only one of the types at once. `Result` is just `Either{T, Error}` and `Option` is just `Either{T, ()}` (or `Either{T, void}`, however we want to represent it, also might go with `Fallible` and `Maybe` instead of `Result` and `Option` as those feel more descriptive of what they are.
+export type infix Prop as . precedence 5; // A.B, returns the sub-type within A referenced by property B. Allows an inverse of a Tuple or Either type, accessed by either the Field name or an integer index
 export type infix AnyOf as & precedence 0; // A & B, which can be passed to a function that takes A or B as necessary.
 export type infix Buffer as [ precedence 1; // Technically allows `Foo[3` by itself to be valid syntax, but...
 export type postfix Group as ] precedence 1; // Technically not necessary, but allows for `Foo[3]` to do the "right thing" and become a buffer of size 3, with a singular useless Group being wrapped around it (and then unwrapped on type generation). The only "bad" thing here is `Group` gets special behavior, matching the `(...)` syntax, so there's two ways to invoke a Group via symbols.
@@ -901,7 +903,8 @@ export fn build{N}(ret: N) -> GPGPU {
   return GPGPU(wgsl, buffers, maxGlobalId);
 }
 
-fn gPrimitiveConvert{I, O}(i: I, typename: string) -> O { // TODO: Get the typename from {O}
+fn gPrimitiveConvert{I, O}(i: I) -> O {
+  let typename = {O.typeName}();
   let varName = typename.concat('_').concat(uuid().string.replace('-', '_'));
   let statement = "var "
     .concat(varName)
@@ -915,27 +918,27 @@ fn gPrimitiveConvert{I, O}(i: I, typename: string) -> O { // TODO: Get the typen
   return {O}(varName, statements, buffers);
 }
 export fn gu32(u: u32) -> gu32 = gu32(u.string, Dict{string, string}(), Set{GBuffer}());
-export fn gu32(gi: gi32) -> gu32 = gPrimitiveConvert{gi32, gu32}(gi, "u32");
-export fn gu32(gf: gf32) -> gu32 = gPrimitiveConvert{gf32, gu32}(gf, "u32");
-export fn gu32(gb: gbool) -> gu32 = gPrimitiveConvert{gbool, gu32}(gb, "u32");
+export fn gu32(gi: gi32) -> gu32 = gPrimitiveConvert{gi32, gu32}(gi);
+export fn gu32(gf: gf32) -> gu32 = gPrimitiveConvert{gf32, gu32}(gf);
+export fn gu32(gb: gbool) -> gu32 = gPrimitiveConvert{gbool, gu32}(gb);
 export fn gu32{T}(u: T) -> gu32 = gu32(u.u32);
 
 export fn gi32(i: i32) -> gi32 = gi32(i.string, Dict{string, string}(), Set{GBuffer}());
-export fn gi32(gu: gu32) -> gi32 = gPrimitiveConvert{gu32, gi32}(gu, "i32");
-export fn gi32(gf: gf32) -> gi32 = gPrimitiveConvert{gf32, gi32}(gf, "i32");
-export fn gi32(gb: gbool) -> gi32 = gPrimitiveConvert{gbool, gi32}(gb, "i32");
+export fn gi32(gu: gu32) -> gi32 = gPrimitiveConvert{gu32, gi32}(gu);
+export fn gi32(gf: gf32) -> gi32 = gPrimitiveConvert{gf32, gi32}(gf);
+export fn gi32(gb: gbool) -> gi32 = gPrimitiveConvert{gbool, gi32}(gb);
 export fn gi32{T}(i: T) -> gi32 = gi32(i.i32);
 
 export fn gf32(f: f32) -> gf32 = gf32(f.string, Dict{string, string}(), Set{GBuffer}());
-export fn gf32(gu: gu32) -> gf32 = gPrimitiveConvert{gu32, gf32}(gu, "f32");
-export fn gf32(gi: gi32) -> gf32 = gPrimitiveConvert{gi32, gf32}(gi, "f32");
-export fn gf32(gb: gbool) -> gf32 = gPrimitiveConvert{gbool, gf32}(gb, "f32");
+export fn gf32(gu: gu32) -> gf32 = gPrimitiveConvert{gu32, gf32}(gu);
+export fn gf32(gi: gi32) -> gf32 = gPrimitiveConvert{gi32, gf32}(gi);
+export fn gf32(gb: gbool) -> gf32 = gPrimitiveConvert{gbool, gf32}(gb);
 export fn gf32{T}(f: T) -> gf32 = gf32(f.f32);
 
 export fn gbool(b: bool) -> gbool = gbool(b.string, Dict{string, string}(), Set{GBuffer}());
-export fn gbool(gu: gu32) -> gbool = gPrimitiveConvert{gu32, gbool}(gu, "bool");
-export fn gbool(gi: gi32) -> gbool = gPrimitiveConvert{gi32, gbool}(gi, "bool");
-export fn gbool(gf: gf32) -> gbool = gPrimitiveConvert{gf32, gbool}(gf, "bool");
+export fn gbool(gu: gu32) -> gbool = gPrimitiveConvert{gu32, gbool}(gu);
+export fn gbool(gi: gi32) -> gbool = gPrimitiveConvert{gi32, gbool}(gi);
+export fn gbool(gf: gf32) -> gbool = gPrimitiveConvert{gf32, gbool}(gf);
 export fn gbool{T}(b: T) -> gbool = gbool(b.bool);
 
 // Vector types and constructors
@@ -952,7 +955,8 @@ export type gvec4i = WgpuType{"vec4i"};
 export type gvec4f = WgpuType{"vec4f"};
 export type gvec4b = WgpuType{"vec4<bool>"};
 
-fn gvec2Primitive{I, O}(a: I, b: I, typename: string) -> O { // TODO: Get the typename from {O}
+fn gvec2Primitive{I, O}(a: I, b: I) -> O {
+  let typename = {O.typeName}();
   let statement = typename
     .concat('(')
     .concat(a.varName)
@@ -965,22 +969,23 @@ fn gvec2Primitive{I, O}(a: I, b: I, typename: string) -> O { // TODO: Get the ty
 }
 
 export fn gvec2u() -> gvec2u = gvec2u("vec2u()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec2u(a: gu32, b: gu32) -> gvec2u = gvec2Primitive{gu32, gvec2u}(a, b, "vec2u");
+export fn gvec2u(a: gu32, b: gu32) -> gvec2u = gvec2Primitive{gu32, gvec2u}(a, b);
 export fn gvec2u{T}(a: T, b: T) -> gvec2u = gvec2u(a.gu32, b.gu32);
 
 export fn gvec2i() -> gvec2i = gvec2i("vec2i()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec2i(a: gi32, b: gi32) -> gvec2i = gvec2Primitive{gi32, gvec2i}(a, b, "vec2i");
+export fn gvec2i(a: gi32, b: gi32) -> gvec2i = gvec2Primitive{gi32, gvec2i}(a, b);
 export fn gvec2i{T}(a: T, b: T) -> gvec2i = gvec2i(a.gi32, b.gi32);
 
 export fn gvec2f() -> gvec2f = gvec2f("vec2f()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec2f(a: gf32, b: gf32) -> gvec2f = gvec2Primitive{gf32, gvec2f}(a, b, "vec2f");
+export fn gvec2f(a: gf32, b: gf32) -> gvec2f = gvec2Primitive{gf32, gvec2f}(a, b);
 export fn gvec2f{T}(a: T, b: T) -> gvec2f = gvec2f(a.gf32, b.gf32);
 
 export fn gvec2b() -> gvec2b = gvec2b("vec2<bool>()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec2b(a: gbool, b: gbool) -> gvec2b = gvec2Primitive{gbool, gvec2b}(a, b, "vec2<bool>");
+export fn gvec2b(a: gbool, b: gbool) -> gvec2b = gvec2Primitive{gbool, gvec2b}(a, b);
 export fn gvec2b{T}(a: T, b: T) -> gvec2b = gvec2b(a.gbool, b.gbool);
 
-fn gvec3Primitive{I, O}(a: I, b: I, c: I, typename: string) -> O { // TODO: Get typename from {O}
+fn gvec3Primitive{I, O}(a: I, b: I, c: I) -> O {
+  let typename = {O.typeName}();
   let statement = typename
     .concat('(')
     .concat(a.varName)
@@ -995,22 +1000,23 @@ fn gvec3Primitive{I, O}(a: I, b: I, c: I, typename: string) -> O { // TODO: Get 
 }
 
 export fn gvec3u() -> gvec3u = gvec3u("vec3u()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec3u(a: gu32, b: gu32, c: gu32) -> gvec3u = gvec3Primitive{gu32, gvec3u}(a, b, c, "vec3u");
+export fn gvec3u(a: gu32, b: gu32, c: gu32) -> gvec3u = gvec3Primitive{gu32, gvec3u}(a, b, c);
 export fn gvec3u{T}(a: T, b: T, c: T) -> gvec3u = gvec3u(a.gu32, b.gu32, c.gu32);
 
 export fn gvec3i() -> gvec3i = gvec3i("vec3i()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec3i(a: gi32, b: gi32, c: gi32) -> gvec3i = gvec3Primitive{gi32, gvec3i}(a, b, c, "vec3i");
+export fn gvec3i(a: gi32, b: gi32, c: gi32) -> gvec3i = gvec3Primitive{gi32, gvec3i}(a, b, c);
 export fn gvec3i{T}(a: T, b: T, c: T) -> gvec3i = gvec3i(a.gi32, b.gi32, c.gi32);
 
 export fn gvec3f() -> gvec3f = gvec3f("vec3f()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec3f(a: gf32, b: gf32, c: gf32) -> gvec3f = gvec3Primitive{gf32, gvec3f}(a, b, c, "vec3f");
+export fn gvec3f(a: gf32, b: gf32, c: gf32) -> gvec3f = gvec3Primitive{gf32, gvec3f}(a, b, c);
 export fn gvec3f{T}(a: T, b: T, c: T) -> gvec3f = gvec3f(a.gf32, b.gf32, c.gf32);
 
 export fn gvec3b() -> gvec3b = gvec3b("vec3<bool>()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec3b(a: gbool, b: gbool, c: gbool) -> gvec3b = gvec3Primitive{gbool, gvec3b}(a, b, c, "vec3<bool>");
+export fn gvec3b(a: gbool, b: gbool, c: gbool) -> gvec3b = gvec3Primitive{gbool, gvec3b}(a, b, c);
 export fn gvec3b{T}(a: T, b: T, c: T) -> gvec3b = gvec3b(a.gbool, b.gbool, c.gbool);
 
-fn gvec4Primitive{I, O}(a: I, b: I, c: I, d: I, typename: string) -> O { // TODO: typename from {O}
+fn gvec4Primitive{I, O}(a: I, b: I, c: I, d: I) -> O {
+  let typename = {O.typeName}();
   let statement = typename
     .concat('(')
     .concat(a.varName)
@@ -1028,25 +1034,25 @@ fn gvec4Primitive{I, O}(a: I, b: I, c: I, d: I, typename: string) -> O { // TODO
 
 export fn gvec4u() -> gvec4u = gvec4u("vec4u()", Dict{string, string}(), Set{GBuffer}());
 export fn gvec4u(a: gu32, b: gu32, c: gu32, d: gu32) -> gvec4u = gvec4Primitive{gu32, gvec4u}(
-  a, b, c, d, "vec4u"
+  a, b, c, d
 );
 export fn gvec4u{T}(a: T, b: T, c: T, d: T) -> gvec4u = gvec4u(a.gu32, b.gu32, c.gu32, d.gu32);
 
 export fn gvec4i() -> gvec4i = gvec4i("vec4i()", Dict{string, string}(), Set{GBuffer}());
 export fn gvec4i(a: gi32, b: gi32, c: gi32, d: gi32) -> gvec4i = gvec4Primitive{gi32, gvec4i}(
-  a, b, c, d, "vec4i"
+  a, b, c, d
 );
 export fn gvec4i{T}(a: T, b: T, c: T, d: T) -> gvec4i = gvec4i(a.gi32, b.gi32, c.gi32, d.gi32);
 
 export fn gvec4f() -> gvec4f = gvec4f("vec4f()", Dict{string, string}(), Set{GBuffer}());
 export fn gvec4f(a: gf32, b: gf32, c: gf32, d: gf32) -> gvec4f = gvec4Primitive{gf32, gvec4f}(
-  a, b, c, d, "vec4f"
+  a, b, c, d
 );
 export fn gvec4f{T}(a: T, b: T, c: T, d: T) -> gvec4f = gvec4f(a.gf32, b.gf32, c.gf32, d.gf32);
 
 export fn gvec4b() -> gvec4b = gvec4b("vec4<bool>()", Dict{string, string}(), Set{GBuffer}());
 export fn gvec4b(a: gbool, b: gbool, c: gbool, d: gbool) -> gvec4b = gvec4Primitive{gbool, gvec4b}(
-  a, b, c, d, "vec4<bool>"
+  a, b, c, d
 );
 export fn gvec4b{T}(a: T, b: T, c: T, d: T) -> gvec4b = gvec4b(a.gbool, b.gbool, c.gbool, d.gbool);
 
@@ -4734,47 +4740,47 @@ export fn shr(a: gvec4i, b: gvec4i) -> gvec4i = gshr(a, b);
 
 // Bitcasting methods (TODO: Is there a better naming scheme possible?)
 
-fn gbitcast{I, O}(v: I, typename: string) -> O {
-  let varName = 'bitcast<'.concat(typename).concat('>(').concat(v.varName).concat(')');
+fn gbitcast{I, O}(v: I) -> O {
+  let varName = 'bitcast<'.concat({O.typeName}()).concat('>(').concat(v.varName).concat(')');
   let statements = v.statements.clone;
   let buffers = v.buffers.clone;
   return {O}(varName, statements, buffers);
 }
 export fn asU32(v: gu32) -> gu32 = v;
-export fn asU32(v: gi32) -> gu32 = gbitcast{gi32, gu32}(v, "u32");
-export fn asU32(v: gf32) -> gu32 = gbitcast{gf32, gu32}(v, "u32");
-export fn asI32(v: gu32) -> gi32 = gbitcast{gu32, gi32}(v, "i32");
+export fn asU32(v: gi32) -> gu32 = gbitcast{gi32, gu32}(v);
+export fn asU32(v: gf32) -> gu32 = gbitcast{gf32, gu32}(v);
+export fn asI32(v: gu32) -> gi32 = gbitcast{gu32, gi32}(v);
 export fn asI32(v: gi32) -> gi32 = v;
-export fn asI32(v: gf32) -> gi32 = gbitcast{gf32, gi32}(v, "i32");
-export fn asF32(v: gu32) -> gf32 = gbitcast{gu32, gf32}(v, "f32");
-export fn asF32(v: gi32) -> gi32 = gbitcast{gi32, gf32}(v, "f32");
+export fn asI32(v: gf32) -> gi32 = gbitcast{gf32, gi32}(v);
+export fn asF32(v: gu32) -> gf32 = gbitcast{gu32, gf32}(v);
+export fn asF32(v: gi32) -> gi32 = gbitcast{gi32, gf32}(v);
 export fn asF32(v: gf32) -> gf32 = v;
 export fn asVec2u(v: gvec2u) -> gvec2u = v;
-export fn asVec2u(v: gvec2i) -> gvec2u = gbitcast{gvec2i, gvec2u}(v, "vec2u");
-export fn asVec2u(v: gvec2f) -> gvec2u = gbitcast{gvec2f, gvec2u}(v, "vec2u");
-export fn asVec2i(v: gvec2u) -> gvec2i = gbitcast{gvec2u, gvec2i}(v, "vec2i");
+export fn asVec2u(v: gvec2i) -> gvec2u = gbitcast{gvec2i, gvec2u}(v);
+export fn asVec2u(v: gvec2f) -> gvec2u = gbitcast{gvec2f, gvec2u}(v);
+export fn asVec2i(v: gvec2u) -> gvec2i = gbitcast{gvec2u, gvec2i}(v);
 export fn asVec2i(v: gvec2i) -> gvec2i = v;
-export fn asVec2i(v: gvec2f) -> gvec2i = gbitcast{gvec2f, gvec2i}(v, "vec2i");
-export fn asVec2f(v: gvec2u) -> gvec2f = gbitcast{gvec2u, gvec2f}(v, "vec2f");
-export fn asVec2f(v: gvec2i) -> gvec2f = gbitcast{gvec2i, gvec2f}(v, "vec2f");
+export fn asVec2i(v: gvec2f) -> gvec2i = gbitcast{gvec2f, gvec2i}(v);
+export fn asVec2f(v: gvec2u) -> gvec2f = gbitcast{gvec2u, gvec2f}(v);
+export fn asVec2f(v: gvec2i) -> gvec2f = gbitcast{gvec2i, gvec2f}(v);
 export fn asVec2f(v: gvec2f) -> gvec2f = v;
 export fn asVec3u(v: gvec3u) -> gvec3u = v;
-export fn asVec3u(v: gvec3i) -> gvec3u = gbitcast{gvec3i, gvec3u}(v, "vec3u");
-export fn asVec3u(v: gvec3f) -> gvec3u = gbitcast{gvec3f, gvec3u}(v, "vec3u");
-export fn asVec3i(v: gvec3u) -> gvec3i = gbitcast{gvec3u, gvec3i}(v, "vec3i");
+export fn asVec3u(v: gvec3i) -> gvec3u = gbitcast{gvec3i, gvec3u}(v);
+export fn asVec3u(v: gvec3f) -> gvec3u = gbitcast{gvec3f, gvec3u}(v);
+export fn asVec3i(v: gvec3u) -> gvec3i = gbitcast{gvec3u, gvec3i}(v);
 export fn asVec3i(v: gvec3i) -> gvec3i = v;
-export fn asVec3i(v: gvec3f) -> gvec3i = gbitcast{gvec3f, gvec3i}(v, "vec3i");
-export fn asVec3f(v: gvec3u) -> gvec3f = gbitcast{gvec3u, gvec3f}(v, "vec3f");
-export fn asVec3f(v: gvec3i) -> gvec3f = gbitcast{gvec3i, gvec3f}(v, "vec3f");
+export fn asVec3i(v: gvec3f) -> gvec3i = gbitcast{gvec3f, gvec3i}(v);
+export fn asVec3f(v: gvec3u) -> gvec3f = gbitcast{gvec3u, gvec3f}(v);
+export fn asVec3f(v: gvec3i) -> gvec3f = gbitcast{gvec3i, gvec3f}(v);
 export fn asVec3f(v: gvec3f) -> gvec3f = v;
 export fn asVec4u(v: gvec4u) -> gvec4u = v;
-export fn asVec4u(v: gvec4i) -> gvec4u = gbitcast{gvec4i, gvec4u}(v, "vec4u");
-export fn asVec4u(v: gvec4f) -> gvec4u = gbitcast{gvec4f, gvec4u}(v, "vec4u");
-export fn asVec4i(v: gvec4u) -> gvec4i = gbitcast{gvec4u, gvec4i}(v, "vec4i");
+export fn asVec4u(v: gvec4i) -> gvec4u = gbitcast{gvec4i, gvec4u}(v);
+export fn asVec4u(v: gvec4f) -> gvec4u = gbitcast{gvec4f, gvec4u}(v);
+export fn asVec4i(v: gvec4u) -> gvec4i = gbitcast{gvec4u, gvec4i}(v);
 export fn asVec4i(v: gvec4i) -> gvec4i = v;
-export fn asVec4i(v: gvec4f) -> gvec4i = gbitcast{gvec4f, gvec4i}(v, "vec4i");
-export fn asVec4f(v: gvec4u) -> gvec4f = gbitcast{gvec4u, gvec4f}(v, "vec4f");
-export fn asVec4f(v: gvec4i) -> gvec4f = gbitcast{gvec4i, gvec4f}(v, "vec4f");
+export fn asVec4i(v: gvec4f) -> gvec4i = gbitcast{gvec4f, gvec4i}(v);
+export fn asVec4f(v: gvec4u) -> gvec4f = gbitcast{gvec4u, gvec4f}(v);
+export fn asVec4f(v: gvec4i) -> gvec4f = gbitcast{gvec4i, gvec4f}(v);
 export fn asVec4f(v: gvec4f) -> gvec4f = v;
 
 // GPU Vector functions

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -4634,7 +4634,7 @@ fn gor{I}(a: I, b: I) -> I {
   let varName = '('.concat(a.varName).concat(' | ').concat(b.varName).concat(')');
   let statements = a.statements.concat(b.statements);
   let buffers = a.buffers.union(b.buffers);
-  return {O}(varName, statements, buffers);
+  return {I}(varName, statements, buffers);
 }
 export fn or(a: gu32, b: gu32) -> gu32 = gor(a, b);
 export fn or{T}(a: gu32, b: T) -> gu32 = gor(a, b.gu32);
@@ -4659,7 +4659,7 @@ fn gand{I}(a: I, b: I) -> I {
   let varName = '('.concat(a.varName).concat(' & ').concat(b.varName).concat(')');
   let statements = a.statements.concat(b.statements);
   let buffers = a.buffers.union(b.buffers);
-  return {O}(varName, statements, buffers);
+  return {I}(varName, statements, buffers);
 }
 export fn and(a: gu32, b: gu32) -> gu32 = gand(a, b);
 export fn and{T}(a: gu32, b: T) -> gu32 = gand(a, b.gu32);
@@ -4685,7 +4685,7 @@ fn gxor{I}(a: I, b: I) -> I {
   let varName = '('.concat(a.varName).concat(' ^ ').concat(b.varName).concat(')');
   let statements = a.statements.concat(b.statements);
   let buffers = a.buffers.union(b.buffers);
-  return {O}(varName, statements, buffers);
+  return {I}(varName, statements, buffers);
 }
 export fn and(a: gu32, b: gu32) -> gu32 = gand(a, b);
 export fn and{T}(a: gu32, b: T) -> gu32 = gand(a, b.gu32);
@@ -4704,7 +4704,7 @@ fn gshl{I}(a: I, b: I) -> I {
   let varName = '('.concat(a.varName).concat(' << ').concat(b.varName).concat(')');
   let statements = a.statements.concat(b.statements);
   let buffers = a.buffers.union(b.buffers);
-  return {O}(varName, statements, buffers);
+  return {I}(varName, statements, buffers);
 }
 export fn shl(a: gu32, b: gu32) -> gu32 = gshl(a, b);
 export fn shl{T}(a: gu32, b: T) -> gu32 = gshl(a, b.gu32);
@@ -4723,7 +4723,7 @@ fn gshr{I}(a: I, b: I) -> I {
   let varName = '('.concat(a.varName).concat(' >> ').concat(b.varName).concat(')');
   let statements = a.statements.concat(b.statements);
   let buffers = a.buffers.union(b.buffers);
-  return {O}(varName, statements, buffers);
+  return {I}(varName, statements, buffers);
 }
 export fn shr(a: gu32, b: gu32) -> gu32 = gshr(a, b);
 export fn shr{T}(a: gu32, b: T) -> gu32 = gshr(a, b.gu32);


### PR DESCRIPTION
This gets the `.` working correctly for the type system. There's no method syntax for types like I was originally thinking of adding support for, but there is a way to access "properties" of types to get at subtype definitions. Eg, a field name for a tuple to get the sub-type, or a number to get the Nth tuple or either sub-type.

This is used in some of the generic functions for the GPU types to get at the `typeName` tag to then use it within the function itself, reducing redundancy and potential sources of error.

This also allows a kind of compile-time type introspection system to probe the structure of the type that was given to you in a generic function, which could be useful without needing to worry about runtime exploits injecting into a "live" reflection system.
