### PR TITLE
Fix a bug involving single-property 'structs' and type inference, and then convert the last of the Fallible and Maybe functions to not require a preamble Rust function

### DIFF
--- a/src/lntors/typen.rs
+++ b/src/lntors/typen.rs
@@ -136,14 +136,14 @@ pub fn ctype_to_rtype(
                     t => out.push(ctype_to_rtype(t, in_function_type)?),
                 }
             }
-            Ok(format!("({})", out.join(", ")))
+            if out.len() == 1 {
+                Ok(format!("({},)", out[0]))
+            } else {
+                Ok(format!("({})", out.join(", ")))
+            }
         }
         CType::Field(k, v) => {
-            if in_function_type {
-                Ok(ctype_to_rtype(v, in_function_type)?)
-            } else {
-                Ok(format!("{}: {}", k, ctype_to_rtype(v, in_function_type)?))
-            }
+            Ok(format!("/* {} */ {}", k, ctype_to_rtype(v, in_function_type)?))
         }
         CType::Either(ts) => {
             // Special handling to convert `Either{T, void}` to `Option<T>` and `Either{T, Error}`

--- a/src/std/root.ln
+++ b/src/std/root.ln
@@ -158,8 +158,8 @@ export fn void() -> void {}
 export fn store{T} (a: Mut{T}, b: T) -> T = {"std::mem::replace" :: (Mut{T}, Own{T}) -> T}(a, b);
 
 /// Fallible, Maybe, and Either functions
-export fn getOr{T} "maybe_get_or" :: (T?, T) -> T;
-export fn getOr{T} "fallible_get_or" :: (T!, T) -> T;
+export fn getOr{T} (v: T?, d: T) = {Method{"unwrap_or"} :: (Own{T?}, Own{T}) -> T}(v, d);
+export fn getOr{T} (v: T!, d: T) = {Method{"unwrap_or"} :: (Own{T!}, Own{T}) -> T}(v, d);
 export fn getOrExit{T} (v: T!) = {Method{"unwrap"} :: Own{T!} -> T}(v);
 export fn getOrExit{T} (v: T?) = {Method{"unwrap"} :: Own{T?} -> T}(v);
 export fn Error{T} (e: string) = {"Err" :: Own{Error} -> T!}(
@@ -600,7 +600,6 @@ export fn gte Infix{">="} :: (Own{string}, Own{string}) -> bool;
 export fn min (a: string, b: string) = if(a.lte(b), fn () = a.clone(), fn () = b.clone());
 export fn max (a: string, b: string) = if(a.gte(b), fn () = a.clone(), fn () = b.clone());
 export fn join Method{"join"} :: (string[], string) -> string;
-// TODO: There's something odd with the Buffer symbolic syntax that needs fixing
 export fn join{S}(a: string[S], s: string) = {Method{"join"} :: (string[S], string) -> string}(a, s);
 
 /// Array related bindings
@@ -643,7 +642,6 @@ export fn delete{T} "deletearray" :: (Mut{T[]}, i64) -> T!;
 /// Buffer related bindings
 export fn get{T, S} "getbuffer" :: (T[S], i64) -> T?;
 export fn len{T, S}(T[S]) = {S}();
-// TODO: Still something weird with the buffer symbolic syntax, skipping it for map
 export fn map{T, S, U} "mapbuffer_onearg" :: (T[S], T -> U) -> (U[S]);
 export fn map{T, S, U} "mapbuffer_twoarg" :: (T[S], (T, i64) -> U) -> (U[S]);
 export fn reduce{T, S} "reducebuffer_sametype" :: (T[S], (T, T) -> T) -> T?;

--- a/src/std/root.rs
+++ b/src/std/root.rs
@@ -74,27 +74,6 @@ fn hashstring(v: &String) -> i64 {
     hasher.finish() as i64
 }
 
-/// Fallible, Maybe, and Either functions
-
-/// `maybe_get_or` gets the Option's value or returns the default if not present.
-#[inline(always)]
-fn maybe_get_or<T: std::clone::Clone>(v: &Option<T>, d: &T) -> T {
-    match v {
-        Some(val) => val.clone(),
-        None => d.clone(),
-    }
-}
-
-/// `fallible_get_or` gets the Fallible (Result with pre-bound error) value or returns the default
-/// if not present.
-#[inline(always)]
-fn fallible_get_or<T: std::clone::Clone>(v: &Result<T, AlanError>, d: &T) -> T {
-    match v {
-        Ok(val) => val.clone(),
-        Err(_) => d.clone(),
-    }
-}
-
 /// Signed Integer-related functions
 
 /// `stringtoi8` tries to convert a string into an i8


### PR DESCRIPTION
This took me 1.5 days to figure out. :/
