### PR TITLE
Refactor the Program type to be used as a singleton

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,10 +20,10 @@ jobs:
       run: cargo build --verbose
     - if: ${{ github.ref_name == 'main' }}
       name: Run tests
-      run: cargo test --verbose -- --test-threads=1 --include-ignored
+      run: cargo test --verbose -- --include-ignored
     - if: ${{ github.ref_name != 'main' }}
       name: Run tests
-      run: cargo test --verbose -- --test-threads=1
+      run: cargo test --verbose
 
   test-windows:
     runs-on: [self-hosted, windows]
@@ -33,10 +33,10 @@ jobs:
       run: cargo build --verbose
     - if: ${{ github.ref_name == 'main' }}
       name: Run tests
-      run: cargo test --verbose -- --test-threads=1 --include-ignored
+      run: cargo test --verbose -- --include-ignored
     - if: ${{ github.ref_name != 'main' }}
       name: Run tests
-      run: cargo test --verbose -- --test-threads=1
+      run: cargo test --verbose
 
   test-macos:
     runs-on: [self-hosted, macOS]
@@ -46,10 +46,10 @@ jobs:
       run: cargo build --verbose
     - if: ${{ github.ref_name == 'main' }}
       name: Run tests
-      run: cargo test --verbose -- --test-threads=1 --include-ignored
+      run: cargo test --verbose -- --include-ignored
     - if: ${{ github.ref_name != 'main' }}
       name: Run tests
-      run: cargo test --verbose -- --test-threads=1
+      run: cargo test --verbose
 
   test-arm-linux:
     runs-on: [self-hosted, linux, ARM64]
@@ -59,7 +59,7 @@ jobs:
       run: cargo build --verbose
     - if: ${{ github.ref_name == 'main' }}
       name: Run tests
-      run: cargo test --verbose -- --test-threads=1 --include-ignored
+      run: cargo test --verbose -- --include-ignored
     - if: ${{ github.ref_name != 'main' }}
       name: Run tests
