### PR TITLE
Fix a bug in buffer_buffer_shader_timings.ln

### DIFF
--- a/alan/benches/buffer_shader_timings.ln
+++ b/alan/benches/buffer_shader_timings.ln
@@ -7,8 +7,8 @@ fn inner(l: i64) {
   let b = GBuffer(v);
   "GPU Buffer load time:    ".concat(t2.elapsed.f64.string).print;
   let t3 = now();
-  let yMax = min(1, v.len / 10_000);
-  let xMax = min(1, v.len - (v.len / 10_000));
+  let yMax = max(1, v.len / 10_000);
+  let xMax = min(v.len, 10_000);
   let id = gFor(xMax, yMax);
   let compute = b[id.x + 10_000 * id.y].store(b[id.x + 10_000 * id.y] * (id.x + 10_000 * id.y).gi32);
   "Define shader time:      ".concat(t3.elapsed.f64.string).print;
@@ -19,7 +19,7 @@ fn inner(l: i64) {
   shader.run;
   "Shader run time:         ".concat(t5.elapsed.f64.string).print;
   let t6 = now();
-  b.read{i32}();
+  b.read{i32};
   "GPU Buffer read time:    ".concat(t6.elapsed.f64.string).print;
   let t7 = now();
   b.replace(v);


### PR DESCRIPTION
I realized the mistake after I tried to run the earlier version on MacOS and it *crashed* the machine (!!!) and then realized what I did wrong when I actually printed the buffer once it was in RAM and saw the garbage that was produced, particularly with the first few, which didn't change the buffer at all.

I was accidentally setting the `yMax` to `0`, which Vulkan and DirectX decide this means "don't run the shader at all" but Metal decides "run the shader on ALL of the GPU memory address space (afaict) until it messes with something it shouldn't and blows up the machine.

This fixes the bug here explicitly, but I need to decide what to do if you call `gFor` with invalid arguments ("correct" the `0` to `1`? `panic!` the program? make `gFor` fallible and return an error type?)
