### PR TITLE
Bind the JS u8 bitwise and arithmetic operations

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -509,37 +509,37 @@ test_full!(i64_neg => r#"
     stdout "-3\n";
 );
 
-test!(u8_add => r#"
+test_full!(u8_add => r#"
     export fn main() -> ExitCode = ExitCode(add(u8(1), u8(2)));"#;
     status 3;
 );
-test!(u8_sub => r#"
+test_full!(u8_sub => r#"
     export fn main() = ExitCode(sub(u8(2), u8(1)));"#;
     status 1;
 );
-test!(u8_mul => r#"
+test_full!(u8_mul => r#"
     export fn main() -> ExitCode = ExitCode(mul(u8(2), u8(1)));"#;
     status 2;
 );
-test!(u8_div => r#"
+test_full!(u8_div => r#"
     export fn main() = ExitCode(div(u8(6), u8(2)));"#;
     status 3;
 );
-test!(u8_mod => r#"
+test_full!(u8_mod => r#"
     export fn main() -> ExitCode = ExitCode(mod(u8(6), u8(4)));"#;
     status 2;
 );
-test!(u8_pow => r#"
+test_full!(u8_pow => r#"
     export fn main() = ExitCode(pow(u8(6), u8(2)));"#;
     status 36;
 );
-test!(u8_min => r#"
+test_full!(u8_min => r#"
     export fn main() {
       print(min(u8(3), u8(5)));
     }"#;
     stdout "3\n";
 );
-test!(u8_max => r#"
+test_full!(u8_max => r#"
     export fn main() {
       print(max(u8(3), u8(5)));
     }"#;
@@ -938,7 +938,7 @@ test_full!(i64_bitwise => r#"
     stdout "0\n3\n6\n-1\n-1\n-4\n-7\n";
 );
 
-test!(u8_bitwise => r#"
+test_full!(u8_bitwise => r#"
     prefix u8 as ~ precedence 10
 
     export fn main {

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -699,31 +699,58 @@ export fn{Rs} wrr (a: i64, b: i64) = {Method{"rotate_right"} :: (i64, Deref{u32}
 export fn{Js} wrr "alan_std::rotateRightI64" <- RootBacking :: (i64, i64) -> i64;
 
 /// Unsigned Integer-related functions and function bindings
-export fn add Method{"wrapping_add"} :: (u8, Deref{u8}) -> u8;
-export fn sub Method{"wrapping_sub"} :: (u8, Deref{u8}) -> u8;
-export fn mul Method{"wrapping_mul"} :: (u8, Deref{u8}) -> u8;
-export fn div Method{"wrapping_div"} :: (u8, Deref{u8}) -> u8;
-export fn mod Method{"wrapping_rem"} :: (u8, Deref{u8}) -> u8;
-export fn pow (a: u8, b: u8) = {Method{"wrapping_pow"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
-export fn and Infix{"&"} :: (Deref{u8}, Deref{u8}) -> u8;
-export fn or Infix{"|"} :: (Deref{u8}, Deref{u8}) -> u8;
-export fn xor Infix{"^"} :: (Deref{u8}, Deref{u8}) -> u8;
-export fn not Prefix{"!"} :: Deref{u8} -> u8;
+export fn{Rs} add Method{"wrapping_add"} :: (u8, Deref{u8}) -> u8;
+export fn{Js} add "alan_std.wrappingAddU8" <- RootBacking :: (u8, u8) -> u8;
+export fn{Rs} sub Method{"wrapping_sub"} :: (u8, Deref{u8}) -> u8;
+export fn{Js} sub "alan_std.wrappingSubU8" <- RootBacking :: (u8, u8) -> u8;
+export fn{Rs} mul Method{"wrapping_mul"} :: (u8, Deref{u8}) -> u8;
+export fn{Js} mul "alan_std.wrappingMulU8" <- RootBacking :: (u8, u8) -> u8;
+export fn{Rs} div Method{"wrapping_div"} :: (u8, Deref{u8}) -> u8;
+export fn{Js} div "alan_std.wrappingDivU8" <- RootBacking :: (u8, u8) -> u8;
+export fn{Rs} mod Method{"wrapping_rem"} :: (u8, Deref{u8}) -> u8;
+export fn{Js} mod "alan_std.wrappingModU8" <- RootBacking :: (u8, u8) -> u8;
+export fn{Rs} pow (a: u8, b: u8) = {Method{"wrapping_pow"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
+export fn{Js} pow "alan_std.wrappingPowU8" <- RootBacking :: (u8, u8) -> u8;
+export fn{Rs} and Infix{"&"} :: (Deref{u8}, Deref{u8}) -> u8;
+export fn{Js} and Infix{"&"} :: (u8, u8) -> u8;
+export fn{Rs} or Infix{"|"} :: (Deref{u8}, Deref{u8}) -> u8;
+export fn{Js} or Infix{"|"} :: (u8, u8) -> u8;
+export fn{Rs} xor Infix{"^"} :: (Deref{u8}, Deref{u8}) -> u8;
+export fn{Js} xor Infix{"^"} :: (u8, u8) -> u8;
+export fn{Rs} not Prefix{"!"} :: Deref{u8} -> u8;
+export fn{Js} not (a: u8) { // TODO: Move this into the stdlib js file?
+  let v = {Prefix{"~"} :: u8 -> u8}(a);
+  return if(
+    {Infix{"<"} :: (u8, i64) -> bool}(v, 0),
+    fn = {Infix{"+"} :: (u8, i64) -> u8}(v, 256),
+    fn = v
+  );
+}
 export fn nand (a: u8, b: u8) = a.and(b).not;
 export fn nor (a: u8, b: u8) = a.or(b).not;
 export fn xnor (a: u8, b: u8) = a.xor(b).not;
-export fn eq Infix{"=="} :: (Deref{u8}, Deref{u8}) -> bool;
-export fn neq Infix{"!="} :: (Deref{u8}, Deref{u8}) -> bool;
-export fn lt Infix{"<"} :: (Deref{u8}, Deref{u8}) -> bool;
-export fn lte Infix{"<="} :: (Deref{u8}, Deref{u8}) -> bool;
-export fn gt Infix{">"} :: (Deref{u8}, Deref{u8}) -> bool;
-export fn gte Infix{">="} :: (Deref{u8}, Deref{u8}) -> bool;
+export fn{Rs} eq Infix{"=="} :: (Deref{u8}, Deref{u8}) -> bool;
+export fn{Js} eq Infix{"=="} :: (u8, u8) -> bool;
+export fn{Rs} neq Infix{"!="} :: (Deref{u8}, Deref{u8}) -> bool;
+export fn{Js} neq Infix{"!="} :: (u8, u8) -> bool;
+export fn{Rs} lt Infix{"<"} :: (Deref{u8}, Deref{u8}) -> bool;
+export fn{Js} lt Infix{"<"} :: (u8, u8) -> bool;
+export fn{Rs} lte Infix{"<="} :: (Deref{u8}, Deref{u8}) -> bool;
+export fn{Js} lte Infix{"<="} :: (u8, u8) -> bool;
+export fn{Rs} gt Infix{">"} :: (Deref{u8}, Deref{u8}) -> bool;
+export fn{Js} gt Infix{">"} :: (u8, u8) -> bool;
+export fn{Rs} gte Infix{">="} :: (Deref{u8}, Deref{u8}) -> bool;
+export fn{Js} gte Infix{">="} :: (u8, u8) -> bool;
 export fn min (a: u8, b: u8) = if(a.lte(b), a, b);
 export fn max (a: u8, b: u8) = if(a.gte(b), a, b);
-export fn shl (a: u8, b: u8) = {Method{"wrapping_shl"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
-export fn shr (a: u8, b: u8) = {Method{"wrapping_shr"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
-export fn wrl (a: u8, b: u8) = {Method{"rotate_left"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
-export fn wrr (a: u8, b: u8) = {Method{"rotate_right"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
+export fn{Rs} shl (a: u8, b: u8) = {Method{"wrapping_shl"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
+export fn{Js} shl "alan_std.wrappingShlU8" <- RootBacking :: (u8, u8) -> u8;
+export fn{Rs} shr (a: u8, b: u8) = {Method{"wrapping_shr"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
+export fn{Js} shr "alan_std.wrappingShrU8" <- RootBacking :: (u8, u8) -> u8;
+export fn{Rs} wrl (a: u8, b: u8) = {Method{"rotate_left"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
+export fn{Js} wrl "alan_std.rotateLeftU8" <- RootBacking :: (u8, u8) -> u8;
+export fn{Rs} wrr (a: u8, b: u8) = {Method{"rotate_right"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
+export fn{Js} wrr "alan_std::rotateRightU8" <- RootBacking :: (u8, u8) -> u8;
 
 export fn add Method{"wrapping_add"} :: (u16, Deref{u16}) -> u16;
 export fn sub Method{"wrapping_sub"} :: (u16, Deref{u16}) -> u16;


### PR DESCRIPTION
I will probably follow this up removing a hack from the root scope and shoving it into an appropriately named JS stdlib function.
