### PR TITLE
Allow numeric access to field types

### DIFF
--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -2281,8 +2281,15 @@ impl CType {
                         CType::fail(&format!("Property {} not found on type {:?}", s, &t))
                     }
                 }
+                CType::Int(i) => match i {
+                    0 => CType::TString(n.to_string()),
+                    1 => *f.clone(),
+                    _ => CType::fail(
+                        &"Only 0 or 1 are valid integer accesses on a field".to_string(),
+                    ),
+                },
                 otherwise => CType::fail(&format!(
-                    "The property must be a name when directly applied to a field, not {:?}",
+                    "Properties must be a name or integer location, not {:?}",
                     otherwise,
                 )),
             },

--- a/src/program/ctype.rs
+++ b/src/program/ctype.rs
@@ -2284,9 +2284,7 @@ impl CType {
                 CType::Int(i) => match i {
                     0 => CType::TString(n.to_string()),
                     1 => *f.clone(),
-                    _ => CType::fail(
-                        &"Only 0 or 1 are valid integer accesses on a field".to_string(),
-                    ),
+                    _ => CType::fail("Only 0 or 1 are valid integer accesses on a field"),
                 },
                 otherwise => CType::fail(&format!(
                     "Properties must be a name or integer location, not {:?}",


### PR DESCRIPTION
I changed my mind on this. It can be useful to be able to automatically "take apart" a field by numeric index, especially if you don't know what the field name is where you need the underlying type to the field.
