### PR TITLE
Add mutable references to the language

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -1582,6 +1582,22 @@ to barto bar3
 "#;
 );
 
+test!(mutable_functions => r#"
+    fn addeq (a: Mut{i64}, b: i64) {
+        a = a.clone() + b;
+    }
+
+    infix addeq as += precedence 0;
+
+    export fn main {
+        let five = 3;
+        five.print;
+        five += 2;
+        five.print;
+    }"#;
+    stdout "3\n5\n";
+);
+
 // Conditionals
 
 test!(if_fn => r#"

--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -3,24 +3,34 @@
 use ordered_hash_map::OrderedHashMap;
 
 use crate::lntors::typen;
-use crate::program::{CType, FnKind, Function, Microstatement, Scope};
+use crate::program::{ArgKind, CType, FnKind, Function, Microstatement, Scope};
 
 pub fn from_microstatement(
     microstatement: &Microstatement,
+    parent_fn: &Function,
     scope: &Scope,
     mut out: OrderedHashMap<String, String>,
 ) -> Result<(String, OrderedHashMap<String, String>), Box<dyn std::error::Error>> {
     match microstatement {
-        Microstatement::Arg { name, typen } => {
+        Microstatement::Arg { name, kind, typen } => {
             // TODO: Update the serialization logic to understand values vs references so we can
             // eliminate this useless (and harmful for mutable references) clone
             if let CType::Function { .. } = typen {
                 Ok(("".to_string(), out))
             } else {
-                Ok((
-                    format!("let mut {} = {}.clone()", name, name), // TODO: not always mutable
-                    out,
-                ))
+                match &kind {
+                    ArgKind::Mut => Ok(("".to_string(), out)), // We actively want to mutate the argument, don't
+                    // alias it
+                    ArgKind::Own => Ok(("".to_string(), out)), // We already own the value
+                    ArgKind::Ref => Ok((
+                        format!("let mut {} = {}.clone()", name, name), // TODO: not always mutable
+                        out,
+                    )), // TODO: Should these two be distinguished?
+                    ArgKind::Deref => Ok((
+                        format!("let mut {} = *{}", name, name), // TODO: not always mutable
+                        out,
+                    )),
+                }
             }
         }
         Microstatement::Assignment {
@@ -28,7 +38,7 @@ pub fn from_microstatement(
             value,
             mutable: _,
         } => {
-            let (val, o) = from_microstatement(value, scope, out)?;
+            let (val, o) = from_microstatement(value, parent_fn, scope, out)?;
             // I wish I didn't have to write the following line because you can't re-assign a
             // variable in a let destructuring, afaict
             out = o;
@@ -51,11 +61,11 @@ pub fn from_microstatement(
             let arg_names = function
                 .args
                 .iter()
-                .map(|(n, _)| n.clone())
+                .map(|(n, _, _)| n.clone())
                 .collect::<Vec<String>>();
             let mut inner_statements = Vec::new();
             for ms in &function.microstatements {
-                let (val, o) = from_microstatement(ms, scope, out)?;
+                let (val, o) = from_microstatement(ms, parent_fn, scope, out)?;
                 out = o;
                 inner_statements.push(val);
             }
@@ -96,7 +106,7 @@ pub fn from_microstatement(
                             | FnKind::Static => {
                                 let mut arg_strs = Vec::new();
                                 for arg in &fun.args {
-                                    arg_strs.push(arg.1.to_callable_string());
+                                    arg_strs.push(arg.2.to_callable_string());
                                 }
                                 // Come up with a function name that is unique so Rust doesn't choke on
                                 // duplicate function names that are allowed in Alan
@@ -118,7 +128,7 @@ pub fn from_microstatement(
         Microstatement::Array { vals, .. } => {
             let mut val_representations = Vec::new();
             for val in vals {
-                let (rep, o) = from_microstatement(val, scope, out)?;
+                let (rep, o) = from_microstatement(val, parent_fn, scope, out)?;
                 val_representations.push(rep);
                 out = o;
             }
@@ -152,7 +162,7 @@ pub fn from_microstatement(
                     out = o;
                     let mut arg_strs = Vec::new();
                     for arg in &function.args {
-                        arg_strs.push(arg.1.to_callable_string());
+                        arg_strs.push(arg.2.to_callable_string());
                     }
                     // Come up with a function name that is unique so Rust doesn't choke on
                     // duplicate function names that are allowed in Alan
@@ -161,8 +171,8 @@ pub fn from_microstatement(
                     out = generate(rustname.clone(), function, scope, out)?;
                     // Now call this function
                     let mut argstrs = Vec::new();
-                    for arg in args {
-                        let (a, o) = from_microstatement(arg, scope, out)?;
+                    for (i, arg) in args.iter().enumerate() {
+                        let (a, o) = from_microstatement(arg, parent_fn, scope, out)?;
                         out = o;
                         // If the argument is itself a function, this is the only place in Rust
                         // where you can't pass by reference, so we check the type and change
@@ -170,11 +180,24 @@ pub fn from_microstatement(
                         let arg_type = arg.get_type();
                         match arg_type {
                             CType::Function(..) => argstrs.push(a.to_string()),
-                            _ => argstrs.push(if a.starts_with("&mut ") {
-                                a
-                            } else {
-                                format!("&mut {}", a)
-                            }),
+                            _ => match function.args[i].1 {
+                                ArgKind::Mut => {
+                                    let mut prefix = "&mut ";
+                                    for (name, kind, _) in &parent_fn.args {
+                                        if name == &a {
+                                            match kind {
+                                                ArgKind::Mut => prefix = "",
+                                                _ => {}
+                                            }
+                                        }
+                                    }
+                                    argstrs.push(format!("{}{}", prefix, a));
+                                }
+                                // Because we create clones for these two right now, we always need
+                                // this
+                                ArgKind::Ref | ArgKind::Deref => argstrs.push(format!("&{}", a)),
+                                ArgKind::Own => argstrs.push(a.clone()),
+                            },
                         }
                     }
                     Ok((
@@ -184,8 +207,8 @@ pub fn from_microstatement(
                 }
                 FnKind::Bind(rustname) => {
                     let mut argstrs = Vec::new();
-                    for arg in args {
-                        let (a, o) = from_microstatement(arg, scope, out)?;
+                    for (i, arg) in args.iter().enumerate() {
+                        let (a, o) = from_microstatement(arg, parent_fn, scope, out)?;
                         out = o;
                         // If the argument is itself a function, this is the only place in Rust
                         // where you can't pass by reference, so we check the type and change
@@ -193,11 +216,24 @@ pub fn from_microstatement(
                         let arg_type = arg.get_type();
                         match arg_type {
                             CType::Function(..) => argstrs.push(a.to_string()),
-                            _ => argstrs.push(if a.starts_with("&mut ") {
-                                a
-                            } else {
-                                format!("&mut {}", a)
-                            }),
+                            _ => match function.args[i].1 {
+                                ArgKind::Mut => {
+                                    let mut prefix = "&mut ";
+                                    for (name, kind, _) in &parent_fn.args {
+                                        if name == &a {
+                                            match kind {
+                                                ArgKind::Mut => prefix = "",
+                                                _ => {}
+                                            }
+                                        }
+                                    }
+                                    argstrs.push(format!("{}{}", prefix, a));
+                                }
+                                // Because we create clones for these two right now, we always need
+                                // this
+                                ArgKind::Ref | ArgKind::Deref => argstrs.push(format!("&{}", a)),
+                                ArgKind::Own => argstrs.push(a.clone()),
+                            },
                         }
                     }
                     Ok((
@@ -231,20 +267,9 @@ pub fn from_microstatement(
                     out = o;
                     let mut argstrs = Vec::new();
                     for arg in args {
-                        let (a, o) = from_microstatement(arg, scope, out)?;
+                        let (a, o) = from_microstatement(arg, parent_fn, scope, out)?;
                         out = o;
-                        // If the argument is itself a function, this is the only place in Rust
-                        // where you can't pass by reference, so we check the type and change
-                        // the argument output accordingly.
-                        let arg_type = arg.get_type();
-                        match arg_type {
-                            CType::Function(..) => argstrs.push(a.to_string()),
-                            _ => argstrs.push(if a.starts_with("&mut ") {
-                                a
-                            } else {
-                                format!("&mut {}", a)
-                            }),
-                        }
+                        argstrs.push(a.to_string());
                     }
                     // The behavior of the generated code depends on the structure of the
                     // return type and the input types. We also do some logic based on the name
@@ -280,7 +305,7 @@ pub fn from_microstatement(
                     //    question. (This conflicts with (1) so it's checked first.)
                     if function.args.len() == 1 {
                         // This is a wacky unwrapping logic...
-                        let mut input_type = &function.args[0].1;
+                        let mut input_type = &function.args[0].2;
                         while matches!(input_type, CType::Type(..) | CType::Group(_)) {
                             input_type = match input_type {
                                 CType::Type(_, t) => t,
@@ -340,7 +365,7 @@ pub fn from_microstatement(
                                 // function argument. We blow up here if the first argument is
                                 // *not* a Type we can get an enum name from (it *shouldn't* be
                                 // possible, but..)
-                                let enum_type = function.args[0].1.degroup();
+                                let enum_type = function.args[0].2.degroup();
                                 let enum_name = enum_type.to_callable_string();
                                 // We pass through to the main path if we can't find a matching
                                 // name
@@ -353,16 +378,16 @@ pub fn from_microstatement(
                                         } else if let CType::Type(name, _) = &ts[1] {
                                             if name == "Error" {
                                                 if function.name == "Error" {
-                                                    return Ok((format!("(match {} {{ Err(e) => Some(e.clone()), _ => None }})", argstrs[0]), out));
+                                                    return Ok((format!("(match &{} {{ Err(e) => Some(e.clone()), _ => None }})", argstrs[0]), out));
                                                 } else {
-                                                    return Ok((format!("(match {} {{ Ok(v) => Some(v.clone()), _ => None }})", argstrs[0]), out));
+                                                    return Ok((format!("(match &{} {{ Ok(v) => Some(v.clone()), _ => None }})", argstrs[0]), out));
                                                 }
                                             }
                                         }
                                     }
                                     return Ok((
                                         format!(
-                                            "(match {} {{ {}::{}(v) => Some(v.clone()), _ => None }})",
+                                            "(match &{} {{ {}::{}(v) => Some(v.clone()), _ => None }})",
                                             argstrs[0], enum_name, function.name
                                         ),
                                         out,
@@ -394,7 +419,7 @@ pub fn from_microstatement(
                                 if argstrs.len() != 2 {
                                     return Err(format!("Invalid arguments {} provided for Either re-assignment function, must be two arguments", argstrs.join(", ")).into());
                                 }
-                                let enum_type = &function.args[1].1.degroup();
+                                let enum_type = &function.args[1].2.degroup();
                                 let enum_name = match enum_type {
                                     CType::Field(n, _) => Ok(n.clone()),
                                     CType::Type(n, _) => Ok(n.clone()),
@@ -691,7 +716,7 @@ pub fn from_microstatement(
                                     return Err(format!("Invalid arguments {} provided for Either constructor function, must be zero or one argument", argstrs.join(", ")).into());
                                 }
                                 let enum_type = match &function.args.first() {
-                                    Some(t) => t.1.degroup(),
+                                    Some(t) => t.2.degroup(),
                                     None => CType::Void,
                                 };
                                 let enum_name = match enum_type {
@@ -1020,7 +1045,7 @@ pub fn from_microstatement(
         Microstatement::VarCall { name, args, .. } => {
             let mut argstrs = Vec::new();
             for arg in args {
-                let (a, o) = from_microstatement(arg, scope, out)?;
+                let (a, o) = from_microstatement(arg, parent_fn, scope, out)?;
                 out = o;
                 // If the argument is itself a function, this is the only place in Rust
                 // where you can't pass by reference, so we check the type and change
@@ -1028,6 +1053,7 @@ pub fn from_microstatement(
                 let arg_type = arg.get_type();
                 match arg_type {
                     CType::Function(..) => argstrs.push(a.to_string()),
+                    // TODO: How to figure out the arg kinds for a VarCall
                     _ => argstrs.push(if a.starts_with("&mut ") {
                         a
                     } else {
@@ -1039,7 +1065,7 @@ pub fn from_microstatement(
         }
         Microstatement::Return { value } => match value {
             Some(val) => {
-                let (retval, o) = from_microstatement(val, scope, out)?;
+                let (retval, o) = from_microstatement(val, parent_fn, scope, out)?;
                 out = o;
                 Ok((
                     format!(
@@ -1068,13 +1094,17 @@ pub fn generate(
     // First make sure all of the function argument types are defined
     let mut arg_strs = Vec::new();
     for arg in &function.args {
-        let (l, t) = arg;
+        let (l, k, t) = arg;
         let (t_str, o) = typen::generate(t, out)?;
         out = o;
         if t_str.starts_with("impl") || t_str.starts_with("&") {
             arg_strs.push(format!("{}: {}", l, t_str));
         } else {
-            arg_strs.push(format!("{}: &{}", l, t_str));
+            match k {
+                ArgKind::Mut => arg_strs.push(format!("{}: &mut {}", l, t_str)),
+                ArgKind::Own => arg_strs.push(format!("{}: {}", l, t_str)),
+                _ => arg_strs.push(format!("{}: &{}", l, t_str)),
+            }
         }
     }
     let opt_ret_str = match &function.rettype.degroup() {
@@ -1107,7 +1137,7 @@ pub fn generate(
     )
     .to_string();
     for microstatement in &function.microstatements {
-        let (stmt, o) = from_microstatement(microstatement, scope, out)?;
+        let (stmt, o) = from_microstatement(microstatement, function, scope, out)?;
         out = o;
         fn_string = format!("{}    {};\n", fn_string, stmt);
     }

--- a/src/lntors/function.rs
+++ b/src/lntors/function.rs
@@ -185,9 +185,8 @@ pub fn from_microstatement(
                                     let mut prefix = "&mut ";
                                     for (name, kind, _) in &parent_fn.args {
                                         if name == &a {
-                                            match kind {
-                                                ArgKind::Mut => prefix = "",
-                                                _ => {}
+                                            if let ArgKind::Mut = kind {
+                                                prefix = "";
                                             }
                                         }
                                     }
@@ -221,9 +220,8 @@ pub fn from_microstatement(
                                     let mut prefix = "&mut ";
                                     for (name, kind, _) in &parent_fn.args {
                                         if name == &a {
-                                            match kind {
-                                                ArgKind::Mut => prefix = "",
-                                                _ => {}
+                                            if let ArgKind::Mut = kind {
+                                                prefix = "";
                                             }
                                         }
                                     }

--- a/src/program/argkind.rs
+++ b/src/program/argkind.rs
@@ -1,0 +1,7 @@
+#[derive(Clone, Debug)]
+pub enum ArgKind {
+    Ref,
+    Own,
+    Deref,
+    Mut,
+}

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -1,3 +1,4 @@
+mod argkind;
 mod constn;
 mod ctype;
 mod export;
@@ -11,6 +12,7 @@ mod program;
 mod scope;
 mod typeoperatormapping;
 
+pub use argkind::ArgKind;
 pub use constn::Const;
 pub use ctype::CType;
 pub use export::Export;

--- a/src/program/scope.rs
+++ b/src/program/scope.rs
@@ -2,6 +2,7 @@ use std::sync::OnceLock;
 
 use ordered_hash_map::OrderedHashMap;
 
+use super::ArgKind;
 use super::CType;
 use super::Const;
 use super::Export;
@@ -361,7 +362,7 @@ impl<'a> Scope<'a> {
                 let input = f
                     .args
                     .iter()
-                    .map(|(_, arg)| arg.clone())
+                    .map(|(_, _, arg)| arg.clone())
                     .collect::<Vec<CType>>();
                 let output = f.rettype.clone();
                 match generics {
@@ -404,7 +405,7 @@ impl<'a> Scope<'a> {
                             Box::new(CType::Tuple(
                                 f.args
                                     .iter()
-                                    .map(|(_, t)| t.clone())
+                                    .map(|(_, _, t)| t.clone())
                                     .collect::<Vec<CType>>(),
                             )),
                             Box::new(f.rettype.clone()),
@@ -484,8 +485,8 @@ impl<'a> Scope<'a> {
                     let args = f
                         .args
                         .iter()
-                        .map(|(name, argtype)| {
-                            (name.clone(), {
+                        .map(|(name, kind, argtype)| {
+                            (name.clone(), kind.clone(), {
                                 let mut a = argtype.clone();
                                 for ((_, o), n) in gen_args.iter().zip(generic_types.iter()) {
                                     a = a.swap_subtype(o, n);
@@ -493,15 +494,15 @@ impl<'a> Scope<'a> {
                                 a
                             })
                         })
-                        .collect::<Vec<(String, CType)>>();
+                        .collect::<Vec<(String, ArgKind, CType)>>();
                     possible_args_vec.push(args);
                 }
                 FnKind::Generic(gen_args, _) => {
                     let args = f
                         .args
                         .iter()
-                        .map(|(name, argtype)| {
-                            (name.clone(), {
+                        .map(|(name, kind, argtype)| {
+                            (name.clone(), kind.clone(), {
                                 let mut a = argtype.clone();
                                 for ((_, o), n) in gen_args.iter().zip(generic_types.iter()) {
                                     a = a.swap_subtype(o, n);
@@ -509,7 +510,7 @@ impl<'a> Scope<'a> {
                                 a
                             })
                         })
-                        .collect::<Vec<(String, CType)>>();
+                        .collect::<Vec<(String, ArgKind, CType)>>();
                     possible_args_vec.push(args);
                 }
             }
@@ -521,7 +522,7 @@ impl<'a> Scope<'a> {
                 // This is pretty cheap, but for now, a "non-strict" string representation
                 // of the CTypes is how we'll match the args against each other. TODO: Do
                 // this without constructing a string to compare against each other.
-                if !possible_args[i].1.accepts(arg) {
+                if !possible_args[i].2.accepts(arg) {
                     args_match = false;
                     break;
                 }
@@ -612,7 +613,7 @@ impl<'a> Scope<'a> {
                     // actual args are the same type as the function's arg.
                     let mut args_match = true;
                     for arg in args.iter() {
-                        if !f.args[0].1.accepts(arg) {
+                        if !f.args[0].2.accepts(arg) {
                             args_match = false;
                             break;
                         }
@@ -632,7 +633,7 @@ impl<'a> Scope<'a> {
                         // This is pretty cheap, but for now, a "non-strict" string representation
                         // of the CTypes is how we'll match the args against each other. TODO: Do
                         // this without constructing a string to compare against each other.
-                        if !f.args[i].1.accepts(arg) {
+                        if !f.args[i].2.accepts(arg) {
                             args_match = false;
                             break;
                         }
@@ -710,7 +711,7 @@ impl<'a> Scope<'a> {
                     // actual args are the same type as the function's arg.
                     let mut args_match = true;
                     for arg in args.iter() {
-                        if !f.args[0].1.accepts(arg) {
+                        if !f.args[0].2.accepts(arg) {
                             args_match = false;
                             break;
                         }
@@ -728,7 +729,7 @@ impl<'a> Scope<'a> {
                         // This is pretty cheap, but for now, a "non-strict" string representation
                         // of the CTypes is how we'll match the args against each other. TODO: Do
                         // this without constructing a string to compare against each other.
-                        if !f.args[i].1.accepts(arg) {
+                        if !f.args[i].2.accepts(arg) {
                             args_match = false;
                             break;
                         }

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -154,8 +154,7 @@ export fn hash "hashstring" :: string -> i64;
 export fn hash{T} "hash" :: T -> i64;
 export fn void{T}(v: T) -> void {}
 export fn void() -> void {}
-//export fn store{T} (a: T, b: T) -> T = {"std::mem::replace" :: (Mut{T}, Own{T}) -> T}(a, b);
-export fn store{T} "storeswap" :: (T, T) -> T;
+export fn store{T} (a: Mut{T}, b: T) -> T = {"std::mem::replace" :: (Mut{T}, Own{T}) -> T}(a, b);
 
 /// Fallible, Maybe, and Either functions
 export fn getOr{T} "maybe_get_or" :: (T?, T) -> T;
@@ -599,8 +598,8 @@ export fn join{S}(a: Buffer{string, S}, s: string) -> string = {Method{"join"} :
 /// Array related bindings
 export fn get{T} "getarray" :: (T[], i64) -> T?;
 export fn len{T} "lenarray" :: T[] -> i64;
-export fn push{T} "pusharray" :: (T[], T);
-export fn pop{T} "poparray" :: T[] -> T?;
+export fn push{T} "pusharray" :: (Mut{T[]}, T);
+export fn pop{T} "poparray" :: Mut{T[]} -> T?;
 export fn map{T, U} "map_onearg" :: (T[], T -> U) -> U[];
 export fn map{T, U} "map_twoarg" :: (T[], (T, i64) -> U) -> U[];
 export fn parmap{T, U} "parmap_onearg" :: (T[], T -> U) -> U[];
@@ -611,7 +610,7 @@ export fn reduce{T} "reduce_sametype_idx" :: (T[], (T, T, i64) -> T) -> T?;
 export fn reduce{T, U} "reduce_difftype" :: (T[], U, (U, T) -> U) -> U;
 export fn reduce{T, U} "reduce_difftype_idx" :: (T[], U, (U, T, i64) -> U) -> U;
 export fn concat{T} "concat" :: (T[], T[]) -> T[];
-export fn append{T} "append" :: (T[], T[]);
+export fn append{T} "append" :: (Mut{T[]}, T[]);
 export fn filled{T} "filled" :: (T, i64) -> T[];
 export fn has{T} (a: T[], v: T) -> bool = {Method{"contains"} :: (T[], T) -> bool}(a, v);
 export fn has{T} "hasfnarray" :: (T[], T -> bool) -> bool;
@@ -639,8 +638,8 @@ export fn index{T}(a: Array{T}, f: (T, i64) -> bool) -> Maybe{i64} = a.reduce(
 export fn every{T} "everyarray" :: (T[], T -> bool) -> bool;
 export fn some{T} "somearray" :: (T[], T -> bool) -> bool;
 export fn repeat{T} "repeatarray" :: (T[], i64) -> T[];
-export fn store{T} "storearray" :: (T[], i64, T) -> void!;
-export fn delete{T} "deletearray" :: (T[], i64) -> T!;
+export fn store{T} "storearray" :: (Mut{T[]}, i64, T) -> void!;
+export fn delete{T} "deletearray" :: (Mut{T[]}, i64) -> T!;
 
 /// Buffer related bindings
 export fn get{T, S} "getbuffer" :: (T[S], i64) -> T?;
@@ -654,7 +653,7 @@ export fn has{T, S} "hasbuffer" :: (T[S], T) -> bool;
 export fn has{T, S} "hasfnbuffer" :: (T[S], T -> bool) -> bool;
 export fn find{T, S} "findbuffer" :: (T[S], T -> bool) -> T?;
 export fn every{T, S} "everybuffer" :: (T[S], T -> bool) -> bool;
-fn concatInner{T, S, N} "concatbuffer" :: (T[S + N], T[S], T[N]);
+fn concatInner{T, S, N} "concatbuffer" :: (Mut{T[S + N]}, T[S], T[N]);
 export fn concat{T, S, N}(a: Buffer{T, S}, b: Buffer{T, N}) -> Buffer{T, S + N} {
   // I can't bind directly into Rust because Rust can't add const integer type parameters together.
   // It's *theoretically* possible to generate a new Rust function in each case with the required
@@ -667,7 +666,7 @@ export fn concat{T, S, N}(a: Buffer{T, S}, b: Buffer{T, N}) -> Buffer{T, S + N} 
 // TODO: Be able to resolve explicit integer constant values as the integer type so it can be
 // grabbed by the type inference system. For now, repeat for buffers outputs an array, instead.
 export fn repeat{T, S} "repeatbuffertoarray" :: (T[S], i64) -> T[];
-export fn store{T, S} "storebuffer" :: (T[S], i64, T) -> T!;
+export fn store{T, S} "storebuffer" :: (Mut{T[S]}, i64, T) -> T!;
 
 /// Dictionary-related bindings
 export fn Dict{K, V} "OrderedHashMap::new" :: () -> Dict{K, V};
@@ -680,7 +679,7 @@ export fn Dict{K, V}(a: Array{(K, V)}) -> Dict{K, V} = a.reduce(Dict{K, V}(), fn
   d.store(v.0, v.1);
   return d;
 });
-export fn store{K, V} "storedict" :: (Dict{K, V}, K, V);
+export fn store{K, V} "storedict" :: (Mut{Dict{K, V}}, K, V);
 export fn get{K, V} "getdict" :: (Dict{K, V}, K) -> V?;
 export fn has{K, V} (d: Dict{K, V}, k: K) -> bool = {Method{"contains_key"} :: (Dict{K, V}, K) -> bool}(d, k);
 export fn len{K, V} (d: Dict{K, V}) -> i64 = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}({Method{"len"} :: Dict{K, V} -> Binds{"usize"}}(d));
@@ -700,7 +699,7 @@ export fn Set{V}(v: V) -> Set{V} {
   out.store(v);
   return out;
 }
-export fn store{V} "storeset" :: (Set{V}, V);
+export fn store{V} "storeset" :: (Mut{Set{V}}, V);
 export fn has{V} (s: Set{V}, v: V) -> bool = {Method{"contains"} :: (Set{V}, V) -> bool}(s, v);
 export fn len{V} (s: Set{V}) -> i64 = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}({Method{"len"} :: Set{V} -> Binds{"usize"}}(s));
 export fn Array{V} "arrayset" :: Set{V} -> V[];

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -74,12 +74,6 @@ fn hashstring(v: &String) -> i64 {
     hasher.finish() as i64
 }
 
-/// `storeswap` swaps the input and output
-#[inline(always)]
-fn storeswap<T: std::clone::Clone>(a: &mut T, b: &mut T) -> T {
-    std::mem::replace(a, b.clone())
-}
-
 /// Fallible, Maybe, and Either functions
 
 /// `maybe_get_or` gets the Option's value or returns the default if not present.
@@ -1002,7 +996,7 @@ impl DerefMut for GBuffer {
     }
 }
 
-fn create_buffer_init(usage: &mut wgpu::BufferUsages, vals: &mut Vec<i32>) -> GBuffer {
+fn create_buffer_init(usage: &wgpu::BufferUsages, vals: &Vec<i32>) -> GBuffer {
     let g = gpu();
     let val_slice = &vals[..];
     let val_ptr = val_slice.as_ptr();
@@ -1018,7 +1012,7 @@ fn create_buffer_init(usage: &mut wgpu::BufferUsages, vals: &mut Vec<i32>) -> GB
     )))
 }
 
-fn create_empty_buffer(usage: &mut wgpu::BufferUsages, size: &mut i64) -> GBuffer {
+fn create_empty_buffer(usage: &wgpu::BufferUsages, size: &i64) -> GBuffer {
     let g = gpu();
     GBuffer(Rc::new(g.device.create_buffer(&wgpu::BufferDescriptor {
         label: None, // TODO: Add a label for easier debugging?
@@ -1073,15 +1067,11 @@ impl GPGPU {
 }
 
 #[inline(always)]
-fn GPGPU_new(
-    source: &mut String,
-    buffers: &mut Vec<Vec<GBuffer>>,
-    max_global_id: &mut [i64; 3],
-) -> GPGPU {
+fn GPGPU_new(source: &String, buffers: &Vec<Vec<GBuffer>>, max_global_id: &[i64; 3]) -> GPGPU {
     GPGPU::new(source.clone(), buffers.clone(), *max_global_id)
 }
 
-fn GPGPU_new_easy(source: &mut String, buffer: &mut GBuffer) -> GPGPU {
+fn GPGPU_new_easy(source: &String, buffer: &GBuffer) -> GPGPU {
     // In order to support larger arrays, we need to split the buffer length across them. Each of
     // indices is allowed to be up to 65535 (yes, a 16-bit integer) leading to a maximum length of
     // 65535^3, or about 2.815x10^14 elements (about 281 trillion elements). Not quite up to the
@@ -1110,7 +1100,7 @@ fn GPGPU_new_easy(source: &mut String, buffer: &mut GBuffer) -> GPGPU {
     GPGPU::new(source.clone(), vec![vec![buffer.clone()]], [x, y, z])
 }
 
-fn gpu_run(gg: &mut GPGPU) {
+fn gpu_run(gg: &GPGPU) {
     let g = gpu();
     let module = g.device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: None,
@@ -1165,7 +1155,7 @@ fn gpu_run(gg: &mut GPGPU) {
     g.queue.submit(Some(encoder.finish()));
 }
 
-fn read_buffer(b: &mut GBuffer) -> Vec<i32> {
+fn read_buffer(b: &GBuffer) -> Vec<i32> {
     // TODO: Support other value types
     let g = gpu();
     let temp_buffer = create_empty_buffer(


### PR DESCRIPTION
I wanted to hide this, but I think making it clear that a function is going to mutate a variable that was passed to it is worthwhile to have in the language.

I then use this to improve the bindings into Rust (and yay, I no longer have to make every function take `&mut` for everything!)