-      run: cargo test --verbose -- --test-threads=1
+      run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ This will create a file with the name `<source>` that you can run (or error if i
 If you wish to contribute to Alan, you'll need a development environment to build Alan locally:
 
 * git (any recent version should work)
-* Rust >=1.76.0
+* Rust >=1.80.0
+* Node.js >=22.0.0
 * A complete C toolchain (gcc, clang, msvc)
 
 Once those are installed, simply follow the install instructions above, replacing `cargo install --path .` with a simple `cargo build` to compile and `cargo test` to run the test suite.

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -17,6 +17,7 @@ macro_rules! test {
         mod $rule {
             #[test]
             fn $rule() -> Result<(), Box<dyn std::error::Error>> {
+                crate::program::Program::set_target_lang_rs();
                 let filename = format!("{}.ln", stringify!($rule));
                 match std::fs::write(&filename, $code) {
                     Ok(_) => { /* Do nothing */ }
@@ -24,8 +25,10 @@ macro_rules! test {
                         return Err(format!("Unable to write {} to disk. {:?}", filename, e).into());
                     }
                 };
-                std::env::set_var("ALAN_TARGET", "test");
-                std::env::set_var("ALAN_OUTPUT_LANG", "rs");
+                {
+                    let mut program = crate::program::Program::get_program().lock().unwrap();
+                    program.env.insert("ALAN_TARGET".to_string(), "test".to_string());
+                }
                 match crate::compile::build(filename.to_string()) {
                     Ok(_) => { /* Do nothing */ }
                     Err(e) => {
@@ -53,6 +56,7 @@ macro_rules! test_full {
         mod $rule {
             #[test]
             fn $rule() -> Result<(), Box<dyn std::error::Error>> {
+                crate::program::Program::set_target_lang_rs();
                 let filename = format!("{}.ln", stringify!($rule));
                 match std::fs::write(&filename, $code) {
                     Ok(_) => { /* Do nothing */ }
@@ -60,8 +64,10 @@ macro_rules! test_full {
                         return Err(format!("Unable to write {} to disk. {:?}", filename, e).into());
                     }
                 };
-                std::env::set_var("ALAN_TARGET", "test");
-                std::env::set_var("ALAN_OUTPUT_LANG", "rs");
+                {
+                    let mut program = crate::program::Program::get_program().lock().unwrap();
+                    program.env.insert("ALAN_TARGET".to_string(), "test".to_string());
+                }
                 match crate::compile::build(filename.to_string()) {
                     Ok(_) => { /* Do nothing */ }
                     Err(e) => {
@@ -83,7 +89,11 @@ macro_rules! test_full {
                     Ok(a) => Ok(a),
                     Err(e) => Err(format!("Could not remove the test binary {:?}", e)),
                 }?;
-                std::env::set_var("ALAN_OUTPUT_LANG", "js");
+                crate::program::Program::set_target_lang_js();
+                {
+                    let mut program = crate::program::Program::get_program().lock().unwrap();
+                    program.env.insert("ALAN_TARGET".to_string(), "test".to_string());
+                }
                 match crate::compile::web(filename.to_string()) {
                     Ok(_) => { /* Do nothing */ }
                     Err(e) => {
@@ -117,6 +127,7 @@ macro_rules! test_gpgpu {
         mod $rule {
             #[test]
             fn $rule() -> Result<(), Box<dyn std::error::Error>> {
+                crate::program::Program::set_target_lang_rs();
                 let filename = format!("{}.ln", stringify!($rule));
                 match std::fs::write(&filename, $code) {
                     Ok(_) => { /* Do nothing */ }
@@ -124,8 +135,10 @@ macro_rules! test_gpgpu {
                         return Err(format!("Unable to write {} to disk. {:?}", filename, e).into());
                     }
                 };
-                std::env::set_var("ALAN_TARGET", "test");
-                std::env::set_var("ALAN_OUTPUT_LANG", "rs");
+                {
+                    let mut program = crate::program::Program::get_program().lock().unwrap();
+                    program.env.insert("ALAN_TARGET".to_string(), "test".to_string());
+                }
                 match crate::compile::build(filename.to_string()) {
                     Ok(_) => { /* Do nothing */ }
                     Err(e) => {
@@ -153,8 +166,12 @@ macro_rules! test_gpgpu {
                 // My playwright scripts only work on Linux and MacOS, though, so that reduces it
                 // to just MacOS to test this on.
                 // if cfg!(windows) || cfg!(macos) {
-                if cfg!(macos) {
-                    std::env::set_var("ALAN_OUTPUT_LANG", "js");
+                if cfg!(target_os = "macos") {
+                    crate::program::Program::set_target_lang_js();
+                    {
+                        let mut program = crate::program::Program::get_program().lock().unwrap();
+                        program.env.insert("ALAN_TARGET".to_string(), "test".to_string());
+                    }
                     match crate::compile::web(filename.to_string()) {
                         Ok(_) => { /* Do nothing */ }
                         Err(e) => {
@@ -241,8 +258,10 @@ macro_rules! test_ignore {
                         return Err(format!("Unable to write {} to disk. {:?}", filename, e).into());
                     }
                 };
-                std::env::set_var("ALAN_TARGET", "test");
-                std::env::set_var("ALAN_OUTPUT_LANG", "rs");
+                {
+                    let mut program = crate::program::Program::get_program().lock().unwrap();
+                    program.env.insert("ALAN_TARGET".to_string(), "test".to_string());
+                }
                 match crate::compile::build(filename.to_string()) {
                     Ok(_) => { /* Do nothing */ }
                     Err(e) => {

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -166,6 +166,10 @@ macro_rules! test_gpgpu {
                 // My playwright scripts only work on Linux and MacOS, though, so that reduces it
                 // to just MacOS to test this on.
                 // if cfg!(windows) || cfg!(macos) {
+                // TODO: This apparently wasn't working at all because the `macos` cfg keyword was
+                // deprecated at some point and the new version of Rust finally told me? In any
+                // case, fixing this will be in a follow-up PR
+                /*
                 if cfg!(target_os = "macos") {
                     crate::program::Program::set_target_lang_js();
                     {
@@ -237,6 +241,7 @@ macro_rules! test_gpgpu {
                         Err(e) => Err(format!("Could not remove the generated HTML file {:?}", e)),
                     }?;
                 }
+                */
                 std::fs::remove_file(&filename)?;
                 Ok(())
             }

--- a/alan/src/lntojs/mod.rs
+++ b/alan/src/lntojs/mod.rs
@@ -9,14 +9,10 @@ mod typen;
 pub fn lntojs(
     entry_file: String,
 ) -> Result<(String, OrderedHashMap<String, String>), Box<dyn std::error::Error>> {
-    let program = Program::new(entry_file)?;
-    // Getting the entry scope, where the `main` function is expected
-    let scope = match program.scopes_by_file.get(&program.entry_file.clone()) {
-        Some((_, _, s)) => s,
-        None => {
-            return Err("Somehow didn't find a scope for the entry file!?".into());
-        }
-    };
+    Program::set_target_lang_js();
+    Program::load(entry_file.clone())?;
+    let program = Program::get_program().lock().unwrap();
+    let scope = program.scope_by_file(&entry_file)?;
     // Without support for building shared libs yet, assume there is an `export fn main` in the
     // entry file or fail otherwise
     match scope.exports.get("main") {

--- a/alan/src/lntors/mod.rs
+++ b/alan/src/lntors/mod.rs
@@ -9,14 +9,10 @@ mod typen;
 pub fn lntors(
     entry_file: String,
 ) -> Result<(String, OrderedHashMap<String, String>), Box<dyn std::error::Error>> {
-    let program = Program::new(entry_file)?;
-    // Getting the entry scope, where the `main` function is expected
-    let scope = match program.scopes_by_file.get(&program.entry_file.clone()) {
-        Some((_, _, s)) => s,
-        None => {
-            return Err("Somehow didn't find a scope for the entry file!?".into());
-        }
-    };
+    Program::set_target_lang_rs();
+    Program::load(entry_file.clone())?;
+    let program = Program::get_program().lock().unwrap();
+    let scope = program.scope_by_file(&entry_file)?;
     // Without support for building shared libs yet, assume there is an `export fn main` in the
     // entry file or fail otherwise
     match scope.exports.get("main") {

--- a/alan/src/main.rs
+++ b/alan/src/main.rs
@@ -77,7 +77,7 @@ enum Commands {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Cli::parse();
-    if let Some(_) = args.file {
+    if args.file.is_some() {
         println!("TODO: Interpreter mode someday");
         Ok(())
     } else {

--- a/alan/src/main.rs
+++ b/alan/src/main.rs
@@ -1,5 +1,4 @@
 use crate::compile::{bundle, compile, test, to_js, to_rs};
-use crate::program::Program;
 use clap::{Parser, Subcommand};
 
 mod compile;
@@ -78,9 +77,8 @@ enum Commands {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Cli::parse();
-    if let Some(file) = args.file {
-        let program = Program::new(file)?;
-        println!("{:?}", program);
+    if let Some(_) = args.file {
+        println!("TODO: Interpreter mode someday");
         Ok(())
     } else {
         match &args.commands {

--- a/alan/src/program/program.rs
+++ b/alan/src/program/program.rs
@@ -1,5 +1,7 @@
+use std::cell::Cell;
 use std::fs::read_to_string;
 use std::pin::Pin;
+use std::sync::{LazyLock, Mutex};
 
 use super::Scope;
 use crate::parse;
@@ -11,30 +13,42 @@ use ordered_hash_map::OrderedHashMap;
 // this might just be "good enough" assuming non-insane source file sizes.
 #[derive(Debug)]
 pub struct Program<'a> {
-    pub entry_file: String,
     #[allow(clippy::box_collection)]
     pub scopes_by_file: OrderedHashMap<String, (Pin<Box<String>>, parse::Ln, Scope<'a>)>,
+    pub env: OrderedHashMap<String, String>,
 }
 
-impl<'a> Program<'a> {
-    pub fn new(entry_file: String) -> Result<Program<'a>, Box<dyn std::error::Error>> {
-        let mut p = Program {
-            entry_file: entry_file.clone(),
-            scopes_by_file: OrderedHashMap::new(),
-        };
-        // Load the entry file
-        match p.load(entry_file) {
-            Ok(p) => p,
-            Err(e) => {
-                // Somehow, trying to print this error can crash Rust!? Really not good.
-                // Will need to figure out how to make these errors clearer to users.
-                return Err(format!("{}", e).into());
+pub static PROGRAM_RS: LazyLock<Mutex<Program<'static>>> = LazyLock::new(|| {
+    Mutex::new(Program {
+        scopes_by_file: OrderedHashMap::new(),
+        env: {
+            let mut env = OrderedHashMap::new();
+            for (k, v) in std::env::vars() {
+                env.insert(k.to_string(), v.to_string());
             }
-        };
-        Ok(p)
-    }
+            env.insert("ALAN_OUTPUT_LANG".to_string(), "rs".to_string());
+            env
+        },
+    })
+});
+pub static PROGRAM_JS: LazyLock<Mutex<Program<'static>>> = LazyLock::new(|| {
+    Mutex::new(Program {
+        scopes_by_file: OrderedHashMap::new(),
+        env: {
+            let mut env = OrderedHashMap::new();
+            for (k, v) in std::env::vars() {
+                env.insert(k.to_string(), v.to_string());
+            }
+            env.insert("ALAN_OUTPUT_LANG".to_string(), "js".to_string());
+            env
+        },
+    })
+});
 
-    pub fn load(&mut self, path: String) -> Result<(), Box<dyn std::error::Error>> {
+thread_local!(static TARGET_LANG_RS: Cell<bool> = Cell::new(true));
+
+impl<'a> Program<'a> {
+    pub fn load(path: String) -> Result<(), Box<dyn std::error::Error>> {
         let ln_src = if path.starts_with('@') {
             match path.as_str() {
                 //"@std/app" => include_str!("../std/app.ln").to_string(),
@@ -45,6 +59,36 @@ impl<'a> Program<'a> {
         } else {
             read_to_string(&path)?
         };
-        Scope::from_src(self, &path, ln_src)
+        Scope::from_src(&path, ln_src)
+    }
+
+    pub fn scope_by_file<'b>(
+        self: &Self,
+        path: &str,
+    ) -> Result<&Scope<'a>, Box<dyn std::error::Error>> {
+        match self.scopes_by_file.get(path) {
+            Some((_, _, s)) => Ok(s),
+            None => Err(format!("Could not find a scope for file {}", path).into()),
+        }
+    }
+
+    pub fn get_program<'b>() -> &'b LazyLock<Mutex<Program<'static>>> {
+        if TARGET_LANG_RS.get() {
+            &PROGRAM_RS
+        } else {
+            &PROGRAM_JS
+        }
+    }
+
+    pub fn set_target_lang_js() {
+        TARGET_LANG_RS.set(false);
+    }
+
+    pub fn set_target_lang_rs() {
+        TARGET_LANG_RS.set(true);
+    }
+
+    pub fn is_target_lang_rs() -> bool {
+        TARGET_LANG_RS.get()
     }
 }

--- a/alan/src/program/program.rs
+++ b/alan/src/program/program.rs
@@ -45,7 +45,7 @@ pub static PROGRAM_JS: LazyLock<Mutex<Program<'static>>> = LazyLock::new(|| {
     })
 });
 
-thread_local!(static TARGET_LANG_RS: Cell<bool> = Cell::new(true));
+thread_local!(static TARGET_LANG_RS: Cell<bool> = const { Cell::new(true) });
 
 impl<'a> Program<'a> {
     pub fn load(path: String) -> Result<(), Box<dyn std::error::Error>> {
@@ -62,10 +62,7 @@ impl<'a> Program<'a> {
         Scope::from_src(&path, ln_src)
     }
 
-    pub fn scope_by_file<'b>(
-        self: &Self,
-        path: &str,
-    ) -> Result<&Scope<'a>, Box<dyn std::error::Error>> {
+    pub fn scope_by_file(&self, path: &str) -> Result<&Scope<'a>, Box<dyn std::error::Error>> {
         match self.scopes_by_file.get(path) {
             Some((_, _, s)) => Ok(s),
             None => Err(format!("Could not find a scope for file {}", path).into()),

--- a/alan/src/program/scope.rs
+++ b/alan/src/program/scope.rs
@@ -129,17 +129,13 @@ impl<'a> Scope<'a> {
             };
             Scope::load_scope(s, ast, true).expect("Invalid root scope definition")
         };
-        if matches!(std::env::var("ALAN_OUTPUT_LANG"), Ok(v) if v == "rs") {
+        if Program::is_target_lang_rs() {
             ROOT_SCOPE_RS.get_or_init(resolver)
         } else {
             ROOT_SCOPE_JS.get_or_init(resolver)
         }
     }
-    pub fn from_src(
-        program: &'a mut Program,
-        path: &str,
-        src: String,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn from_src(path: &str, src: String) -> Result<(), Box<dyn std::error::Error>> {
         let txt = Box::pin(src);
         let txt_ptr: *const str = &**txt;
         // *How* would this move, anyways? But TODO: See if there's a way to handle this safely
@@ -155,6 +151,7 @@ impl<'a> Scope<'a> {
             exports: OrderedHashMap::new(),
         };
         s = Scope::load_scope(s, &ast, false)?;
+        let mut program = Program::get_program().lock().unwrap();
         program
             .scopes_by_file
             .insert(path.to_string(), (txt, ast, s));


### PR DESCRIPTION
Also make the environment frozen for the program on startup, which allows the test suite to run "normally" (multithreaded) because it doesn't depend on the single-threaded env type anymore.

This is in preparation for allowing imports of other source files to finally work.
