### PR TITLE
Fix the bug blocking the Fallible test from eliminating the return type annotation, removing some hackery and properly resolving return types

### DIFF
--- a/src/compile/integration_tests.rs
+++ b/src/compile/integration_tests.rs
@@ -2554,8 +2554,7 @@ void
 );
 test!(fallible => r#"
     // TODO: Rewrite these conditionals with conditional syntax once implemented
-    // TODO: Why does this function still require a return type to work?
-    fn reciprocal(val: f64) -> Fallible{f64} = if(val == 0.0, fn {
+    fn reciprocal(val: f64) = if(val == 0.0, fn {
       return Error{f64}('Divide by zero error!');
     }, fn {
       return Fallible{f64}(1.0 / val);

--- a/src/program/function.rs
+++ b/src/program/function.rs
@@ -424,7 +424,6 @@ impl Function {
                     };
                     // In case there were any created functions (eg constructor or accessor
                     // functions) in that path, we need to merge the child's functions back up
-                    // TODO: Why can't I box this up into a function?
                     merge!(scope, temp_scope);
                     let degrouped_input = input_type.degroup();
                     Ok(CType::Function(
@@ -444,53 +443,6 @@ impl Function {
                             CType::Infer("unknown".to_string(), "unknown".to_string()),
                         ),
                     };
-                    // TODO: This is getting duplicated in a few different places. The CType creation
-                    // should probably centralize creating these type names and constructor functions
-                    // for us rather than this hackiness. Only adding the hackery to the output_type
-                    // because that's all I need, and the input type would be much more convoluted.
-                    if let CType::Void = output_type {
-                        // Skip this
-                    } else if let CType::Infer(_, _) = output_type {
-                        // Also skip
-                    } else {
-                        // This particular hackery assumes that the return type is not itself a
-                        // function and that it is using the `->` operator syntax. These are terrible
-                        // assumptions and this hacky code needs to die soon.
-                        let mut lastfnop = None;
-                        for (i, ta) in typeassignable.iter().enumerate() {
-                            if ta.to_string().trim() == "->" {
-                                lastfnop = Some(i);
-                            }
-                        }
-                        if let Some(lastfnop) = lastfnop {
-                            let returntypeassignables =
-                                typeassignable[lastfnop + 1..typeassignable.len()].to_vec();
-                            // TODO: Be more complete here
-                            let name = output_type.to_callable_string();
-                            // Don't recreate the exact same thing. It only causes pain
-                            if scope.resolve_type(&name).is_none() {
-                                let parse_type = parse::Types {
-                                    typen: "type".to_string(),
-                                    a: "".to_string(),
-                                    opttypegenerics: None,
-                                    b: "".to_string(),
-                                    fulltypename: parse::FullTypename {
-                                        typename: name.clone(),
-                                        opttypegenerics: None,
-                                    },
-                                    c: "".to_string(),
-                                    typedef: parse::TypeDef {
-                                        a: "=".to_string(),
-                                        b: "".to_string(),
-                                        typeassignables: returntypeassignables,
-                                    },
-                                    optsemicolon: ";".to_string(),
-                                };
-                                let res = CType::from_ast(scope, &parse_type, false)?;
-                                scope = res.0;
-                            }
-                        }
-                    }
                     let degrouped_input = input_type.degroup();
                     Ok(CType::Function(
                         Box::new(degrouped_input),
@@ -546,6 +498,33 @@ impl Function {
                     // Do nothing, they're the same
                 }
             }
+        }
+        // TODO: This is getting duplicated in a few different places. The CType creation
+        // should probably centralize creating these type names and constructor functions
+        // for us rather than this hackiness. Only adding the hackery to the output_type
+        // because that's all I need, and the input type would be much more convoluted.
+        match &typen {
+            CType::Function(i, o) => {
+                match &**o {
+                    CType::Void => { /* Do nothing */ }
+                    CType::Infer(t, _) if t == "unknown" && function_ast.optgenerics.is_none() => {
+                        CType::fail(&format!(
+                            "The return type for {}({}) could not be inferred.",
+                            name,
+                            i.to_strict_string(false)
+                        ));
+                    }
+                    CType::Infer(..) => { /* Do nothing */ }
+                    otherwise => {
+                        let name = otherwise.to_callable_string();
+                        // Don't recreate the exact same thing. It only causes pain
+                        if scope.resolve_type(&name).is_none() {
+                            scope = CType::from_ctype(scope, name, otherwise.clone());
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
         }
         let function = Function {
             name,


### PR DESCRIPTION
I realized this morning that the bug I saw last night wrt the `Fallible{T}` test confusingly still requiring the return type annotation was due to an issue with proper type resolution for inferred return types.

I need to construct all of the type's functions *after* inference is complete, not before. And at the same time I was able to eliminate some hacky code that was doing it, so it should now be possible (at least for the type system) for a function to return a function without causing the compiler to barf.
