### PR TITLE
Consolidate the Binds{T} and BindsGeneric{T, ...} into one ctype

### DIFF
--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -75,7 +75,7 @@ pub fn from_microstatement(
             CType::Type(n, _) if n == "string" => {
                 Ok((format!("{}.to_string()", representation).to_string(), out))
             }
-            CType::Binds(a) if a == "String" => {
+            CType::Binds(a, _) if a == "String" => {
                 Ok((format!("{}.to_string()", representation).to_string(), out))
             }
             CType::Function(..) => {
@@ -216,7 +216,7 @@ pub fn from_microstatement(
                             CType::Type(n, _) if n == "string" => {
                                 Ok((format!("{}.to_string()", representation).to_string(), out))
                             }
-                            CType::Binds(a) if a == "String" => {
+                            CType::Binds(a, _) if a == "String" => {
                                 Ok((format!("{}.to_string()", representation).to_string(), out))
                             }
                             _ => Ok((representation.clone(), out)),
@@ -850,81 +850,7 @@ pub fn from_microstatement(
                                                 out,
                                             ));
                                         }
-                                        CType::Binds(n) if *n == enum_name => {
-                                            // Special-casing for Option and Result mapping. TODO:
-                                            // Make this more centralized
-                                            if ts.len() == 2 {
-                                                if let CType::Void = &ts[1] {
-                                                    if let CType::Void = t {
-                                                        return Ok(("None".to_string(), out));
-                                                    } else {
-                                                        return Ok((
-                                                            format!(
-                                                                "Some({})",
-                                                                match argstrs[0]
-                                                                    .strip_prefix("&mut ")
-                                                                {
-                                                                    Some(s) => s,
-                                                                    None => &argstrs[0],
-                                                                }
-                                                            ),
-                                                            out,
-                                                        ));
-                                                    }
-                                                } else if let CType::Type(name, _) = &ts[1] {
-                                                    if name == "Error" {
-                                                        let okrustname =
-                                                            typen::ctype_to_rtype(&ts[0], true)?;
-                                                        let errrustname =
-                                                            typen::ctype_to_rtype(&ts[1], true)?;
-                                                        if let CType::Binds(..) = t {
-                                                            return Ok((
-                                                                format!(
-                                                                    "Err::<{}, {}>({})",
-                                                                    okrustname,
-                                                                    errrustname,
-                                                                    match argstrs[0]
-                                                                        .strip_prefix("&mut ")
-                                                                    {
-                                                                        Some(s) => s,
-                                                                        None => &argstrs[0],
-                                                                    }
-                                                                ),
-                                                                out,
-                                                            ));
-                                                        } else {
-                                                            return Ok((
-                                                                format!(
-                                                                    "Ok::<{}, {}>({})",
-                                                                    okrustname,
-                                                                    errrustname,
-                                                                    match argstrs[0]
-                                                                        .strip_prefix("&mut ")
-                                                                    {
-                                                                        Some(s) => s,
-                                                                        None => &argstrs[0],
-                                                                    }
-                                                                ),
-                                                                out,
-                                                            ));
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            return Ok((
-                                                format!(
-                                                    "{}::{}({})",
-                                                    function.name,
-                                                    enum_name,
-                                                    match argstrs[0].strip_prefix("&mut ") {
-                                                        Some(s) => s,
-                                                        None => &argstrs[0],
-                                                    },
-                                                ),
-                                                out,
-                                            ));
-                                        }
-                                        CType::BindsGeneric(n, ..) if *n == enum_name => {
+                                        CType::Binds(n, ..) if *n == enum_name => {
                                             // Special-casing for Option and Result mapping. TODO:
                                             // Make this more centralized
                                             if ts.len() == 2 {
@@ -1075,7 +1001,7 @@ pub fn from_microstatement(
                                     out,
                                 ));
                             }
-                            CType::Binds(_) => {
+                            CType::Binds(..) => {
                                 return Ok((argstrs.join(", "), out));
                             }
                             otherwise => {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -965,7 +965,7 @@ named_and!(types: Types =>
 test!(types =>
     pass "type Foo = bar: string;";
     pass "type Foo = Bar";
-    pass "type Result{T, Error} = BindsGeneric{'Result', T, Error};";
+    pass "type Result{T, Error} = Binds{'Result', T, Error};";
     pass "type ExitCode = Binds{'std::process::ExitCode'};";
     pass "type{Windows} Path = driveLetter: string, pathsegments: Array{string};";
 );

--- a/src/program/microstatement.rs
+++ b/src/program/microstatement.rs
@@ -291,7 +291,7 @@ pub fn baseassignablelist_to_microstatements<'a>(
                         prior_value = Some(Microstatement::Value {
                             typen: CType::Type(
                                 "bool".to_string(),
-                                Box::new(CType::Binds("bool".to_string())),
+                                Box::new(CType::Binds("bool".to_string(), Vec::new())),
                             ),
                             representation: b.clone(),
                         });
@@ -300,7 +300,7 @@ pub fn baseassignablelist_to_microstatements<'a>(
                         prior_value = Some(Microstatement::Value {
                             typen: CType::Type(
                                 "string".to_string(),
-                                Box::new(CType::Binds("String".to_string())),
+                                Box::new(CType::Binds("String".to_string(), Vec::new())),
                             ),
                             representation: if s.starts_with('"') {
                                 s.clone()
@@ -320,7 +320,7 @@ pub fn baseassignablelist_to_microstatements<'a>(
                                 // that accept them
                                 typen: CType::Type(
                                     "f64".to_string(),
-                                    Box::new(CType::Binds("f64".to_string())),
+                                    Box::new(CType::Binds("f64".to_string(), Vec::new())),
                                 ),
                                 representation: r.clone(),
                             });
@@ -331,7 +331,7 @@ pub fn baseassignablelist_to_microstatements<'a>(
                                 // accept them
                                 typen: CType::Type(
                                     "i64".to_string(),
-                                    Box::new(CType::Binds("i64".to_string())),
+                                    Box::new(CType::Binds("i64".to_string(), Vec::new())),
                                 ),
                                 representation: i.clone(),
                             });

--- a/src/program/scope.rs
+++ b/src/program/scope.rs
@@ -93,13 +93,13 @@ impl<'a> Scope<'a> {
                             // to construct their own types.
                             match c.name.as_str() {
                                 "Type" | "Generic" | "Int" | "Float" | "Bool" | "String" => { /* Do nothing for the 'structural' types */ }
-                                g @ ("Binds" | "Group" | "Array" | "Fail" | "Neg" | "Len" | "Size" | "FileStr"
+                                g @ ("Group" | "Array" | "Fail" | "Neg" | "Len" | "Size" | "FileStr"
                                 | "Env" | "EnvExists" | "Not") => s = CType::from_generic(s, g, 1),
                                 g @ ("Function" | "Call" | "Field" | "Prop" | "Buffer" | "Add"
                                 | "Sub" | "Mul" | "Div" | "Mod" | "Pow" | "Min" | "Max" | "If" | "And" | "Or"
                                 | "Xor" | "Nand" | "Nor" | "Xnor" | "Eq" | "Neq" | "Lt" | "Lte"
                                 | "Gt" | "Gte") => s = CType::from_generic(s, g, 2),
-                                g @ ("BindsGeneric" | "Tuple" | "Either" | "AnyOf") => s = CType::from_generic(s, g, 0), // Not kosher in Rust land, but 0 means "as many as we want"
+                                g @ ("Binds" | "Tuple" | "Either" | "AnyOf") => s = CType::from_generic(s, g, 0), // Not kosher in Rust land, but 0 means "as many as we want"
                                 // TODO: Also add support for three arg `If` and `Env` with a
                                 // default property via overloading types
                                 unknown => {

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -8,8 +8,7 @@
 // Declaration of the types the compiler-time type system is built on
 export ctype Type; // Any kind of concrete type
 export ctype Generic; // Any type that is a generic type (not yet realized into a concrete type)
-export ctype Binds{T}; // A direct reference into the platform language's type system equivalen to a concrete type
-export ctype BindsGeneric{T, N}; // A direct reference into the platform language's generic type system
+export ctype Binds{T}; // A direct reference into the platform language's type system
 export ctype Int; // An integer used *to define a type*, like the length of a fixed array
 export ctype Float; // A float used to define a type. I have no idea why you'd want this, yet
 export ctype Bool; // A bool used to define a type. Heavily used for conditional compilation
@@ -132,8 +131,8 @@ export type Duration = Binds{"std::time::Duration"};
 export type uuid = Binds{"uuid::Uuid"};
 
 // Binding the Dict and Set types
-export type Dict{K, V} = BindsGeneric{"OrderedHashMap", K, V};
-export type Set{V} = BindsGeneric{"std::collections::HashSet", V};
+export type Dict{K, V} = Binds{"OrderedHashMap", K, V};
+export type Set{V} = Binds{"std::collections::HashSet", V};
 
 /// Functions for (potentially) every type
 export fn clone{T} "clone" :: T -> T;


### PR DESCRIPTION
I realized that I could just represent the "bare type" binding with an array of zero elements, so this reduces the number of type functions to learn.
