### PR TITLE
Remove no longer used piece of the parser

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -373,7 +373,6 @@ build!(closearr, token!("]"));
 build!(comma, token!(","));
 build!(semicolon, token!(";"));
 build!(optsemicolon, zero_or_one!(semicolon));
-build!(notsemicolon, one_or_more!(not!(";")));
 build!(at, token!("@"));
 build!(slash, token!("/"));
 // Validating charset


### PR DESCRIPTION
I somehow missed this in the function binding PR
