### PR TITLE
Make the root scope code more 'normal' looking

### DIFF
--- a/alan/src/parse.rs
+++ b/alan/src/parse.rs
@@ -1270,7 +1270,6 @@ named_or!(exportable: Exportable =>
     Functions: Functions as functions,
     ConstDeclaration: ConstDeclaration as constdeclaration,
     Types: Types as types,
-    CTypes: CTypes as ctypes,
     Intefaces: Interfaces as interfaces,
     Ref: String as variable,
 );
@@ -1292,6 +1291,7 @@ named_or!(rootelements: RootElements =>
     TypeOperatorMapping: TypeOperatorMapping as typeoperatormapping,
     Functions: Functions as functions,
     Types: Types as types,
+    CTypes: CTypes as ctypes,
     ConstDeclaration: ConstDeclaration as constdeclaration,
     Interfaces: Interfaces as interfaces,
 );

--- a/alan/src/program/scope.rs
+++ b/alan/src/program/scope.rs
@@ -62,45 +62,45 @@ impl<'a> Scope<'a> {
                         let res = CType::from_ast(s, t, true)?;
                         s = res.0;
                     }
-                    parse::Exportable::CTypes(c) => {
-                        // For now this is just declaring in the Alan source code the compile-time
-                        // types that can be used, and is simply a special kind of documentation.
-                        // *Only* the root scope is allowed to use this syntax, and I cannot imagine
-                        // any other way, since the compiler needs to exactly match what is declared.
-                        // So we return an error if they're encountered outside of the root scope and
-                        // simply verify that each `ctype` we encounter is one of a set the compiler
-                        // expects to exist. Later when `cfn` is implemented these will be loaded up
-                        // for verification of the meta-typing of the compile-time functions.
-                        // This is also an exception in that it is *only* allowed to be exported
-                        // (from the root scope) and can't be hidden, as all code will need these
-                        // to construct their own types.
-                        if !is_root {
-                            return Err("ctypes can only be defined in the compiler internals".into());
-                        }
-                        match c.name.as_str() {
-                            "Type" | "Generic" | "Int" | "Float" | "Bool" | "String" => {
-                                /* Do nothing for the 'structural' types */
-                            }
-                            g @ ("Group" | "Infix" | "Prefix" | "Method" | "Property" | "Cast"
-                            | "Own" | "Deref" | "Mut" | "Rust" | "Node" | "From" | "Array"
-                            | "Fail" | "Neg" | "Len" | "Size" | "FileStr" | "Env" | "EnvExists"
-                            | "Not") => s = CType::from_generic(s, g, 1),
-                            g @ ("Function" | "Call" | "Dependency" | "Import" | "Field"
-                            | "Prop" | "Buffer" | "Add" | "Sub" | "Mul" | "Div" | "Mod"
-                            | "Pow" | "Min" | "Max" | "Concat" | "And" | "Or" | "Xor" | "Nand"
-                            | "Nor" | "Xnor" | "Eq" | "Neq" | "Lt" | "Lte" | "Gt" | "Gte") => s = CType::from_generic(s, g, 2),
-                            g @ ("If" | "Binds" | "Tuple" | "Either" | "AnyOf") => {
-                                // Not kosher in Rust land, but 0 means "as many as we want"
-                                s = CType::from_generic(s, g, 0)
-                            }
-                            unknown => {
-                                panic!("Unknown ctype {} defined in root scope. There's something wrong with the compiler.", unknown);
-                            }
-                        }
-                    }
                     e => eprintln!("TODO: Not yet supported export syntax: {:?}\nLast good parsed lines:\n{:?}\n{:?}", e, ast.body[i - 2], ast.body[i - 1]),
                 },
                 parse::RootElements::Whitespace(_) => { /* Do nothing */ }
+                parse::RootElements::CTypes(c) => {
+                    // For now this is just declaring in the Alan source code the compile-time
+                    // types that can be used, and is simply a special kind of documentation.
+                    // *Only* the root scope is allowed to use this syntax, and I cannot imagine
+                    // any other way, since the compiler needs to exactly match what is declared.
+                    // So we return an error if they're encountered outside of the root scope and
+                    // simply verify that each `ctype` we encounter is one of a set the compiler
+                    // expects to exist. Later when `cfn` is implemented these will be loaded up
+                    // for verification of the meta-typing of the compile-time functions.
+                    // This is also an exception in that it is *only* allowed to be exported
+                    // (from the root scope) and can't be hidden, as all code will need these
+                    // to construct their own types.
+                    if !is_root {
+                        return Err("ctypes can only be defined in the compiler internals".into());
+                    }
+                    match c.name.as_str() {
+                        "Type" | "Generic" | "Int" | "Float" | "Bool" | "String" => {
+                            /* Do nothing for the 'structural' types */
+                        }
+                        g @ ("Group" | "Infix" | "Prefix" | "Method" | "Property" | "Cast"
+                        | "Own" | "Deref" | "Mut" | "Rust" | "Node" | "From" | "Array"
+                        | "Fail" | "Neg" | "Len" | "Size" | "FileStr" | "Env" | "EnvExists"
+                        | "Not") => s = CType::from_generic(s, g, 1),
+                        g @ ("Function" | "Call" | "Dependency" | "Import" | "Field"
+                        | "Prop" | "Buffer" | "Add" | "Sub" | "Mul" | "Div" | "Mod"
+                        | "Pow" | "Min" | "Max" | "Concat" | "And" | "Or" | "Xor" | "Nand"
+                        | "Nor" | "Xnor" | "Eq" | "Neq" | "Lt" | "Lte" | "Gt" | "Gte") => s = CType::from_generic(s, g, 2),
+                        g @ ("If" | "Binds" | "Tuple" | "Either" | "AnyOf") => {
+                            // Not kosher in Rust land, but 0 means "as many as we want"
+                            s = CType::from_generic(s, g, 0)
+                        }
+                        unknown => {
+                            panic!("Unknown ctype {} defined in root scope. There's something wrong with the compiler.", unknown);
+                        }
+                    }
+                }
                 parse::RootElements::Interfaces(_) => {
                     panic!("Interfaces not yet implemented");
                 }

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -6,1351 +6,1386 @@
 /// Type system setup
 
 // Declaration of the types the compiler-time type system is built on
-export ctype Type; // Any kind of concrete type
-export ctype Generic; // Any type that is a generic type (not yet realized into a concrete type)
-export ctype Binds{T}; // A direct reference into the platform language's type system
-export ctype Int; // An integer used *to define a type*, like the length of a fixed array
-export ctype Float; // A float used to define a type. I have no idea why you'd want this, yet
-export ctype Bool; // A bool used to define a type. Heavily used for conditional compilation
-export ctype String; // A string used to define a type. Useful for conditional inclusion of files/code
-export ctype Group{G}; // A grouping of type statements `()`. Useful to allow for tuples of tuples
-export ctype Function{I, O}; // A function type, indicating the input and output of the function
-export ctype Call{N, F}; // A reference to a function call (or method, etc) in the platform language
-export ctype Infix{O}; // A reference to a native infix operation in the platform language
-export ctype Prefix{O}; // A reference to a native prefix operation in the platform language
-export ctype Method{F}; // A reference to a native method in the platform language
-export ctype Property{P}; // A reference to a native property in the platform language
-export ctype Cast{T}; // A reference to a native type in the platform language to cast to
-export ctype Own{T}; // Specifying that the native code needs an owned version of the type
-export ctype Deref{T}; // Specifying that the native code needs an owned version of the type and it is safe to dereference the reference
-export ctype Mut{T}; // Specifying that the function (native or otherwise) needs a mutable reference of the type
-export ctype Dependency{N, V}; // The representation of a dependency (of some form or another). Does nothing on its own
-export ctype Rust{D}; // Specifying that the provided dependency is a Rust dependency.
-export ctype Node{D}; // Specifying that the provided dependency is a Node.js dependency.
-export ctype From{D}; // Pulls the desired value from the dependency. Magically figures out which is needed through compiler trickery.
-export ctype Import{N, D}; // Imports the named value from the dependency.
-export ctype Tuple{A, B}; // A tuple of two (or more) types in a single compound type
-export ctype Field{L, V}; // Labeling a type with a property name. Useful to turn tuples into structs
-export ctype Either{A, B}; // An either type, allowing the value to be from *one* of the specified types, kinda like Rust enums
-export ctype Prop{T, P}; // Extracts the inner type from the outer type by the property name or number
-export ctype AnyOf{A, B}; // The AnyOf type is kinda like a Tuple, in that all sub-types are present, but it only *resolves* into one of these types above it. Useful for choosing the "best" integer, or a particular function by name.
-export ctype Buffer{T, S}; // A buffer type, a pre-allocated, fixed-length array of the specified type the specified amount
-export ctype Array{T}; // An array type, a variable-length array of the specified type the specified amount. This would usually be an stdlib type built in the language itself, but we're just going to re-use the one in the platform language
+ctype Type; // Any kind of concrete type
+ctype Generic; // Any type that is a generic type (not yet realized into a concrete type)
+ctype Binds{T}; // A direct reference into the platform language's type system
+ctype Int; // An integer used *to define a type*, like the length of a fixed array
+ctype Float; // A float used to define a type. I have no idea why you'd want this, yet
+ctype Bool; // A bool used to define a type. Heavily used for conditional compilation
+ctype String; // A string used to define a type. Useful for conditional inclusion of files/code
+ctype Group{G}; // A grouping of type statements `()`. Useful to allow for tuples of tuples
+ctype Function{I, O}; // A function type, indicating the input and output of the function
+ctype Call{N, F}; // A reference to a function call (or method, etc) in the platform language
+ctype Infix{O}; // A reference to a native infix operation in the platform language
+ctype Prefix{O}; // A reference to a native prefix operation in the platform language
+ctype Method{F}; // A reference to a native method in the platform language
+ctype Property{P}; // A reference to a native property in the platform language
+ctype Cast{T}; // A reference to a native type in the platform language to cast to
+ctype Own{T}; // Specifying that the native code needs an owned version of the type
+ctype Deref{T}; // Specifying that the native code needs an owned version of the type and it is safe to dereference the reference
+ctype Mut{T}; // Specifying that the function (native or otherwise) needs a mutable reference of the type
+ctype Dependency{N, V}; // The representation of a dependency (of some form or another). Does nothing on its own
+ctype Rust{D}; // Specifying that the provided dependency is a Rust dependency.
+ctype Node{D}; // Specifying that the provided dependency is a Node.js dependency.
+ctype From{D}; // Pulls the desired value from the dependency. Magically figures out which is needed through compiler trickery.
+ctype Import{N, D}; // Imports the named value from the dependency.
+ctype Tuple{A, B}; // A tuple of two (or more) types in a single compound type
+ctype Field{L, V}; // Labeling a type with a property name. Useful to turn tuples into structs
+ctype Either{A, B}; // An either type, allowing the value to be from *one* of the specified types, kinda like Rust enums
+ctype Prop{T, P}; // Extracts the inner type from the outer type by the property name or number
+ctype AnyOf{A, B}; // The AnyOf type is kinda like a Tuple, in that all sub-types are present, but it only *resolves* into one of these types above it. Useful for choosing the "best" integer, or a particular function by name.
+ctype Buffer{T, S}; // A buffer type, a pre-allocated, fixed-length array of the specified type the specified amount
+ctype Array{T}; // An array type, a variable-length array of the specified type the specified amount. This would usually be an stdlib type built in the language itself, but we're just going to re-use the one in the platform language
 
 // The following `ctype`s don't represent data but instead represent transforms that convert into one of the many ctypes above. (I did not expect to need so many of them.)
-export ctype Fail{M}; // A special type that if ever encountered at compile time causes the compilation to fail with the specified error message. Useful with conditional types
-export ctype Add{A, B}; // Combines the Int or Float types together at compile time into a new Int or Float. Fails if an Int and Float are mixed.
-export ctype Sub{A, B}; // Same, but subtracts them
-export ctype Mul{A, B}; // Multiplication
-export ctype Div{A, B}; // Division
-export ctype Mod{A, B}; // Modulus (remainder)
-export ctype Pow{A, B}; // Exponentiation/Power
-export ctype Min{A, B}; // Minimum value of the two
-export ctype Max{A, B}; // Maximum value of the two
-export ctype Neg{A}; // Negate the value
-export ctype Len{A}; // Returns the length of the input type in terms of the number of elements it contains, which is most useful for Buffers, Tuples, and Either, causes a compiler failure for Arrays, and returns 1 for everything else
-export ctype Size{T}; // Returns the size in bytes of the type in question, if possible, causing a compiler failure otherwise.
-export ctype FileStr{F}; // Read a file and return a string constant, useful for including large strings from a separate, nearby file, or fails if it doesn't exist
-export ctype Concat{A, B}; // Concatenates two strings together at compile time
-export ctype Env{K}; // Read an environment variable at compile time and return a string of the value. Returns an empty string if the key doesn't exist. Intended to be used with...
-export ctype EnvExists{K}; // Returns a boolean if the environment variable key exists at compile time, and...
-export ctype If{C, A, B}; // A conditional type, if C is true, resolves to A, otherwise to B. There's also a simpler version...
-export ctype If{C, T}; // That expects a two-type tuple and extracts the first tuple type for true and the second for false, which can be bound to symbolic syntax
-export ctype Env{K, D}; // Finally, since the majority of the time this is what you'd want, this variant of `Env` takes a default value to use when the key does not exist, making this another conditional type
-export ctype And{A, B}; // Performs a boolean or bitwise AND on the inputs, depending on type
-export ctype Or{A, B}; // Performs a boolean or bitwise OR on the inputs
-export ctype Xor{A, B}; // Performs a boolean or bitwise XOR on the inputs
-export ctype Not{B}; // Inverts the boolean provided
-export ctype Nand{A, B}; // Performs a boolean or bitwise NAND on the inputs
-export ctype Nor{A, B}; // Performs a boolean or bitwise NOR on the inputs
-export ctype Xnor{A, B}; // Performs a boolean or bitwise XNOR on the inputs (same as EQ for booleans)
-export ctype Eq{A, B}; // Returns true if the two types are the same (or are the same int, float, bool, or string), false otherwise
-export ctype Neq{A, B}; // Returns true if the two types are difference
-export ctype Lt{A, B}; // Returns true if A is less than B (and are an int or float)
-export ctype Lte{A, B}; // Returns true if A is less than or equal to B
-export ctype Gt{A, B}; // Returns true if A is greater than B
-export ctype Gte{A, B}; // Returns true if A is greater than or equal to B
+ctype Fail{M}; // A special type that if ever encountered at compile time causes the compilation to fail with the specified error message. Useful with conditional types
+ctype Add{A, B}; // Combines the Int or Float types together at compile time into a new Int or Float. Fails if an Int and Float are mixed.
+ctype Sub{A, B}; // Same, but subtracts them
+ctype Mul{A, B}; // Multiplication
+ctype Div{A, B}; // Division
+ctype Mod{A, B}; // Modulus (remainder)
+ctype Pow{A, B}; // Exponentiation/Power
+ctype Min{A, B}; // Minimum value of the two
+ctype Max{A, B}; // Maximum value of the two
+ctype Neg{A}; // Negate the value
+ctype Len{A}; // Returns the length of the input type in terms of the number of elements it contains, which is most useful for Buffers, Tuples, and Either, causes a compiler failure for Arrays, and returns 1 for everything else
+ctype Size{T}; // Returns the size in bytes of the type in question, if possible, causing a compiler failure otherwise.
+ctype FileStr{F}; // Read a file and return a string constant, useful for including large strings from a separate, nearby file, or fails if it doesn't exist
+ctype Concat{A, B}; // Concatenates two strings together at compile time
+ctype Env{K}; // Read an environment variable at compile time and return a string of the value. Returns an empty string if the key doesn't exist. Intended to be used with...
+ctype EnvExists{K}; // Returns a boolean if the environment variable key exists at compile time, and...
+ctype If{C, A, B}; // A conditional type, if C is true, resolves to A, otherwise to B. There's also a simpler version...
+ctype If{C, T}; // That expects a two-type tuple and extracts the first tuple type for true and the second for false, which can be bound to symbolic syntax
+ctype Env{K, D}; // Finally, since the majority of the time this is what you'd want, this variant of `Env` takes a default value to use when the key does not exist, making this another conditional type
+ctype And{A, B}; // Performs a boolean or bitwise AND on the inputs, depending on type
+ctype Or{A, B}; // Performs a boolean or bitwise OR on the inputs
+ctype Xor{A, B}; // Performs a boolean or bitwise XOR on the inputs
+ctype Not{B}; // Inverts the boolean provided
+ctype Nand{A, B}; // Performs a boolean or bitwise NAND on the inputs
+ctype Nor{A, B}; // Performs a boolean or bitwise NOR on the inputs
+ctype Xnor{A, B}; // Performs a boolean or bitwise XNOR on the inputs (same as EQ for booleans)
+ctype Eq{A, B}; // Returns true if the two types are the same (or are the same int, float, bool, or string), false otherwise
+ctype Neq{A, B}; // Returns true if the two types are difference
+ctype Lt{A, B}; // Returns true if A is less than B (and are an int or float)
+ctype Lte{A, B}; // Returns true if A is less than or equal to B
+ctype Gt{A, B}; // Returns true if A is greater than B
+ctype Gte{A, B}; // Returns true if A is greater than or equal to B
+
+// Defining the operators in the type system; they can be defined before the types themselves
+type infix Function as -> precedence 4; // I -> O, where I is the input and O is the output. With Tuples and Fields you can reconstruct arguments for functions.
+type infix Call as :: precedence 0; // N :: F, where N is the native function (or method) and F is the function type
+type infix Dependency as @ precedence 1; // N @ V, where N is the name of the dependency and V is the version
+type infix Import as <- precedence 0; // N <- D, where N is the name of the value to be imported and D is the dependency to pull it from
+type prefix From as <-- precedence 0; // <- D, where D is the dependency to pull a value or values from, TODO: Switch to <- once disambiguation is fixed
+type infix Tuple as , precedence 0; // A, B, C, ... The tuple type combines with other tuple types to become a larger tuple type. To have a tuple of tuples, you need to `Group` the inner tuple, eg `(a, b), c`
+type infix Field as : precedence 1; // Foo: Bar, let's you specify a property access label for the type, useful for syntactic sugar on a tuple type and the Either type (eventually).
+type infix Either as | precedence 0; // A | B, the type has a singular value from only one of the types at once.
+type infix Prop as . precedence 6; // A.B, returns the sub-type within A referenced by property B. Allows an inverse of a Tuple or Either type, accessed by either the Field name or an integer index
+type infix AnyOf as & precedence 0; // A & B, which can be passed to a function that takes A or B as necessary.
+type infix Buffer as [ precedence 2; // Technically allows `Foo[3` by itself to be valid syntax, but...
+type postfix Self as ] precedence 11; // This one goes to eleven. Technically not necessary, but allows for `Foo[3]` to do the "right thing" and become a buffer of size 3
+type postfix Array as [] precedence 5; // Allows `Foo[]` to do the right thing
+type postfix Maybe as ? precedence 5; // Allows `Foo?` for nullable types. Should this have a precedence of 5?
+type postfix Fallible as ! precedence 5; // Allows `Foo!` for fallible types. Same question on the precedence.
+type infix Add as + precedence 3;
+type infix Sub as - precedence 3;
+type infix Mul as * precedence 4;
+type infix Div as / precedence 4;
+type infix Mod as % precedence 4;
+type infix Pow as ** precedence 5;
+type infix If as :? precedence 1; // C puts this kind of thing as a very high precedence. I'm not sure if I want to follow it. I feel like that would force grouping parens everywhere.
+type infix And as && precedence 4;
+type infix Or as || precedence 3;
+type infix Xor as ^ precedence 3;
+type prefix Not as ~ precedence 5; // TODO: Temporarily change this from ! to ~ until the operator prefix/postfix tiebreaker is updated to accept whichever *works* rather than prefer prefix
+type infix Nand as !& precedence 4;
+type infix Nor as !| precedence 3;
+type infix Xnor as !^ precedence 3;
+type infix Eq as == precedence 1;
+type infix Neq as != precedence 1;
+type infix Lt as < precedence 1;
+type infix Lte as <= precedence 1;
+type infix Gt as > precedence 1;
+type infix Gte as >= precedence 1;
 
 // Environment variable-derived boolean constants to be used by the root scope (or your own code)
-export type Test = Eq{Env{"ALAN_TARGET"}, "test"};
-export type Release = Eq{Env{"ALAN_TARGET"}, "release"};
-export type Debug = Eq{Env{"ALAN_TARGET"}, "debug"};
-export type Rs = Eq{Env{"ALAN_OUTPUT_LANG"}, "rs"};
-export type Js = Eq{Env{"ALAN_OUTPUT_LANG"}, "js"};
+type Test = Env{"ALAN_TARGET"} == "test";
+type Release = Env{"ALAN_TARGET"} == "release";
+type Debug = Env{"ALAN_TARGET"} == "debug";
+type Rs = Env{"ALAN_OUTPUT_LANG"} == "rs";
+type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
-export type{Rs} RootBacking = Rust{Dependency{"alan_std", "https://github.com/alantech/alan.git"}};
-export type{Js} RootBacking = Node{Dependency{"alan_std", "https://github.com/alantech/alan.git"}};
+type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
 
 // Defining derived types
-export type void = ();
-export type Self{T} = T;
-export type{Rs} Error = Binds{Import{"alan_std::AlanError", RootBacking}};
-export type{Js} Error = Binds{Import{"alan_std.AlanError", RootBacking}};
-export type Fallible{T} = Either{T, Error};
-export type Maybe{T} = Either{T, ()};
-
-// Defining the operators in the type system
-export type infix Function as -> precedence 4; // I -> O, where I is the input and O is the output. With Tuples and Fields you can reconstruct arguments for functions.
-export type infix Call as :: precedence 0; // N :: F, where N is the native function (or method) and F is the function type
-export type infix Dependency as @ precedence 1; // N @ V, where N is the name of the dependency and V is the version
-export type infix Import as <- precedence 0; // N <- D, where N is the name of the value to be imported and D is the dependency to pull it from
-export type prefix From as <-- precedence 0; // <- D, where D is the dependency to pull a value or values from, TODO: Switch to <- once disambiguation is fixed
-export type infix Tuple as , precedence 0; // A, B, C, ... The tuple type combines with other tuple types to become a larger tuple type. To have a tuple of tuples, you need to `Group` the inner tuple, eg `(a, b), c`
-export type infix Field as : precedence 1; // Foo: Bar, let's you specify a property access label for the type, useful for syntactic sugar on a tuple type and the Either type (eventually).
-export type infix Either as | precedence 0; // A | B, the type has a singular value from only one of the types at once.
-export type infix Prop as . precedence 6; // A.B, returns the sub-type within A referenced by property B. Allows an inverse of a Tuple or Either type, accessed by either the Field name or an integer index
-export type infix AnyOf as & precedence 0; // A & B, which can be passed to a function that takes A or B as necessary.
-export type infix Buffer as [ precedence 2; // Technically allows `Foo[3` by itself to be valid syntax, but...
-export type postfix Self as ] precedence 11; // This one goes to eleven. Technically not necessary, but allows for `Foo[3]` to do the "right thing" and become a buffer of size 3
-export type postfix Array as [] precedence 5; // Allows `Foo[]` to do the right thing
-export type postfix Maybe as ? precedence 5; // Allows `Foo?` for nullable types. Should this have a precedence of 5?
-export type postfix Fallible as ! precedence 5; // Allows `Foo!` for fallible types. Same question on the precedence.
-export type infix Add as + precedence 3;
-export type infix Sub as - precedence 3;
-export type infix Mul as * precedence 4;
-export type infix Div as / precedence 4;
-export type infix Mod as % precedence 4;
-export type infix Pow as ** precedence 5;
-export type infix If as ?? precedence 1; // C puts this kind of thing as a very high precedence. I'm not sure if I want to follow it. I feel like that would force grouping parens everywhere.
-export type infix And as && precedence 4;
-export type infix Or as || precedence 3;
-export type infix Xor as ^ precedence 3;
-export type prefix Not as ~ precedence 5; // TODO: Temporarily change this from ! to ~ until the operator prefix/postfix tiebreaker is updated to accept whichever *works* rather than prefer prefix
-export type infix Nand as !& precedence 4;
-export type infix Nor as !| precedence 3;
-export type infix Xnor as !^ precedence 3;
-export type infix Eq as == precedence 1;
-export type infix Neq as != precedence 1;
-export type infix Lt as < precedence 1;
-export type infix Lte as <= precedence 1;
-export type infix Gt as > precedence 1;
-export type infix Gte as >= precedence 1;
-
-// Binding the integer types
-export type{Rs} i8 = Binds{"i8"};
-export type{Js} i8 = Binds{"alan_std.I8" <- RootBacking};
-export type{Rs} i16 = Binds{"i16"};
-export type{Js} i16 = Binds{"alan_std.I16" <- RootBacking};
-export type{Rs} i32 = Binds{"i32"};
-export type{Js} i32 = Binds{"alan_std.I32" <- RootBacking};
-export type{Rs} i64 = Binds{"i64"};
-export type{Js} i64 = Binds{"alan_std.I64" <- RootBacking};
-export type{Rs} u8 = Binds{"u8"};
-export type{Js} u8 = Binds{"alan_std.U8" <- RootBacking};
-export type{Rs} u16 = Binds{"u16"};
-export type{Js} u16 = Binds{"alan_std.U16" <- RootBacking};
-export type{Rs} u32 = Binds{"u32"};
-export type{Js} u32 = Binds{"alan_std.U32" <- RootBacking};
-export type{Rs} u64 = Binds{"u64"};
-export type{Js} u64 = Binds{"alan_std.U64" <- RootBacking};
+type void = ();
+type Self{T} = T;
+type{Rs} Error = Binds{"alan_std::AlanError" <- RootBacking};
+type{Js} Error = Binds{"alan_std.AlanError" <- RootBacking};
+type Fallible{T} = T | Error;
+type Maybe{T} = T | ();
 
 // Binding the float types
-export type{Rs} f32 = Binds{"f32"};
-export type{Js} f32 = Binds{"alan_std.F32" <- RootBacking};
-export type{Rs} f64 = Binds{"f64"};
-export type{Js} f64 = Binds{"alan_std.F64" <- RootBacking};
+type{Rs} f32 = Binds{"f32"};
+type{Js} f32 = Binds{"alan_std.F32" <- RootBacking};
+type{Rs} f64 = Binds{"f64"};
+type{Js} f64 = Binds{"alan_std.F64" <- RootBacking};
+
+// Binding the integer types
+type{Rs} u8 = Binds{"u8"};
+type{Js} u8 = Binds{"alan_std.U8" <- RootBacking};
+type{Rs} u16 = Binds{"u16"};
+type{Js} u16 = Binds{"alan_std.U16" <- RootBacking};
+type{Rs} u32 = Binds{"u32"};
+type{Js} u32 = Binds{"alan_std.U32" <- RootBacking};
+type{Rs} u64 = Binds{"u64"};
+type{Js} u64 = Binds{"alan_std.U64" <- RootBacking};
+type{Rs} i8 = Binds{"i8"};
+type{Js} i8 = Binds{"alan_std.I8" <- RootBacking};
+type{Rs} i16 = Binds{"i16"};
+type{Js} i16 = Binds{"alan_std.I16" <- RootBacking};
+type{Rs} i32 = Binds{"i32"};
+type{Js} i32 = Binds{"alan_std.I32" <- RootBacking};
+type{Rs} i64 = Binds{"i64"};
+type{Js} i64 = Binds{"alan_std.I64" <- RootBacking};
 
 // Binding the string types
-export type{Rs} string = Binds{"String"};
-export type{Js} string = Binds{"alan_std.Str" <- RootBacking};
+type{Rs} string = Binds{"String"};
+type{Js} string = Binds{"alan_std.Str" <- RootBacking};
 
 // Binding the boolean types
-export type{Rs} bool = Binds{"bool"};
-export type{Js} bool = Binds{"alan_std.Bool" <- RootBacking};
+type{Rs} bool = Binds{"bool"};
+type{Js} bool = Binds{"alan_std.Bool" <- RootBacking};
 
 // Binding the exit code type
-export type{Rs} ExitCode = Binds{"std::process::ExitCode"};
-export type{Js} ExitCode = Binds{"Number"};
+type{Rs} ExitCode = Binds{"std::process::ExitCode"};
+type{Js} ExitCode = Binds{"Number"};
 
 // Binding the time types
-export type{Rs} Instant = Binds{"std::time::Instant"};
-export type{Rs} Duration = Binds{"std::time::Duration"};
-export type{Js} Performance = Binds{"Performance"}
+type{Rs} Instant = Binds{"std::time::Instant"};
+type{Rs} Duration = Binds{"std::time::Duration"};
+type{Js} Performance = Binds{"Performance"}
 
 // Binding the uuid type
-export type{Rs} uuid = Binds{"alan_std::Uuid" <- RootBacking};
-export type{Js} uuid = Binds{"alan_std.uuidv4" <- RootBacking};
+type{Rs} uuid = Binds{"alan_std::Uuid" <- RootBacking};
+type{Js} uuid = Binds{"alan_std.uuidv4" <- RootBacking};
 // TODO: JS variant
 
 // Binding the Dict and Set types
-export type{Rs} Dict{K, V} = Binds{"alan_std::OrderedHashMap" <- RootBacking, K, V};
-export type{Js} Dict{K, V} = Binds{"Map", K, V};
-export type{Rs} Set{V} = Binds{"std::collections::HashSet", V};
-export type{Js} Set{V} = Binds{"Set", V};
+type{Rs} Dict{K, V} = Binds{"alan_std::OrderedHashMap" <- RootBacking, K, V};
+type{Js} Dict{K, V} = Binds{"Map", K, V};
+type{Rs} Set{V} = Binds{"std::collections::HashSet", V};
+type{Js} Set{V} = Binds{"Set", V};
 
 // Basic trig constants (this language is meant for GPGPU, this makes sense in the root scope)
-export const e = 2.718281828459045;
-export const pi = 3.141592653589793;
-export const tau = 6.283185307179586;
+const e = 2.718281828459045;
+const pi = 3.141592653589793;
+const tau = 6.283185307179586;
+
+/// Built-in operator definitions; can be defined before the functions are
+infix add as + precedence 3;
+infix sub as - precedence 3;
+prefix neg as - precedence 6;
+infix mul as * precedence 4;
+infix div as / precedence 4;
+infix mod as % precedence 4;
+// export infix template as % precedence 4;
+infix pow as ** precedence 5;
+infix and as & precedence 4;
+infix and as && precedence 4;
+infix or as | precedence 3;
+infix or as || precedence 3;
+infix getOr as ?? precedence 3;
+postfix getOrExit as !! precedence 3;
+postfix Maybe as ? precedence 5;
+postfix Fallible as ! precedence 5;
+infix xor as ^ precedence 3;
+prefix not as ! precedence 5;
+infix nand as !& precedence 4;
+infix nor as !| precedence 3;
+infix xnor as !^ precedence 3;
+infix eq as == precedence 1;
+infix neq as != precedence 1;
+infix lt as < precedence 1;
+infix lte as <= precedence 1;
+infix gt as > precedence 1;
+infix gte as >= precedence 1;
+prefix len as # precedence 1; // TODO: Is this useful?
+infix shl as << precedence 2;
+infix shr as >> precedence 2;
+infix wrl as <<< precedence 2;
+infix wrr as >>> precedence 2;
+infix store as = precedence 0;
 
 /// Functions for (potentially) every type
-export fn{Rs} clone{T} (v: T) -> T = {Method{"clone"} :: T -> T}(v);
+fn{Rs} clone{T} (v: T) -> T = {Method{"clone"} :: T -> T}(v);
 // TODO: This needs to be turned into a JS function that's bound
-export fn{Js} clone{T} (v: T) -> T = {"(function clone(t) { if (t instanceof Array) { return t.map(clone); } else if (t.build instanceof Function) { return t.build(t.val); } else if (t instanceof Set) { return t.union(new Set()); } else { return structuredClone(t); } })" :: T -> T}(v);
+fn{Js} clone{T} (v: T) -> T = {"(function clone(t) { if (t instanceof Array) { return t.map(clone); } else if (t.build instanceof Function) { return t.build(t.val); } else if (t instanceof Set) { return t.union(new Set()); } else { return structuredClone(t); } })" :: T -> T}(v);
 // TODO: The "proper" way to hash this consistently for all types is to decompose the input type
 // into the various primitive types of Alan and then have hashing rules for each of them, which
 // may themselves decompose, etc. This might be doable in Alan code on top of specialized hashing
 // functions in Rust (as partially implemented here) or it might be better done as a special `hash`
 // function created by the compiler for the specific type *if* ever actually used, walking the
 // CType tree to determine the correct code to run. In either case, this is "good enough" for now.
-export fn{Rs} hash{T} "alan_std::hash" <- RootBacking :: T -> i64;
-export fn{Rs} hash{T} "alan_std::hasharray" <- RootBacking :: T[] -> i64;
-export fn{Rs} hash "alan_std::hashstring" <- RootBacking :: string -> i64;
+fn{Rs} hash{T} "alan_std::hash" <- RootBacking :: T -> i64;
+fn{Rs} hash{T} "alan_std::hasharray" <- RootBacking :: T[] -> i64;
+fn{Rs} hash "alan_std::hashstring" <- RootBacking :: string -> i64;
 // TODO: JS variant for `hash`
-export fn void{T}(v: T) -> void {}
-export fn void() -> void {}
-export fn{Rs} store{T} (a: Mut{T}, b: T) -> T = {"std::mem::replace" :: (Mut{T}, Own{T}) -> T}(a, b);
-export fn{Js} store{T} (a: Mut{T}, b: T) -> T = {"((a, b) => Object.keys(b).forEach((k) => a[k] = b[k]))" :: (Mut{T}, T) -> T}(a, b);
+fn void{T}(v: T) -> void {}
+fn void() -> void {}
+fn{Rs} store{T} (a: Mut{T}, b: T) -> T = {"std::mem::replace" :: (Mut{T}, Own{T}) -> T}(a, b);
+fn{Js} store{T} (a: Mut{T}, b: T) -> T = {"((a, b) => Object.keys(b).forEach((k) => a[k] = b[k]))" :: (Mut{T}, T) -> T}(a, b);
 
 /// Fallible, Maybe, and Either functions
-export fn{Rs} Maybe{T}(v: T!) = {Method{"ok"} :: T! -> T?}(v);
-export fn{Rs} Fallible{T}(v: T?, e: Error) = {Method{"ok_or"} :: (T?, Error) -> T!}(v, e);
-export fn getOr{T, U}(v: U, d: T) = {T}(v).getOr(d);
-export fn{Rs} getOr{T} (v: T?, d: T) = {Method{"unwrap_or"} :: (Own{T?}, Own{T}) -> T}(v, d);
-export fn{Js} getOr{T} (v: T?, d: T) = {"((v, d) => v ?? d)" :: (T?, T) -> T}(v, d);
-export fn{Rs} getOr{T} (v: T!, d: T) = {Method{"unwrap_or"} :: (Own{T!}, Own{T}) -> T}(v, d);
-export fn{Js} getOr{T} (v: T!, d: T) = {"((v, d) => v instanceof alan_std.AlanError ? d : v)" :: (T!, T) -> T}(v, d);
-export fn{Rs} getOrExit{T} (v: T!) = {Method{"unwrap"} :: Own{T!} -> T}(v);
-export fn{Js} getOrExit{T} (v: T!) = {"((a) => { if (!(a instanceof alan_std.AlanError)) { return a; } else { process.exit(101); } })" :: T! -> T}(v);
-export fn{Rs} getOrExit{T} (v: T?) = {Method{"unwrap"} :: Own{T?} -> T}(v);
-export fn{Js} getOrExit{T} (v: T?) = {"((a) => a)" :: T? -> T}(v);
-export fn{Js} getOrExit{T} (v: T?) = {"((a) => { if (a !== null && a !== undefined) { return a; } else { process.exit(101); } })" :: T? -> T}(v);
-export fn{Rs} Error{T} (e: string) = {"Err" :: Own{Error} -> T!}(
+fn{Rs} Maybe{T}(v: T!) = {Method{"ok"} :: T! -> T?}(v);
+fn{Rs} Fallible{T}(v: T?, e: Error) = {Method{"ok_or"} :: (T?, Error) -> T!}(v, e);
+fn getOr{T, U}(v: U, d: T) = {T}(v) ?? d;
+fn{Rs} getOr{T} (v: T?, d: T) = {Method{"unwrap_or"} :: (Own{T?}, Own{T}) -> T}(v, d);
+fn{Js} getOr{T} (v: T?, d: T) = {"((v, d) => v ?? d)" :: (T?, T) -> T}(v, d);
+fn{Rs} getOr{T} (v: T!, d: T) = {Method{"unwrap_or"} :: (Own{T!}, Own{T}) -> T}(v, d);
+fn{Js} getOr{T} (v: T!, d: T) = {"((v, d) => v instanceof alan_std.AlanError ? d : v)" :: (T!, T) -> T}(v, d);
+fn{Rs} getOrExit{T} (v: T!) = {Method{"unwrap"} :: Own{T!} -> T}(v);
+fn{Js} getOrExit{T} (v: T!) = {"((a) => { if (!(a instanceof alan_std.AlanError)) { return a; } else { process.exit(101); } })" :: T! -> T}(v);
+fn{Rs} getOrExit{T} (v: T?) = {Method{"unwrap"} :: Own{T?} -> T}(v);
+fn{Js} getOrExit{T} (v: T?) = {"((a) => a)" :: T? -> T}(v);
+fn{Js} getOrExit{T} (v: T?) = {"((a) => { if (a !== null && a !== undefined) { return a; } else { process.exit(101); } })" :: T? -> T}(v);
+fn{Rs} Error{T} (e: string) = {"Err" :: Own{Error} -> T!}(
   {Method{"into"} :: Own{string} -> Error}(e));
-export fn{Rs} Error (e: string) = {Method{"into"} :: Own{string} -> Error}(e);
-export fn{Js} Error{T} "new alan_std.AlanError" <- RootBacking :: string -> T!;
-export fn{Js} Error "new alan_std.AlanError" <- RootBacking :: string -> Error;
-export fn{Rs} exists{T} (m: T?) = {Method{"is_some"} :: T? -> bool}(m);
-export fn{Js} exists{T} (m: T?) = {"((a) => new alan_std.Bool(a !== null))" <- RootBacking :: T? -> bool}(m);
-export fn{Rs} string(e: Error) = {"format!" :: ("{}", Error) -> string}(e);
-export fn{Js} string Property{"message"} :: Error -> string;
+fn{Rs} Error (e: string) = {Method{"into"} :: Own{string} -> Error}(e);
+fn{Js} Error{T} "new alan_std.AlanError" <- RootBacking :: string -> T!;
+fn{Js} Error "new alan_std.AlanError" <- RootBacking :: string -> Error;
+fn{Rs} exists{T} (m: T?) = {Method{"is_some"} :: T? -> bool}(m);
+fn{Js} exists{T} (m: T?) = {"((a) => new alan_std.Bool(a !== null))" <- RootBacking :: T? -> bool}(m);
+fn{Rs} string(e: Error) = {"format!" :: ("{}", Error) -> string}(e);
+fn{Js} string Property{"message"} :: Error -> string;
 
 /// Primitive type casting functions
-export fn i8(i: i8) = i;
-export fn{Rs} i8 Cast{"i8"} :: Deref{i16} -> i8;
-export fn{Js} i8 "new alan_std.I8" <- RootBacking :: i16 -> i8;
-export fn{Rs} i8 Cast{"i8"} :: Deref{i32} -> i8;
-export fn{Js} i8 "new alan_std.I8" <- RootBacking :: i32 -> i8;
-export fn{Rs} i8 Cast{"i8"} :: Deref{i64} -> i8;
-export fn{Js} i8 "new alan_std.I8" <- RootBacking :: i64 -> i8;
-export fn{Rs} i8 Cast{"i8"} :: Deref{u8} -> i8;
-export fn{Js} i8 "new alan_std.I8" <- RootBacking :: u8 -> i8;
-export fn{Rs} i8 Cast{"i8"} :: Deref{u16} -> i8;
-export fn{Js} i8 "new alan_std.I8" <- RootBacking :: u16 -> i8;
-export fn{Rs} i8 Cast{"i8"} :: Deref{u32} -> i8;
-export fn{Js} i8 "new alan_std.I8" <- RootBacking :: u32 -> i8;
-export fn{Rs} i8 Cast{"i8"} :: Deref{u64} -> i8;
-export fn{Js} i8 "new alan_std.I8" <- RootBacking :: u64 -> i8;
-export fn{Rs} i8 Cast{"i8"} :: Deref{f32} -> i8;
-export fn{Js} i8 "((f) => new alan_std.I8(Math.floor(f.val)))" <- RootBacking :: f32 -> i8;
-export fn{Rs} i8 Cast{"i8"} :: Deref{f64} -> i8;
-export fn{Js} i8 "((f) => new alan_std.I8(Math.floor(f.val)))" <- RootBacking :: f64 -> i8;
+fn{Rs} f32 Cast{"f32"} :: Deref{i8} -> f32;
+fn{Js} f32 "new alan_std.F32" <- RootBacking :: i8 -> f32;
+fn{Rs} f32 Cast{"f32"} :: Deref{i16} -> f32;
+fn{Js} f32 "new alan_std.F32" <- RootBacking :: i16 -> f32;
+fn{Rs} f32 Cast{"f32"} :: Deref{i32} -> f32;
+fn{Js} f32 "new alan_std.F32" <- RootBacking :: i32 -> f32;
+fn{Rs} f32 Cast{"f32"} :: Deref{i64} -> f32;
+fn{Js} f32 "new alan_std.F32" <- RootBacking :: i64 -> f32;
+fn{Rs} f32 Cast{"f32"} :: Deref{u8} -> f32;
+fn{Js} f32 "new alan_std.F32" <- RootBacking :: u8 -> f32;
+fn{Rs} f32 Cast{"f32"} :: Deref{u16} -> f32;
+fn{Js} f32 "new alan_std.F32" <- RootBacking :: u16 -> f32;
+fn{Rs} f32 Cast{"f32"} :: Deref{u32} -> f32;
+fn{Js} f32 "new alan_std.F32" <- RootBacking :: u32 -> f32;
+fn{Rs} f32 Cast{"f32"} :: Deref{u64} -> f32;
+fn{Js} f32 "new alan_std.F32" <- RootBacking :: u64 -> f32;
+fn f32(f: f32) = f;
+fn{Rs} f32 Cast{"f32"} :: Deref{f64} -> f32;
+fn{Js} f32 "new alan_std.F32" <- RootBacking :: f64 -> f32;
+fn{Rs} f32 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> f32!;
+fn{Js} f32 "((s) => { let f = parseFloat(s.val); if (Number.isNaN(f)) { return alan_std.nanToError(f); } else { return new alan_std.F32(f); } })" :: string -> f32!;
+
+fn{Rs} f64 Cast{"f64"} :: Deref{i8} -> f64;
+fn{Js} f64 "new alan_std.F64" <- RootBacking :: i8 -> f64;
+fn{Rs} f64 Cast{"f64"} :: Deref{i16} -> f64;
+fn{Js} f64 "new alan_std.F64" <- RootBacking :: i16 -> f64;
+fn{Rs} f64 Cast{"f64"} :: Deref{i32} -> f64;
+fn{Js} f64 "new alan_std.F64" <- RootBacking :: i32 -> f64;
+fn{Rs} f64 Cast{"f64"} :: Deref{i64} -> f64;
+fn{Js} f64 "new alan_std.F64" <- RootBacking :: i64 -> f64;
+fn{Rs} f64 Cast{"f64"} :: Deref{u8} -> f64;
+fn{Js} f64 "new alan_std.F64" <- RootBacking :: u8 -> f64;
+fn{Rs} f64 Cast{"f64"} :: Deref{u16} -> f64;
+fn{Js} f64 "new alan_std.F64" <- RootBacking :: u16 -> f64;
+fn{Rs} f64 Cast{"f64"} :: Deref{u32} -> f64;
+fn{Js} f64 "new alan_std.F64" <- RootBacking :: u32 -> f64;
+fn{Rs} f64 Cast{"f64"} :: Deref{u64} -> f64;
+fn{Js} f64 "new alan_std.F64" <- RootBacking :: u64 -> f64;
+fn{Rs} f64 Cast{"f64"} :: Deref{f32} -> f64;
+fn{Js} f64 "new alan_std.F64" <- RootBacking :: f32 -> f64;
+fn f64(f: f64) = f;
+fn{Rs} f64 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> f64!;
+fn{Js} f64 "((s) => { let f = parseFloat(s.val); if (Number.isNaN(f)) { return alan_std.nanToError(f); } else { return new alan_std.F32(f); } })" :: string -> f64!;
+
+fn{Rs} u8 Cast{"u8"} :: Deref{i8} -> u8;
+fn{Js} u8 "new alan_std.U8" <- RootBacking :: i8 -> u8;
+fn{Rs} u8 Cast{"u8"} :: Deref{i16} -> u8;
+fn{Js} u8 "new alan_std.U8" <- RootBacking :: i16 -> u8;
+fn{Rs} u8 Cast{"u8"} :: Deref{i32} -> u8;
+fn{Js} u8 "new alan_std.U8" <- RootBacking :: i32 -> u8;
+fn{Rs} u8 Cast{"u8"} :: Deref{i64} -> u8;
+fn{Js} u8 "new alan_std.U8" <- RootBacking :: i64 -> u8;
+fn u8(i: u8) = i;
+fn{Rs} u8 Cast{"u8"} :: Deref{u16} -> u8;
+fn{Js} u8 "new alan_std.U8" <- RootBacking :: u16 -> u8;
+fn{Rs} u8 Cast{"u8"} :: Deref{u32} -> u8;
+fn{Js} u8 "new alan_std.U8" <- RootBacking :: u32 -> u8;
+fn{Rs} u8 Cast{"u8"} :: Deref{u64} -> u8;
+fn{Js} u8 "new alan_std.U8" <- RootBacking :: u64 -> u8;
+fn{Rs} u8 Cast{"u8"} :: Deref{f32} -> u8;
+fn{Js} u8 "((f) => new alan_std.U8(Math.floor(f.val)))" <- RootBacking :: f32 -> u8;
+fn{Rs} u8 Cast{"u8"} :: Deref{f64} -> u8;
+fn{Js} u8 "((f) => new alan_std.U8(Math.floor(f.val)))" <- RootBacking :: f64 -> u8;
+fn{Rs} u8 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> u8!;
+fn{Js} u8 "((s) => { let v = parseInt(s.val); if (Number.isNaN(v)) { return new alan_std.AlanError(new alan_std.Str('Not a Number')); } else { return new alan_std.U8(v); } })" <- RootBacking :: string -> u8!;
+
+fn{Rs} u16 Cast{"u16"} :: Deref{i8} -> u16;
+fn{Js} u16 "new alan_std.U16" <- RootBacking :: i8 -> u16;
+fn{Rs} u16 Cast{"u16"} :: Deref{i16} -> u16;
+fn{Js} u16 "new alan_std.U16" <- RootBacking :: i16 -> u16;
+fn{Rs} u16 Cast{"u16"} :: Deref{i32} -> u16;
+fn{Js} u16 "new alan_std.U16" <- RootBacking :: i32 -> u16;
+fn{Rs} u16 Cast{"u16"} :: Deref{i64} -> u16;
+fn{Js} u16 "new alan_std.U16" <- RootBacking :: i64 -> u16;
+fn{Rs} u16 Cast{"u16"} :: Deref{u8} -> u16;
+fn{Js} u16 "new alan_std.U16" <- RootBacking :: u8 -> u16;
+fn u16(i: u16) = i;
+fn{Rs} u16 Cast{"u16"} :: Deref{u32} -> u16;
+fn{Js} u16 "new alan_std.U16" <- RootBacking :: u32 -> u16;
+fn{Rs} u16 Cast{"u16"} :: Deref{u64} -> u16;
+fn{Js} u16 "new alan_std.U16" <- RootBacking :: u64 -> u16;
+fn{Rs} u16 Cast{"u16"} :: Deref{f32} -> u16;
+fn{Js} u16 "((f) => new alan_std.U16(Math.floor(f.val)))" <- RootBacking :: f32 -> u16;
+fn{Rs} u16 Cast{"u16"} :: Deref{f64} -> u16;
+fn{Js} u16 "((f) => new alan_std.U16(Math.floor(f.val)))" <- RootBacking :: f64 -> u16;
+fn{Rs} u16 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> u16!;
+fn{Js} u16 "((s) => { let v = parseInt(s.val); if (Number.isNaN(v)) { return new alan_std.AlanError(new alan_std.Str('Not a Number')); } else { return new alan_std.U16(v); } })" <- RootBacking :: string -> u16!;
+
+fn{Rs} u32 Cast{"u32"} :: Deref{i8} -> u32;
+fn{Js} u32 "new alan_std.U32" <- RootBacking :: i8 -> u32;
+fn{Rs} u32 Cast{"u32"} :: Deref{i16} -> u32;
+fn{Js} u32 "new alan_std.U32" <- RootBacking :: i16 -> u32;
+fn{Rs} u32 Cast{"u32"} :: Deref{i32} -> u32;
+fn{Js} u32 "new alan_std.U32" <- RootBacking :: i32 -> u32;
+fn{Rs} u32 Cast{"u32"} :: Deref{i64} -> u32;
+fn{Js} u32 "new alan_std.U32" <- RootBacking :: i64 -> u32;
+fn{Rs} u32 Cast{"u32"} :: Deref{u8} -> u32;
+fn{Js} u32 "new alan_std.U32" <- RootBacking :: u8 -> u32;
+fn{Rs} u32 Cast{"u32"} :: Deref{u16} -> u32;
+fn{Js} u32 "new alan_std.U32" <- RootBacking :: u16 -> u32;
+fn u32(i: u32) = i;
+fn{Rs} u32 Cast{"u32"} :: Deref{u64} -> u32;
+fn{Js} u32 "new alan_std.U32" <- RootBacking :: u64 -> u32;
+fn{Rs} u32 Cast{"u32"} :: Deref{f32} -> u32;
+fn{Js} u32 "((f) => new alan_std.U32(Math.floor(f.val)))" <- RootBacking :: f32 -> u32;
+fn{Rs} u32 Cast{"u32"} :: Deref{f64} -> u32;
+fn{Js} u32 "((f) => new alan_std.U32(Math.floor(f.val)))" <- RootBacking :: f64 -> u32;
+fn{Rs} u32 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> u32!;
+fn{Js} u32 "((s) => { let v = parseInt(s.val); if (Number.isNaN(v)) { return new alan_std.AlanError(new alan_std.Str('Not a Number')); } else { return new alan_std.U32(v); } })" <- RootBacking :: string -> u32!;
+
+fn{Rs} u64 Cast{"u64"} :: Deref{i8} -> u64;
+fn{Js} u64 "new alan_std.U64" <- RootBacking :: i8 -> u64;
+fn{Rs} u64 Cast{"u64"} :: Deref{i16} -> u64;
+fn{Js} u64 "new alan_std.U64" <- RootBacking :: i16 -> u64;
+fn{Rs} u64 Cast{"u64"} :: Deref{i32} -> u64;
+fn{Js} u64 "new alan_std.U64" <- RootBacking :: i32 -> u64;
+fn{Rs} u64 Cast{"u64"} :: Deref{i64} -> u64;
+fn{Js} u64 "new alan_std.U64" <- RootBacking :: i64 -> u64;
+fn{Rs} u64 Cast{"u64"} :: Deref{u8} -> u64;
+fn{Js} u64 "new alan_std.U64" <- RootBacking :: u8 -> u64;
+fn{Rs} u64 Cast{"u64"} :: Deref{u16} -> u64;
+fn{Js} u64 "new alan_std.U64" <- RootBacking :: u16 -> u64;
+fn{Rs} u64 Cast{"u64"} :: Deref{u32} -> u64;
+fn{Js} u64 "new alan_std.U64" <- RootBacking :: u32 -> u64;
+fn u64(u: u64) = u;
+fn{Rs} u64 Cast{"u64"} :: Deref{f32} -> u64;
+fn{Js} u64 "((f) => new alan_std.U64(Math.floor(f.val)))" <- RootBacking :: f32 -> u64;
+fn{Rs} u64 Cast{"u64"} :: Deref{f64} -> u64;
+fn{Js} u64 "((f) => new alan_std.U64(Math.floor(f.val)))" <- RootBacking :: f64 -> u64;
+fn{Rs} u64 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> u64!;
+fn{Js} u64 "((s) => { try { return new alan_std.U64(BigInt(s.val)) } catch (e) { return new alan_std.AlanError(new alan_std.Str(e.message)); } })" <- RootBacking :: string -> u64!;
+
+fn i8(i: i8) = i;
+fn{Rs} i8 Cast{"i8"} :: Deref{i16} -> i8;
+fn{Js} i8 "new alan_std.I8" <- RootBacking :: i16 -> i8;
+fn{Rs} i8 Cast{"i8"} :: Deref{i32} -> i8;
+fn{Js} i8 "new alan_std.I8" <- RootBacking :: i32 -> i8;
+fn{Rs} i8 Cast{"i8"} :: Deref{i64} -> i8;
+fn{Js} i8 "new alan_std.I8" <- RootBacking :: i64 -> i8;
+fn{Rs} i8 Cast{"i8"} :: Deref{u8} -> i8;
+fn{Js} i8 "new alan_std.I8" <- RootBacking :: u8 -> i8;
+fn{Rs} i8 Cast{"i8"} :: Deref{u16} -> i8;
+fn{Js} i8 "new alan_std.I8" <- RootBacking :: u16 -> i8;
+fn{Rs} i8 Cast{"i8"} :: Deref{u32} -> i8;
+fn{Js} i8 "new alan_std.I8" <- RootBacking :: u32 -> i8;
+fn{Rs} i8 Cast{"i8"} :: Deref{u64} -> i8;
+fn{Js} i8 "new alan_std.I8" <- RootBacking :: u64 -> i8;
+fn{Rs} i8 Cast{"i8"} :: Deref{f32} -> i8;
+fn{Js} i8 "((f) => new alan_std.I8(Math.floor(f.val)))" <- RootBacking :: f32 -> i8;
+fn{Rs} i8 Cast{"i8"} :: Deref{f64} -> i8;
+fn{Js} i8 "((f) => new alan_std.I8(Math.floor(f.val)))" <- RootBacking :: f64 -> i8;
 // TODO: LOL, what a hack
-export fn{Rs} i8 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> i8!;
-export fn{Js} i8 "((s) => { let v = parseInt(s.val); if (Number.isNaN(v)) { return new alan_std.AlanError(new alan_std.Str('Not a Number')); } else { return new alan_std.I8(v); } })" <- RootBacking :: string -> i8!;
+fn{Rs} i8 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> i8!;
+fn{Js} i8 "((s) => { let v = parseInt(s.val); if (Number.isNaN(v)) { return new alan_std.AlanError(new alan_std.Str('Not a Number')); } else { return new alan_std.I8(v); } })" <- RootBacking :: string -> i8!;
 
-export fn{Rs} i16 Cast{"i16"} :: Deref{i8} -> i16;
-export fn{Js} i16 "new alan_std.I16" <- RootBacking :: i8 -> i16;
-export fn i16(i: i16) = i;
-export fn{Rs} i16 Cast{"i16"} :: Deref{i32} -> i16;
-export fn{Js} i16 "new alan_std.I16" <- RootBacking :: i32 -> i16;
-export fn{Rs} i16 Cast{"i16"} :: Deref{i64} -> i16;
-export fn{Js} i16 "new alan_std.I16" <- RootBacking :: i64 -> i16;
-export fn{Rs} i16 Cast{"i16"} :: Deref{u8} -> i16;
-export fn{Js} i16 "new alan_std.I16" <- RootBacking :: u8 -> i16;
-export fn{Rs} i16 Cast{"i16"} :: Deref{u16} -> i16;
-export fn{Js} i16 "new alan_std.I16" <- RootBacking :: u16 -> i16;
-export fn{Rs} i16 Cast{"i16"} :: Deref{u32} -> i16;
-export fn{Js} i16 "new alan_std.I16" <- RootBacking :: u32 -> i16;
-export fn{Rs} i16 Cast{"i16"} :: Deref{u64} -> i16;
-export fn{Js} i16 "new alan_std.I16" <- RootBacking :: u64 -> i16;
-export fn{Rs} i16 Cast{"i16"} :: Deref{f32} -> i16;
-export fn{Js} i16 "((f) => new alan_std.I16(Math.floor(f.val)))" <- RootBacking :: f32 -> i16;
-export fn{Rs} i16 Cast{"i16"} :: Deref{f64} -> i16;
-export fn{Js} i16 "((f) => new alan_std.I16(Math.floor(f.val)))" <- RootBacking :: f64 -> i16;
-export fn{Rs} i16 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> i16!;
-export fn{Js} i16 "((s) => { let v = parseInt(s.val); if (Number.isNaN(v)) { return new alan_std.AlanError(new alan_std.Str('Not a Number')); } else { return new alan_std.I16(v); } })" <- RootBacking :: string -> i16!;
+fn{Rs} i16 Cast{"i16"} :: Deref{i8} -> i16;
+fn{Js} i16 "new alan_std.I16" <- RootBacking :: i8 -> i16;
+fn i16(i: i16) = i;
+fn{Rs} i16 Cast{"i16"} :: Deref{i32} -> i16;
+fn{Js} i16 "new alan_std.I16" <- RootBacking :: i32 -> i16;
+fn{Rs} i16 Cast{"i16"} :: Deref{i64} -> i16;
+fn{Js} i16 "new alan_std.I16" <- RootBacking :: i64 -> i16;
+fn{Rs} i16 Cast{"i16"} :: Deref{u8} -> i16;
+fn{Js} i16 "new alan_std.I16" <- RootBacking :: u8 -> i16;
+fn{Rs} i16 Cast{"i16"} :: Deref{u16} -> i16;
+fn{Js} i16 "new alan_std.I16" <- RootBacking :: u16 -> i16;
+fn{Rs} i16 Cast{"i16"} :: Deref{u32} -> i16;
+fn{Js} i16 "new alan_std.I16" <- RootBacking :: u32 -> i16;
+fn{Rs} i16 Cast{"i16"} :: Deref{u64} -> i16;
+fn{Js} i16 "new alan_std.I16" <- RootBacking :: u64 -> i16;
+fn{Rs} i16 Cast{"i16"} :: Deref{f32} -> i16;
+fn{Js} i16 "((f) => new alan_std.I16(Math.floor(f.val)))" <- RootBacking :: f32 -> i16;
+fn{Rs} i16 Cast{"i16"} :: Deref{f64} -> i16;
+fn{Js} i16 "((f) => new alan_std.I16(Math.floor(f.val)))" <- RootBacking :: f64 -> i16;
+fn{Rs} i16 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> i16!;
+fn{Js} i16 "((s) => { let v = parseInt(s.val); if (Number.isNaN(v)) { return new alan_std.AlanError(new alan_std.Str('Not a Number')); } else { return new alan_std.I16(v); } })" <- RootBacking :: string -> i16!;
 
-export fn{Rs} i32 Cast{"i32"} :: Deref{i8} -> i32;
-export fn{Js} i32 "new alan_std.I32" <- RootBacking :: i8 -> i32;
-export fn{Rs} i32 Cast{"i32"} :: Deref{i16} -> i32;
-export fn{Js} i32 "new alan_std.I32" <- RootBacking :: i16 -> i32;
-export fn i32(i: i32) = i;
-export fn{Rs} i32 Cast{"i32"} :: Deref{i64} -> i32;
-export fn{Js} i32 "new alan_std.I32" <- RootBacking :: i64 -> i32;
-export fn{Rs} i32 Cast{"i32"} :: Deref{u8} -> i32;
-export fn{Js} i32 "new alan_std.I32" <- RootBacking :: u8 -> i32;
-export fn{Rs} i32 Cast{"i32"} :: Deref{u16} -> i32;
-export fn{Js} i32 "new alan_std.I32" <- RootBacking :: u16 -> i32;
-export fn{Rs} i32 Cast{"i32"} :: Deref{u32} -> i32;
-export fn{Js} i32 "new alan_std.I32" <- RootBacking :: u32 -> i32;
-export fn{Rs} i32 Cast{"i32"} :: Deref{u64} -> i32;
-export fn{Js} i32 "new alan_std.I32" <- RootBacking :: u64 -> i32;
-export fn{Rs} i32 Cast{"i32"} :: Deref{f32} -> i32;
-export fn{Js} i32 "((f) => new alan_std.I32(Math.floor(f.val)))" <- RootBacking :: f32 -> i32;
-export fn{Rs} i32 Cast{"i32"} :: Deref{f64} -> i32;
-export fn{Js} i32 "((f) => new alan_std.I32(Math.floor(f.val)))" <- RootBacking :: f64 -> i32;
-export fn{Js} i32 (f: f64) -> i32 = {"new alan_std.I32" <- RootBacking :: f64 -> i32}(
+fn{Rs} i32 Cast{"i32"} :: Deref{i8} -> i32;
+fn{Js} i32 "new alan_std.I32" <- RootBacking :: i8 -> i32;
+fn{Rs} i32 Cast{"i32"} :: Deref{i16} -> i32;
+fn{Js} i32 "new alan_std.I32" <- RootBacking :: i16 -> i32;
+fn i32(i: i32) = i;
+fn{Rs} i32 Cast{"i32"} :: Deref{i64} -> i32;
+fn{Js} i32 "new alan_std.I32" <- RootBacking :: i64 -> i32;
+fn{Rs} i32 Cast{"i32"} :: Deref{u8} -> i32;
+fn{Js} i32 "new alan_std.I32" <- RootBacking :: u8 -> i32;
+fn{Rs} i32 Cast{"i32"} :: Deref{u16} -> i32;
+fn{Js} i32 "new alan_std.I32" <- RootBacking :: u16 -> i32;
+fn{Rs} i32 Cast{"i32"} :: Deref{u32} -> i32;
+fn{Js} i32 "new alan_std.I32" <- RootBacking :: u32 -> i32;
+fn{Rs} i32 Cast{"i32"} :: Deref{u64} -> i32;
+fn{Js} i32 "new alan_std.I32" <- RootBacking :: u64 -> i32;
+fn{Rs} i32 Cast{"i32"} :: Deref{f32} -> i32;
+fn{Js} i32 "((f) => new alan_std.I32(Math.floor(f.val)))" <- RootBacking :: f32 -> i32;
+fn{Rs} i32 Cast{"i32"} :: Deref{f64} -> i32;
+fn{Js} i32 "((f) => new alan_std.I32(Math.floor(f.val)))" <- RootBacking :: f64 -> i32;
+fn{Js} i32 (f: f64) -> i32 = {"new alan_std.I32" <- RootBacking :: f64 -> i32}(
   {"Math.floor" :: f64 -> f64}(f));
-export fn{Rs} i32 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> i32!;
-export fn{Js} i32 "((s) => { let v = parseInt(s.val); if (Number.isNaN(v)) { return new alan_std.AlanError(new alan_std.Str('Not a Number')); } else { return new alan_std.I32(v); } })" <- RootBacking :: string -> i32!;
+fn{Rs} i32 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> i32!;
+fn{Js} i32 "((s) => { let v = parseInt(s.val); if (Number.isNaN(v)) { return new alan_std.AlanError(new alan_std.Str('Not a Number')); } else { return new alan_std.I32(v); } })" <- RootBacking :: string -> i32!;
 
-export fn{Rs} i64 Cast{"i64"} :: Deref{i8} -> i64;
-export fn{Js} i64 "new alan_std.I64" <- RootBacking :: i8 -> i64;
-export fn{Rs} i64 Cast{"i64"} :: Deref{i16} -> i64;
-export fn{Js} i64 "new alan_std.I64" <- RootBacking :: i16 -> i64;
-export fn{Rs} i64 Cast{"i64"} :: Deref{i32} -> i64;
-export fn{Js} i64 "new alan_std.I64" <- RootBacking :: i32 -> i64;
-export fn i64(i: i64) = i;
-export fn{Rs} i64 Cast{"i64"} :: Deref{u8} -> i64;
-export fn{Js} i64 "new alan_std.I64" <- RootBacking :: u8 -> i64;
-export fn{Rs} i64 Cast{"i64"} :: Deref{u16} -> i64;
-export fn{Js} i64 "new alan_std.I64" <- RootBacking :: u16 -> i64;
-export fn{Rs} i64 Cast{"i64"} :: Deref{u32} -> i64;
-export fn{Js} i64 "new alan_std.I64" <- RootBacking :: u32 -> i64;
-export fn{Rs} i64 Cast{"i64"} :: Deref{u64} -> i64;
-export fn{Js} i64 "new alan_std.I64" <- RootBacking :: u64 -> i64;
-export fn{Rs} i64 Cast{"i64"} :: Deref{f32} -> i64;
-export fn{Js} i64 "((f) => new alan_std.I64(Math.floor(f.val)))" <- RootBacking :: f32 -> i64;
-export fn{Rs} i64 Cast{"i64"} :: Deref{f64} -> i64;
-export fn{Js} i64 "((f) => new alan_std.I64(Math.floor(f.val)))" <- RootBacking :: f64 -> i64;
-export fn{Rs} i64 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> i64!;
-export fn{Js} i64 "((s) => { try { return new alan_std.I64(BigInt(s.val)) } catch (e) { return new alan_std.AlanError(new alan_std.Str(e.message)); } })" <- RootBacking :: string -> i64!;
+fn{Rs} i64 Cast{"i64"} :: Deref{i8} -> i64;
+fn{Js} i64 "new alan_std.I64" <- RootBacking :: i8 -> i64;
+fn{Rs} i64 Cast{"i64"} :: Deref{i16} -> i64;
+fn{Js} i64 "new alan_std.I64" <- RootBacking :: i16 -> i64;
+fn{Rs} i64 Cast{"i64"} :: Deref{i32} -> i64;
+fn{Js} i64 "new alan_std.I64" <- RootBacking :: i32 -> i64;
+fn i64(i: i64) = i;
+fn{Rs} i64 Cast{"i64"} :: Deref{u8} -> i64;
+fn{Js} i64 "new alan_std.I64" <- RootBacking :: u8 -> i64;
+fn{Rs} i64 Cast{"i64"} :: Deref{u16} -> i64;
+fn{Js} i64 "new alan_std.I64" <- RootBacking :: u16 -> i64;
+fn{Rs} i64 Cast{"i64"} :: Deref{u32} -> i64;
+fn{Js} i64 "new alan_std.I64" <- RootBacking :: u32 -> i64;
+fn{Rs} i64 Cast{"i64"} :: Deref{u64} -> i64;
+fn{Js} i64 "new alan_std.I64" <- RootBacking :: u64 -> i64;
+fn{Rs} i64 Cast{"i64"} :: Deref{f32} -> i64;
+fn{Js} i64 "((f) => new alan_std.I64(Math.floor(f.val)))" <- RootBacking :: f32 -> i64;
+fn{Rs} i64 Cast{"i64"} :: Deref{f64} -> i64;
+fn{Js} i64 "((f) => new alan_std.I64(Math.floor(f.val)))" <- RootBacking :: f64 -> i64;
+fn{Rs} i64 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> i64!;
+fn{Js} i64 "((s) => { try { return new alan_std.I64(BigInt(s.val)) } catch (e) { return new alan_std.AlanError(new alan_std.Str(e.message)); } })" <- RootBacking :: string -> i64!;
 
-export fn{Rs} u8 Cast{"u8"} :: Deref{i8} -> u8;
-export fn{Js} u8 "new alan_std.U8" <- RootBacking :: i8 -> u8;
-export fn{Rs} u8 Cast{"u8"} :: Deref{i16} -> u8;
-export fn{Js} u8 "new alan_std.U8" <- RootBacking :: i16 -> u8;
-export fn{Rs} u8 Cast{"u8"} :: Deref{i32} -> u8;
-export fn{Js} u8 "new alan_std.U8" <- RootBacking :: i32 -> u8;
-export fn{Rs} u8 Cast{"u8"} :: Deref{i64} -> u8;
-export fn{Js} u8 "new alan_std.U8" <- RootBacking :: i64 -> u8;
-export fn u8(i: u8) = i;
-export fn{Rs} u8 Cast{"u8"} :: Deref{u16} -> u8;
-export fn{Js} u8 "new alan_std.U8" <- RootBacking :: u16 -> u8;
-export fn{Rs} u8 Cast{"u8"} :: Deref{u32} -> u8;
-export fn{Js} u8 "new alan_std.U8" <- RootBacking :: u32 -> u8;
-export fn{Rs} u8 Cast{"u8"} :: Deref{u64} -> u8;
-export fn{Js} u8 "new alan_std.U8" <- RootBacking :: u64 -> u8;
-export fn{Rs} u8 Cast{"u8"} :: Deref{f32} -> u8;
-export fn{Js} u8 "((f) => new alan_std.U8(Math.floor(f.val)))" <- RootBacking :: f32 -> u8;
-export fn{Rs} u8 Cast{"u8"} :: Deref{f64} -> u8;
-export fn{Js} u8 "((f) => new alan_std.U8(Math.floor(f.val)))" <- RootBacking :: f64 -> u8;
-export fn{Rs} u8 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> u8!;
-export fn{Js} u8 "((s) => { let v = parseInt(s.val); if (Number.isNaN(v)) { return new alan_std.AlanError(new alan_std.Str('Not a Number')); } else { return new alan_std.U8(v); } })" <- RootBacking :: string -> u8!;
-
-export fn{Rs} u16 Cast{"u16"} :: Deref{i8} -> u16;
-export fn{Js} u16 "new alan_std.U16" <- RootBacking :: i8 -> u16;
-export fn{Rs} u16 Cast{"u16"} :: Deref{i16} -> u16;
-export fn{Js} u16 "new alan_std.U16" <- RootBacking :: i16 -> u16;
-export fn{Rs} u16 Cast{"u16"} :: Deref{i32} -> u16;
-export fn{Js} u16 "new alan_std.U16" <- RootBacking :: i32 -> u16;
-export fn{Rs} u16 Cast{"u16"} :: Deref{i64} -> u16;
-export fn{Js} u16 "new alan_std.U16" <- RootBacking :: i64 -> u16;
-export fn{Rs} u16 Cast{"u16"} :: Deref{u8} -> u16;
-export fn{Js} u16 "new alan_std.U16" <- RootBacking :: u8 -> u16;
-export fn u16(i: u16) = i;
-export fn{Rs} u16 Cast{"u16"} :: Deref{u32} -> u16;
-export fn{Js} u16 "new alan_std.U16" <- RootBacking :: u32 -> u16;
-export fn{Rs} u16 Cast{"u16"} :: Deref{u64} -> u16;
-export fn{Js} u16 "new alan_std.U16" <- RootBacking :: u64 -> u16;
-export fn{Rs} u16 Cast{"u16"} :: Deref{f32} -> u16;
-export fn{Js} u16 "((f) => new alan_std.U16(Math.floor(f.val)))" <- RootBacking :: f32 -> u16;
-export fn{Rs} u16 Cast{"u16"} :: Deref{f64} -> u16;
-export fn{Js} u16 "((f) => new alan_std.U16(Math.floor(f.val)))" <- RootBacking :: f64 -> u16;
-export fn{Rs} u16 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> u16!;
-export fn{Js} u16 "((s) => { let v = parseInt(s.val); if (Number.isNaN(v)) { return new alan_std.AlanError(new alan_std.Str('Not a Number')); } else { return new alan_std.U16(v); } })" <- RootBacking :: string -> u16!;
-
-export fn{Rs} u32 Cast{"u32"} :: Deref{i8} -> u32;
-export fn{Js} u32 "new alan_std.U32" <- RootBacking :: i8 -> u32;
-export fn{Rs} u32 Cast{"u32"} :: Deref{i16} -> u32;
-export fn{Js} u32 "new alan_std.U32" <- RootBacking :: i16 -> u32;
-export fn{Rs} u32 Cast{"u32"} :: Deref{i32} -> u32;
-export fn{Js} u32 "new alan_std.U32" <- RootBacking :: i32 -> u32;
-export fn{Rs} u32 Cast{"u32"} :: Deref{i64} -> u32;
-export fn{Js} u32 "new alan_std.U32" <- RootBacking :: i64 -> u32;
-export fn{Rs} u32 Cast{"u32"} :: Deref{u8} -> u32;
-export fn{Js} u32 "new alan_std.U32" <- RootBacking :: u8 -> u32;
-export fn{Rs} u32 Cast{"u32"} :: Deref{u16} -> u32;
-export fn{Js} u32 "new alan_std.U32" <- RootBacking :: u16 -> u32;
-export fn u32(i: u32) = i;
-export fn{Rs} u32 Cast{"u32"} :: Deref{u64} -> u32;
-export fn{Js} u32 "new alan_std.U32" <- RootBacking :: u64 -> u32;
-export fn{Rs} u32 Cast{"u32"} :: Deref{f32} -> u32;
-export fn{Js} u32 "((f) => new alan_std.U32(Math.floor(f.val)))" <- RootBacking :: f32 -> u32;
-export fn{Rs} u32 Cast{"u32"} :: Deref{f64} -> u32;
-export fn{Js} u32 "((f) => new alan_std.U32(Math.floor(f.val)))" <- RootBacking :: f64 -> u32;
-export fn{Rs} u32 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> u32!;
-export fn{Js} u32 "((s) => { let v = parseInt(s.val); if (Number.isNaN(v)) { return new alan_std.AlanError(new alan_std.Str('Not a Number')); } else { return new alan_std.U32(v); } })" <- RootBacking :: string -> u32!;
-
-export fn{Rs} u64 Cast{"u64"} :: Deref{i8} -> u64;
-export fn{Js} u64 "new alan_std.U64" <- RootBacking :: i8 -> u64;
-export fn{Rs} u64 Cast{"u64"} :: Deref{i16} -> u64;
-export fn{Js} u64 "new alan_std.U64" <- RootBacking :: i16 -> u64;
-export fn{Rs} u64 Cast{"u64"} :: Deref{i32} -> u64;
-export fn{Js} u64 "new alan_std.U64" <- RootBacking :: i32 -> u64;
-export fn{Rs} u64 Cast{"u64"} :: Deref{i64} -> u64;
-export fn{Js} u64 "new alan_std.U64" <- RootBacking :: i64 -> u64;
-export fn{Rs} u64 Cast{"u64"} :: Deref{u8} -> u64;
-export fn{Js} u64 "new alan_std.U64" <- RootBacking :: u8 -> u64;
-export fn{Rs} u64 Cast{"u64"} :: Deref{u16} -> u64;
-export fn{Js} u64 "new alan_std.U64" <- RootBacking :: u16 -> u64;
-export fn{Rs} u64 Cast{"u64"} :: Deref{u32} -> u64;
-export fn{Js} u64 "new alan_std.U64" <- RootBacking :: u32 -> u64;
-export fn u64(u: u64) = u;
-export fn{Rs} u64 Cast{"u64"} :: Deref{f32} -> u64;
-export fn{Js} u64 "((f) => new alan_std.U64(Math.floor(f.val)))" <- RootBacking :: f32 -> u64;
-export fn{Rs} u64 Cast{"u64"} :: Deref{f64} -> u64;
-export fn{Js} u64 "((f) => new alan_std.U64(Math.floor(f.val)))" <- RootBacking :: f64 -> u64;
-export fn{Rs} u64 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> u64!;
-export fn{Js} u64 "((s) => { try { return new alan_std.U64(BigInt(s.val)) } catch (e) { return new alan_std.AlanError(new alan_std.Str(e.message)); } })" <- RootBacking :: string -> u64!;
-
-export fn{Rs} f32 Cast{"f32"} :: Deref{i8} -> f32;
-export fn{Js} f32 "new alan_std.F32" <- RootBacking :: i8 -> f32;
-export fn{Rs} f32 Cast{"f32"} :: Deref{i16} -> f32;
-export fn{Js} f32 "new alan_std.F32" <- RootBacking :: i16 -> f32;
-export fn{Rs} f32 Cast{"f32"} :: Deref{i32} -> f32;
-export fn{Js} f32 "new alan_std.F32" <- RootBacking :: i32 -> f32;
-export fn{Rs} f32 Cast{"f32"} :: Deref{i64} -> f32;
-export fn{Js} f32 "new alan_std.F32" <- RootBacking :: i64 -> f32;
-export fn{Rs} f32 Cast{"f32"} :: Deref{u8} -> f32;
-export fn{Js} f32 "new alan_std.F32" <- RootBacking :: u8 -> f32;
-export fn{Rs} f32 Cast{"f32"} :: Deref{u16} -> f32;
-export fn{Js} f32 "new alan_std.F32" <- RootBacking :: u16 -> f32;
-export fn{Rs} f32 Cast{"f32"} :: Deref{u32} -> f32;
-export fn{Js} f32 "new alan_std.F32" <- RootBacking :: u32 -> f32;
-export fn{Rs} f32 Cast{"f32"} :: Deref{u64} -> f32;
-export fn{Js} f32 "new alan_std.F32" <- RootBacking :: u64 -> f32;
-export fn f32(f: f32) = f;
-export fn{Rs} f32 Cast{"f32"} :: Deref{f64} -> f32;
-export fn{Js} f32 "new alan_std.F32" <- RootBacking :: f64 -> f32;
-export fn{Rs} f32 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> f32!;
-export fn{Js} f32 "((s) => { let f = parseFloat(s.val); if (Number.isNaN(f)) { return alan_std.nanToError(f); } else { return new alan_std.F32(f); } })" :: string -> f32!;
-
-export fn{Rs} f64 Cast{"f64"} :: Deref{i8} -> f64;
-export fn{Js} f64 "new alan_std.F64" <- RootBacking :: i8 -> f64;
-export fn{Rs} f64 Cast{"f64"} :: Deref{i16} -> f64;
-export fn{Js} f64 "new alan_std.F64" <- RootBacking :: i16 -> f64;
-export fn{Rs} f64 Cast{"f64"} :: Deref{i32} -> f64;
-export fn{Js} f64 "new alan_std.F64" <- RootBacking :: i32 -> f64;
-export fn{Rs} f64 Cast{"f64"} :: Deref{i64} -> f64;
-export fn{Js} f64 "new alan_std.F64" <- RootBacking :: i64 -> f64;
-export fn{Rs} f64 Cast{"f64"} :: Deref{u8} -> f64;
-export fn{Js} f64 "new alan_std.F64" <- RootBacking :: u8 -> f64;
-export fn{Rs} f64 Cast{"f64"} :: Deref{u16} -> f64;
-export fn{Js} f64 "new alan_std.F64" <- RootBacking :: u16 -> f64;
-export fn{Rs} f64 Cast{"f64"} :: Deref{u32} -> f64;
-export fn{Js} f64 "new alan_std.F64" <- RootBacking :: u32 -> f64;
-export fn{Rs} f64 Cast{"f64"} :: Deref{u64} -> f64;
-export fn{Js} f64 "new alan_std.F64" <- RootBacking :: u64 -> f64;
-export fn{Rs} f64 Cast{"f64"} :: Deref{f32} -> f64;
-export fn{Js} f64 "new alan_std.F64" <- RootBacking :: f32 -> f64;
-export fn f64(f: f64) = f;
-export fn{Rs} f64 Method{"parse().map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: string -> f64!;
-export fn{Js} f64 "((s) => { let f = parseFloat(s.val); if (Number.isNaN(f)) { return alan_std.nanToError(f); } else { return new alan_std.F32(f); } })" :: string -> f64!;
-
-export fn{Rs} bool (i: i8) = {Infix{"!="} :: (Deref{i8}, Deref{i8}) -> bool}(i, 0.i8);
-export fn{Js} bool "((i) => new alan_std.Bool(i.val != 0))" <- RootBacking :: i8 -> bool;
-export fn{Rs} bool (i: i16) = {Infix{"!="} :: (Deref{i16}, Deref{i16}) -> bool}(i, 0.i16);
-export fn{Js} bool "((i) => new alan_std.Bool(i.val != 0))" <- RootBacking :: i16 -> bool;
-export fn{Rs} bool (i: i32) = {Infix{"!="} :: (Deref{i32}, Deref{i32}) -> bool}(i, 0.i32);
-export fn{Js} bool "((i) => new alan_std.Bool(i.val != 0))" <- RootBacking :: i32 -> bool;
-export fn{Rs} bool (i: i64) = {Infix{"!="} :: (Deref{i64}, Deref{i64}) -> bool}(i, 0);
-export fn{Js} bool "((i) => new alan_std.Bool(i.val != 0n))" <- RootBacking :: i64 -> bool;
-export fn{Rs} bool (u: u8) = {Infix{"!="} :: (Deref{u8}, Deref{u8}) -> bool}(u, 0.u8);
-export fn{Js} bool "((u) => new alan_std.Bool(u.val != 0))" <- RootBacking :: u8 -> bool;
-export fn{Rs} bool (u: u16) = {Infix{"!="} :: (Deref{u16}, Deref{u16}) -> bool}(u, 0.u16);
-export fn{Js} bool "((u) => new alan_std.Bool(u.val != 0))" <- RootBacking :: u16 -> bool;
-export fn{Rs} bool (u: u32) = {Infix{"!="} :: (Deref{u32}, Deref{u32}) -> bool}(u, 0.u32);
-export fn{Js} bool "((u) => new alan_std.Bool(u.val != 0))" <- RootBacking :: u32 -> bool;
-export fn{Rs} bool (u: u64) = {Infix{"!="} :: (Deref{u64}, Deref{u64}) -> bool}(u, 0.u64);
-export fn{Js} bool "((u) => new alan_std.Bool(u.val != 0n))" <- RootBacking :: u64 -> bool;
-export fn{Rs} bool (f: f32) = {Infix{"!="} :: (Deref{f32}, Deref{f32}) -> bool}(f, 0.f32);
-export fn{Js} bool "((f) => new alan_std.Bool(f.val != 0.0))" <- RootBacking :: f32 -> bool;
-export fn{Rs} bool (f: f64) = {Infix{"!="} :: (Deref{f64}, Deref{f64}) -> bool}(f, 0.f64);
-export fn{Js} bool "((f) => new alan_std.Bool(f.val != 0.0))" <- RootBacking :: f64 -> bool;
-export fn{Rs} bool(s: string) = {Infix{"=="} :: (string, string) -> bool}(s, "true");
-export fn{Js} bool "((s) => new alan_std.Bool(s.val == 'true'))" <- RootBacking :: string -> bool;
-export fn bool(b: bool) = b;
+fn{Rs} bool (i: i8) = {Infix{"!="} :: (Deref{i8}, Deref{i8}) -> bool}(i, 0.i8);
+fn{Js} bool "((i) => new alan_std.Bool(i.val != 0))" <- RootBacking :: i8 -> bool;
+fn{Rs} bool (i: i16) = {Infix{"!="} :: (Deref{i16}, Deref{i16}) -> bool}(i, 0.i16);
+fn{Js} bool "((i) => new alan_std.Bool(i.val != 0))" <- RootBacking :: i16 -> bool;
+fn{Rs} bool (i: i32) = {Infix{"!="} :: (Deref{i32}, Deref{i32}) -> bool}(i, 0.i32);
+fn{Js} bool "((i) => new alan_std.Bool(i.val != 0))" <- RootBacking :: i32 -> bool;
+fn{Rs} bool (i: i64) = {Infix{"!="} :: (Deref{i64}, Deref{i64}) -> bool}(i, 0);
+fn{Js} bool "((i) => new alan_std.Bool(i.val != 0n))" <- RootBacking :: i64 -> bool;
+fn{Rs} bool (u: u8) = {Infix{"!="} :: (Deref{u8}, Deref{u8}) -> bool}(u, 0.u8);
+fn{Js} bool "((u) => new alan_std.Bool(u.val != 0))" <- RootBacking :: u8 -> bool;
+fn{Rs} bool (u: u16) = {Infix{"!="} :: (Deref{u16}, Deref{u16}) -> bool}(u, 0.u16);
+fn{Js} bool "((u) => new alan_std.Bool(u.val != 0))" <- RootBacking :: u16 -> bool;
+fn{Rs} bool (u: u32) = {Infix{"!="} :: (Deref{u32}, Deref{u32}) -> bool}(u, 0.u32);
+fn{Js} bool "((u) => new alan_std.Bool(u.val != 0))" <- RootBacking :: u32 -> bool;
+fn{Rs} bool (u: u64) = {Infix{"!="} :: (Deref{u64}, Deref{u64}) -> bool}(u, 0.u64);
+fn{Js} bool "((u) => new alan_std.Bool(u.val != 0n))" <- RootBacking :: u64 -> bool;
+fn{Rs} bool (f: f32) = {Infix{"!="} :: (Deref{f32}, Deref{f32}) -> bool}(f, 0.f32);
+fn{Js} bool "((f) => new alan_std.Bool(f.val != 0.0))" <- RootBacking :: f32 -> bool;
+fn{Rs} bool (f: f64) = {Infix{"!="} :: (Deref{f64}, Deref{f64}) -> bool}(f, 0.f64);
+fn{Js} bool "((f) => new alan_std.Bool(f.val != 0.0))" <- RootBacking :: f64 -> bool;
+fn{Rs} bool(s: string) = {Infix{"=="} :: (string, string) -> bool}(s, "true");
+fn{Js} bool "((s) => new alan_std.Bool(s.val == 'true'))" <- RootBacking :: string -> bool;
+fn bool(b: bool) = b;
 
 /// Boolean related bindings
-export fn{Rs} and Infix{"&&"} :: (Deref{bool}, Deref{bool}) -> bool;
-export fn{Js} and "((a, b) => new alan_std.Bool(a.val && b.val))" <- RootBacking :: (bool, bool) -> bool;
-export fn{Rs} or Infix{"||"} :: (Deref{bool}, Deref{bool}) -> bool;
-export fn{Js} or "((a, b) => new alan_std.Bool(a.val || b.val))" <- RootBacking :: (bool, bool) -> bool;
-export fn{Rs} xor Infix{"^"} :: (Deref{bool}, Deref{bool}) -> bool;
-export fn{Js} xor "((a, b) => new alan_std.Bool(!!(a.val ^ b.val)))" <- RootBacking :: (bool, bool) -> bool;
-export fn{Rs} not Prefix{"!"} :: Deref{bool} -> bool;
-export fn{Js} not "((a) => new alan_std.Bool(!a.val))" :: bool -> bool;
-export fn nand (a: bool, b: bool) = a.and(b).not;
-export fn nor (a: bool, b: bool) = a.or(b).not;
-export fn{Rs} xnor Infix{"=="} :: (bool, bool) -> bool;
-export fn{Js} xnor "((a, b) => new alan_std.Bool(a.val == b.val))" :: (bool, bool) -> bool;
-export fn{Rs} eq Infix{"=="} :: (bool, bool) -> bool;
-export fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" :: (bool, bool) -> bool;
-export fn{Rs} neq Infix{"!="} :: (bool, bool) -> bool;
-export fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" :: (bool, bool) -> bool;
-export fn if{T}(c: bool, t: T) = if(c, fn () -> Maybe{T} = Maybe{T}(t), fn () -> Maybe{T} = Maybe{T}());
-export fn if{T}(c: bool, t: T, f: T) = if(c, fn () -> T = t, fn () -> T = f);
-export fn if{T}(c: bool, t: () -> T) = if(c, fn () -> Maybe{T} = Maybe{T}(t()), fn () -> Maybe{T} = Maybe{T}());
-export fn{Rs} if{T} "alan_std::ifbool" <- RootBacking :: (bool, () -> T, () -> T) -> T;
-export fn{Js} if{T} "alan_std.ifbool" <- RootBacking :: (bool, () -> T, () -> T) -> T;
-
-/// Signed Integer-related functions and function bindings
-export fn{Rs} add Method{"wrapping_add"} :: (i8, Deref{i8}) -> i8;
-export fn{Js} add Method{"wrappingAdd"} :: (i8, i8) -> i8;
-export fn{Rs} sub Method{"wrapping_sub"} :: (i8, Deref{i8}) -> i8;
-export fn{Js} sub Method{"wrappingSub"} :: (i8, i8) -> i8;
-export fn{Rs} mul Method{"wrapping_mul"} :: (i8, Deref{i8}) -> i8;
-export fn{Js} mul Method{"wrappingMul"} :: (i8, i8) -> i8;
-export fn{Rs} div Method{"wrapping_div"} :: (i8, Deref{i8}) -> i8;
-export fn{Js} div Method{"wrappingDiv"} :: (i8, i8) -> i8;
-export fn{Rs} mod Method{"wrapping_rem"} :: (i8, Deref{i8}) -> i8;
-export fn{Js} mod Method{"wrappingMod"} :: (i8, i8) -> i8;
-export fn{Rs} pow (a: i8, b: i8) = {Method{"wrapping_pow"} :: (i8, Deref{u32}) -> i8}(a, b.u32);
-export fn{Js} pow Method{"wrappingPow"} :: (i8, i8) -> i8;
-export fn{Rs} abs Method{"abs"} :: i8 -> i8;
-export fn{Js} abs "((a) => new alan_std.I8(Math.abs(a.val)))" <- RootBacking :: i8 -> i8;
-export fn{Rs} neg Prefix{"-"} :: Deref{i8} -> i8;
-export fn{Js} neg "((a) => new alan_std.I8(-a))" <- RootBacking :: i8 -> i8;
-export fn{Rs} and Infix{"&"} :: (Deref{i8}, Deref{i8}) -> i8;
-export fn{Js} and "((a, b) => new alan_std.I8(a & b))" <- RootBacking :: (i8, i8) -> i8;
-export fn{Rs} or Infix{"|"} :: (Deref{i8}, Deref{i8}) -> i8;
-export fn{Js} or "((a, b) => new alan_std.I8(a | b))" <- RootBacking :: (i8, i8) -> i8;
-export fn{Rs} xor Infix{"^"} :: (Deref{i8}, Deref{i8}) -> i8;
-export fn{Js} xor "((a, b) => new alan_std.I8(a ^ b))" <- RootBacking :: (i8, i8) -> i8;
-export fn{Rs} not Prefix{"!"} :: Deref{i8} -> i8;
-export fn{Js} not Method{"not"} :: i8 -> i8;
-export fn nand (a: i8, b: i8) = a.and(b).not;
-export fn nor (a: i8, b: i8) = a.or(b).not;
-export fn xnor (a: i8, b: i8) = a.xor(b).not;
-export fn{Rs} eq Infix{"=="} :: (Deref{i8}, Deref{i8}) -> bool;
-export fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (i8, i8) -> bool;
-export fn{Rs} neq Infix{"!="} :: (Deref{i8}, Deref{i8}) -> bool;
-export fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (i8, i8) -> bool;
-export fn{Rs} lt Infix{"<"} :: (Deref{i8}, Deref{i8}) -> bool;
-export fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (i8, i8) -> bool;
-export fn{Rs} lte Infix{"<="} :: (Deref{i8}, Deref{i8}) -> bool;
-export fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (i8, i8) -> bool;
-export fn{Rs} gt Infix{">"} :: (Deref{i8}, Deref{i8}) -> bool;
-export fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (i8, i8) -> bool;
-export fn{Rs} gte Infix{">="} :: (Deref{i8}, Deref{i8}) -> bool;
-export fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (i8, i8) -> bool;
-export fn min (a: i8, b: i8) = if(a.lte(b), a, b);
-export fn max (a: i8, b: i8) = if(a.gte(b), a, b);
-export fn clamp(v: i8, l: i8, h: i8) = if(v.lte(l), l, if(v.gte(h), h, v));
-export fn{Rs} shl (a: i8, b: i8) = {Method{"wrapping_shl"} :: (i8, Deref{u32}) -> i8}(a, b.u32);
-export fn{Js} shl Method{"wrappingShl"} :: (i8, i8) -> i8;
-export fn{Rs} shr (a: i8, b: i8) = {Method{"wrapping_shr"} :: (i8, Deref{u32}) -> i8}(a, b.u32);
-export fn{Js} shr Method{"wrappingShr"} :: (i8, i8) -> i8;
-export fn{Rs} wrl (a: i8, b: i8) = {Method{"rotate_left"} :: (i8, Deref{u32}) -> i8}(a, b.u32);
-export fn{Js} wrl Method{"rotateLeft"} :: (i8, i8) -> i8;
-export fn{Rs} wrr (a: i8, b: i8) = {Method{"rotate_right"} :: (i8, Deref{u32}) -> i8}(a, b.u32);
-export fn{Js} wrr Method{"rotateRight"} :: (i8, i8) -> i8;
-export fn{Rs} clz (a: i8) = {Method{"leading_zeros"} :: i8 -> u32}(a).i8;
-export fn{Js} clz Method{"clz"} :: i8 -> i8;
-
-export fn{Rs} add Method{"wrapping_add"} :: (i16, Deref{i16}) -> i16;
-export fn{Js} add Method{"wrappingAdd"} :: (i16, i16) -> i16;
-export fn{Rs} sub Method{"wrapping_sub"} :: (i16, Deref{i16}) -> i16;
-export fn{Js} sub Method{"wrappingSub"} :: (i16, i16) -> i16;
-export fn{Rs} mul Method{"wrapping_mul"} :: (i16, Deref{i16}) -> i16;
-export fn{Js} mul Method{"wrappingMul"} :: (i16, i16) -> i16;
-export fn{Rs} div Method{"wrapping_div"} :: (i16, Deref{i16}) -> i16;
-export fn{Js} div Method{"wrappingDiv"} :: (i16, i16) -> i16;
-export fn{Rs} mod Method{"wrapping_rem"} :: (i16, Deref{i16}) -> i16;
-export fn{Js} mod Method{"wrappingMod"} :: (i16, i16) -> i16;
-export fn{Rs} pow (a: i16, b: i16) = {Method{"wrapping_pow"} :: (i16, Deref{u32}) -> i16}(a, b.u32);
-export fn{Js} pow Method{"wrappingPow"} :: (i16, i16) -> i16;
-export fn{Rs} abs Method{"abs"} :: i16 -> i16;
-export fn{Js} abs "((a) => new alan_std.I16(Math.abs(a.val)))" <- RootBacking :: i16 -> i16;
-export fn{Rs} neg Prefix{"-"} :: Deref{i16} -> i16;
-export fn{Js} neg "((a) => new alan_std.I16(-a))" <- RootBacking :: i16 -> i16;
-export fn{Rs} and Infix{"&"} :: (Deref{i16}, Deref{i16}) -> i16;
-export fn{Js} and "((a, b) => new alan_std.I16(a & b))" <- RootBacking :: (i16, i16) -> i16;
-export fn{Rs} or Infix{"|"} :: (Deref{i16}, Deref{i16}) -> i16;
-export fn{Js} or "((a, b) => new alan_std.I16(a | b))" <- RootBacking :: (i16, i16) -> i16;
-export fn{Rs} xor Infix{"^"} :: (Deref{i16}, Deref{i16}) -> i16;
-export fn{Js} xor "((a, b) => new alan_std.I16(a ^ b))" <- RootBacking :: (i16, i16) -> i16;
-export fn{Rs} not Prefix{"!"} :: Deref{i16} -> i16;
-export fn{Js} not Method{"not"} :: i16 -> i16;
-export fn nand (a: i16, b: i16) = a.and(b).not;
-export fn nor (a: i16, b: i16) = a.or(b).not;
-export fn xnor (a: i16, b: i16) = a.xor(b).not;
-export fn{Rs} eq Infix{"=="} :: (Deref{i16}, Deref{i16}) -> bool;
-export fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (i16, i16) -> bool;
-export fn{Rs} neq Infix{"!="} :: (Deref{i16}, Deref{i16}) -> bool;
-export fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (i16, i16) -> bool;
-export fn{Rs} lt Infix{"<"} :: (Deref{i16}, Deref{i16}) -> bool;
-export fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (i16, i16) -> bool;
-export fn{Rs} lte Infix{"<="} :: (Deref{i16}, Deref{i16}) -> bool;
-export fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (i16, i16) -> bool;
-export fn{Rs} gt Infix{">"} :: (Deref{i16}, Deref{i16}) -> bool;
-export fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (i16, i16) -> bool;
-export fn{Rs} gte Infix{">="} :: (Deref{i16}, Deref{i16}) -> bool;
-export fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (i16, i16) -> bool;
-export fn min (a: i16, b: i16) = if(a.lte(b), a, b);
-export fn max (a: i16, b: i16) = if(a.gte(b), a, b);
-export fn clamp(v: i16, l: i16, h: i16) = if(v.lte(l), l, if(v.gte(h), h, v));
-export fn{Rs} shl (a: i16, b: i16) = {Method{"wrapping_shl"} :: (i16, Deref{u32}) -> i16}(a, b.u32);
-export fn{Js} shl Method{"wrappingShl"} :: (i16, i16) -> i16;
-export fn{Rs} shr (a: i16, b: i16) = {Method{"wrapping_shr"} :: (i16, Deref{u32}) -> i16}(a, b.u32);
-export fn{Js} shr Method{"wrappingShr"} :: (i16, i16) -> i16;
-export fn{Rs} wrl (a: i16, b: i16) = {Method{"rotate_left"} :: (i16, Deref{u32}) -> i16}(a, b.u32);
-export fn{Js} wrl Method{"rotateLeft"} :: (i16, i16) -> i16;
-export fn{Rs} wrr (a: i16, b: i16) = {Method{"rotate_right"} :: (i16, Deref{u32}) -> i16}(a, b.u32);
-export fn{Js} wrr Method{"rotateRight"} :: (i16, i16) -> i16;
-export fn{Rs} clz (a: i16) = {Method{"leading_zeros"} :: i16 -> u32}(a).i16;
-export fn{Js} clz Method{"clz"} :: i16 -> i16;
-
-export fn{Rs} add Method{"wrapping_add"} :: (i32, Deref{i32}) -> i32;
-export fn{Js} add Method{"wrappingAdd"} :: (i32, i32) -> i32;
-export fn{Rs} sub Method{"wrapping_sub"} :: (i32, Deref{i32}) -> i32;
-export fn{Js} sub Method{"wrappingSub"} :: (i32, i32) -> i32;
-export fn{Rs} mul Method{"wrapping_mul"} :: (i32, Deref{i32}) -> i32;
-export fn{Js} mul Method{"wrappingMul"} :: (i32, i32) -> i32;
-export fn{Rs} div Method{"wrapping_div"} :: (i32, Deref{i32}) -> i32;
-export fn{Js} div Method{"wrappingDiv"} :: (i32, i32) -> i32;
-export fn{Rs} mod Method{"wrapping_rem"} :: (i32, Deref{i32}) -> i32;
-export fn{Js} mod Method{"wrappingMod"} :: (i32, i32) -> i32;
-export fn{Rs} pow (a: i32, b: i32) = {Method{"wrapping_pow"} :: (i32, Deref{u32}) -> i32}(a, b.u32);
-export fn{Js} pow Method{"wrappingPow"} :: (i32, i32) -> i32;
-export fn{Rs} abs Method{"abs"} :: i32 -> i32;
-export fn{Js} abs "((a) => new alan_std.I32(Math.abs(a.val)))" <- RootBacking :: i32 -> i32;
-export fn{Rs} neg Prefix{"-"} :: Deref{i32} -> i32;
-export fn{Js} neg "((a) => new alan_std.I32(-a))" <- RootBacking :: i32 -> i32;
-export fn{Rs} and Infix{"&"} :: (Deref{i32}, Deref{i32}) -> i32;
-export fn{Js} and "((a, b) => new alan_std.I32(a & b))" <- RootBacking :: (i32, i32) -> i32;
-export fn{Rs} or Infix{"|"} :: (Deref{i32}, Deref{i32}) -> i32;
-export fn{Js} or "((a, b) => new alan_std.I32(a | b))" <- RootBacking :: (i32, i32) -> i32;
-export fn{Rs} xor Infix{"^"} :: (Deref{i32}, Deref{i32}) -> i32;
-export fn{Js} xor "((a, b) => new alan_std.I32(a ^ b))" <- RootBacking :: (i32, i32) -> i32;
-export fn{Rs} not Prefix{"!"} :: Deref{i32} -> i32;
-export fn{Js} not Method{"not"} :: i32 -> i32;
-export fn nand (a: i32, b: i32) = a.and(b).not;
-export fn nor (a: i32, b: i32) = a.or(b).not;
-export fn xnor (a: i32, b: i32) = a.xor(b).not;
-export fn{Rs} eq Infix{"=="} :: (Deref{i32}, Deref{i32}) -> bool;
-export fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (i32, i32) -> bool;
-export fn{Rs} neq Infix{"!="} :: (Deref{i32}, Deref{i32}) -> bool;
-export fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (i32, i32) -> bool;
-export fn{Rs} lt Infix{"<"} :: (Deref{i32}, Deref{i32}) -> bool;
-export fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (i32, i32) -> bool;
-export fn{Rs} lte Infix{"<="} :: (Deref{i32}, Deref{i32}) -> bool;
-export fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (i32, i32) -> bool;
-export fn{Rs} gt Infix{">"} :: (Deref{i32}, Deref{i32}) -> bool;
-export fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" :: (i32, i32) -> bool;
-export fn{Rs} gte Infix{">="} :: (Deref{i32}, Deref{i32}) -> bool;
-export fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" :: (i32, i32) -> bool;
-export fn min (a: i32, b: i32) = if(a.lte(b), a, b);
-export fn max (a: i32, b: i32) = if(a.gte(b), a, b);
-export fn clamp(v: i32, l: i32, h: i32) = if(v.lte(l), l, if(v.gte(h), h, v));
-export fn{Rs} shl (a: i32, b: i32) = {Method{"wrapping_shl"} :: (i32, Deref{u32}) -> i32}(a, b.u32);
-export fn{Js} shl Method{"wrappingShl"} :: (i32, i32) -> i32;
-export fn{Rs} shr (a: i32, b: i32) = {Method{"wrapping_shr"} :: (i32, Deref{u32}) -> i32}(a, b.u32);
-export fn{Js} shr Method{"wrappingShr"} :: (i32, i32) -> i32;
-export fn{Rs} wrl (a: i32, b: i32) = {Method{"rotate_left"} :: (i32, Deref{u32}) -> i32}(a, b.u32);
-export fn{Js} wrl Method{"rotateLeft"} :: (i32, i32) -> i32;
-export fn{Rs} wrr (a: i32, b: i32) = {Method{"rotate_right"} :: (i32, Deref{u32}) -> i32}(a, b.u32);
-export fn{Js} wrr Method{"rotateRight"} :: (i32, i32) -> i32;
-export fn{Rs} clz (a: i32) = {Method{"leading_zeros"} :: i32 -> u32}(a).i32;
-export fn{Js} clz Method{"clz"} :: i32 -> i32;
-
-export fn{Rs} add Method{"wrapping_add"} :: (i64, Deref{i64}) -> i64;
-export fn{Js} add Method{"wrappingAdd"} :: (i64, i64) -> i64;
-export fn{Rs} sub Method{"wrapping_sub"} :: (i64, Deref{i64}) -> i64;
-export fn{Js} sub Method{"wrappingSub"} :: (i64, i64) -> i64;
-export fn{Rs} mul Method{"wrapping_mul"} :: (i64, Deref{i64}) -> i64;
-export fn{Js} mul Method{"wrappingMul"} :: (i64, i64) -> i64;
-export fn{Rs} div Method{"wrapping_div"} :: (i64, Deref{i64}) -> i64;
-export fn{Js} div Method{"wrappingDiv"} :: (i64, i64) -> i64;
-export fn{Rs} mod Method{"wrapping_rem"} :: (i64, Deref{i64}) -> i64;
-export fn{Js} mod Method{"wrappingMod"} :: (i64, i64) -> i64;
-export fn{Rs} pow (a: i64, b: i64) = {Method{"wrapping_pow"} :: (i64, Deref{u32}) -> i64}(a, b.u32);
-export fn{Js} pow Method{"wrappingPow"} :: (i64, i64) -> i64;
-export fn{Rs} abs Method{"abs"} :: i64 -> i64;
-export fn{Js} abs "((a) => new alan_std.I64(a < 0n ? -a : a))" <- RootBacking :: i64 -> i64;
-export fn{Rs} neg Prefix{"-"} :: Deref{i64} -> i64;
-export fn{Js} neg "((a) => new alan_std.I64(-a))" <- RootBacking :: i64 -> i64;
-export fn{Rs} and Infix{"&"} :: (Deref{i64}, Deref{i64}) -> i64;
-export fn{Js} and "((a, b) => new alan_std.I64(a & b))" <- RootBacking :: (i64, i64) -> i64;
-export fn{Rs} or Infix{"|"} :: (Deref{i64}, Deref{i64}) -> i64;
-export fn{Js} or "((a, b) => new alan_std.I64(a | b))" <- RootBacking :: (i64, i64) -> i64;
-export fn{Rs} xor Infix{"^"} :: (Deref{i64}, Deref{i64}) -> i64;
-export fn{Js} xor "((a, b) => new alan_std.I64(a ^ b))" <- RootBacking :: (i64, i64) -> i64;
-export fn{Rs} not Prefix{"!"} :: Deref{i64} -> i64;
-export fn{Js} not Method{"not"} :: i64 -> i64;
-export fn nand (a: i64, b: i64) = a.and(b).not;
-export fn nor (a: i64, b: i64) = a.or(b).not;
-export fn xnor (a: i64, b: i64) = a.xor(b).not;
-export fn{Rs} eq Infix{"=="} :: (Deref{i64}, Deref{i64}) -> bool;
-export fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (i64, i64) -> bool;
-export fn{Rs} neq Infix{"!="} :: (Deref{i64}, Deref{i64}) -> bool;
-export fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (i64, i64) -> bool;
-export fn{Rs} lt Infix{"<"} :: (Deref{i64}, Deref{i64}) -> bool;
-export fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (i64, i64) -> bool;
-export fn{Rs} lte Infix{"<="} :: (Deref{i64}, Deref{i64}) -> bool;
-export fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (i64, i64) -> bool;
-export fn{Rs} gt Infix{">"} :: (Deref{i64}, Deref{i64}) -> bool;
-export fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (i64, i64) -> bool;
-export fn{Rs} gte Infix{">="} :: (Deref{i64}, Deref{i64}) -> bool;
-export fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (i64, i64) -> bool;
-export fn min (a: i64, b: i64) = if(a.lte(b), a, b);
-export fn max (a: i64, b: i64) = if(a.gte(b), a, b);
-export fn clamp(v: i64, l: i64, h: i64) = if(v.lte(l), l, if(v.gte(h), h, v));
-export fn{Rs} shl (a: i64, b: i64) = {Method{"wrapping_shl"} :: (i64, Deref{u32}) -> i64}(a, b.u32);
-export fn{Js} shl Method{"wrappingShl"} :: (i64, i64) -> i64;
-export fn{Rs} shr (a: i64, b: i64) = {Method{"wrapping_shr"} :: (i64, Deref{u32}) -> i64}(a, b.u32);
-export fn{Js} shr Method{"wrappingShr"} :: (i64, i64) -> i64;
-export fn{Rs} wrl (a: i64, b: i64) = {Method{"rotate_left"} :: (i64, Deref{u32}) -> i64}(a, b.u32);
-export fn{Js} wrl Method{"rotateLeft"} :: (i64, i64) -> i64;
-export fn{Rs} wrr (a: i64, b: i64) = {Method{"rotate_right"} :: (i64, Deref{u32}) -> i64}(a, b.u32);
-export fn{Js} wrr Method{"rotateRight"} :: (i64, i64) -> i64;
-export fn{Rs} clz (a: i64) = {Method{"leading_zeros"} :: i64 -> u32}(a).i64;
-export fn{Js} clz Method{"clz"} :: i64 -> i64;
-
-/// Unsigned Integer-related functions and function bindings
-export fn{Rs} add Method{"wrapping_add"} :: (u8, Deref{u8}) -> u8;
-export fn{Js} add Method{"wrappingAdd"} :: (u8, u8) -> u8;
-export fn{Rs} sub Method{"wrapping_sub"} :: (u8, Deref{u8}) -> u8;
-export fn{Js} sub Method{"wrappingSub"} :: (u8, u8) -> u8;
-export fn{Rs} mul Method{"wrapping_mul"} :: (u8, Deref{u8}) -> u8;
-export fn{Js} mul Method{"wrappingMul"} :: (u8, u8) -> u8;
-export fn{Rs} div Method{"wrapping_div"} :: (u8, Deref{u8}) -> u8;
-export fn{Js} div Method{"wrappingDiv"} :: (u8, u8) -> u8;
-export fn{Rs} mod Method{"wrapping_rem"} :: (u8, Deref{u8}) -> u8;
-export fn{Js} mod Method{"wrappingMod"} :: (u8, u8) -> u8;
-export fn{Rs} pow (a: u8, b: u8) = {Method{"wrapping_pow"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
-export fn{Js} pow Method{"wrappingPow"} :: (u8, u8) -> u8;
-export fn{Rs} and Infix{"&"} :: (Deref{u8}, Deref{u8}) -> u8;
-export fn{Js} and "((a, b) => new alan_std.U8(a & b))" <- RootBacking :: (u8, u8) -> u8;
-export fn{Rs} or Infix{"|"} :: (Deref{u8}, Deref{u8}) -> u8;
-export fn{Js} or "((a, b) => new alan_std.U8(a | b))" <- RootBacking :: (u8, u8) -> u8;
-export fn{Rs} xor Infix{"^"} :: (Deref{u8}, Deref{u8}) -> u8;
-export fn{Js} xor "((a, b) => new alan_std.U8(a ^ b))" <- RootBacking :: (u8, u8) -> u8;
-export fn{Rs} not Prefix{"!"} :: Deref{u8} -> u8;
-export fn{Js} not Method{"not"} :: u8 -> u8;
-export fn nand (a: u8, b: u8) = a.and(b).not;
-export fn nor (a: u8, b: u8) = a.or(b).not;
-export fn xnor (a: u8, b: u8) = a.xor(b).not;
-export fn{Rs} eq Infix{"=="} :: (Deref{u8}, Deref{u8}) -> bool;
-export fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (u8, u8) -> bool;
-export fn{Rs} neq Infix{"!="} :: (Deref{u8}, Deref{u8}) -> bool;
-export fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (u8, u8) -> bool;
-export fn{Rs} lt Infix{"<"} :: (Deref{u8}, Deref{u8}) -> bool;
-export fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (u8, u8) -> bool;
-export fn{Rs} lte Infix{"<="} :: (Deref{u8}, Deref{u8}) -> bool;
-export fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (u8, u8) -> bool;
-export fn{Rs} gt Infix{">"} :: (Deref{u8}, Deref{u8}) -> bool;
-export fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (u8, u8) -> bool;
-export fn{Rs} gte Infix{">="} :: (Deref{u8}, Deref{u8}) -> bool;
-export fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (u8, u8) -> bool;
-export fn min (a: u8, b: u8) = if(a.lte(b), a, b);
-export fn max (a: u8, b: u8) = if(a.gte(b), a, b);
-export fn clamp(v: u8, l: u8, h: u8) = if(v.lte(l), l, if(v.gte(h), h, v));
-export fn{Rs} shl (a: u8, b: u8) = {Method{"wrapping_shl"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
-export fn{Js} shl Method{"wrappingShl"} :: (u8, u8) -> u8;
-export fn{Rs} shr (a: u8, b: u8) = {Method{"wrapping_shr"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
-export fn{Js} shr Method{"wrappingShr"} :: (u8, u8) -> u8;
-export fn{Rs} wrl (a: u8, b: u8) = {Method{"rotate_left"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
-export fn{Js} wrl Method{"rotateLeft"} :: (u8, u8) -> u8;
-export fn{Rs} wrr (a: u8, b: u8) = {Method{"rotate_right"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
-export fn{Js} wrr Method{"rotateRight"} :: (u8, u8) -> u8;
-export fn{Rs} clz (a: u8) = {Method{"leading_zeros"} :: u8 -> u32}(a).u8;
-export fn{Js} clz Method{"clz"} :: u8 -> u8;
-
-export fn{Rs} add Method{"wrapping_add"} :: (u16, Deref{u16}) -> u16;
-export fn{Js} add Method{"wrappingAdd"} :: (u16, u16) -> u16;
-export fn{Rs} sub Method{"wrapping_sub"} :: (u16, Deref{u16}) -> u16;
-export fn{Js} sub Method{"wrappingSub"} :: (u16, u16) -> u16;
-export fn{Rs} mul Method{"wrapping_mul"} :: (u16, Deref{u16}) -> u16;
-export fn{Js} mul Method{"wrappingMul"} :: (u16, u16) -> u16;
-export fn{Rs} div Method{"wrapping_div"} :: (u16, Deref{u16}) -> u16;
-export fn{Js} div Method{"wrappingDiv"} :: (u16, u16) -> u16;
-export fn{Rs} mod Method{"wrapping_rem"} :: (u16, Deref{u16}) -> u16;
-export fn{Js} mod Method{"wrappingMod"} :: (u16, u16) -> u16;
-export fn{Rs} pow (a: u16, b: u16) = {Method{"wrapping_pow"} :: (u16, Deref{u32}) -> u16}(a, b.u32);
-export fn{Js} pow Method{"wrappingPow"} :: (u16, u16) -> u16;
-export fn{Rs} and Infix{"&"} :: (Deref{u16}, Deref{u16}) -> u16;
-export fn{Js} and "((a, b) => new alan_std.U16(a & b))" <- RootBacking :: (u16, u16) -> u16;
-export fn{Rs} or Infix{"|"} :: (Deref{u16}, Deref{u16}) -> u16;
-export fn{Js} or "((a, b) => new alan_std.U16(a | b))" <- RootBacking :: (u16, u16) -> u16;
-export fn{Rs} xor Infix{"^"} :: (Deref{u16}, Deref{u16}) -> u16;
-export fn{Js} xor "((a, b) => new alan_std.U16(a ^ b))" <- RootBacking :: (u16, u16) -> u16;
-export fn{Rs} not Prefix{"!"} :: Deref{u16} -> u16;
-export fn{Js} not Method{"not"} :: u16 -> u16;
-export fn nand (a: u16, b: u16) = a.and(b).not;
-export fn nor (a: u16, b: u16) = a.or(b).not;
-export fn xnor (a: u16, b: u16) = a.xor(b).not;
-export fn{Rs} eq Infix{"=="} :: (Deref{u16}, Deref{u16}) -> bool;
-export fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (u16, u16) -> bool;
-export fn{Rs} neq Infix{"!="} :: (Deref{u16}, Deref{u16}) -> bool;
-export fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (u16, u16) -> bool;
-export fn{Rs} lt Infix{"<"} :: (Deref{u16}, Deref{u16}) -> bool;
-export fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (u16, u16) -> bool;
-export fn{Rs} lte Infix{"<="} :: (Deref{u16}, Deref{u16}) -> bool;
-export fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (u16, u16) -> bool;
-export fn{Rs} gt Infix{">"} :: (Deref{u16}, Deref{u16}) -> bool;
-export fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (u16, u16) -> bool;
-export fn{Rs} gte Infix{">="} :: (Deref{u16}, Deref{u16}) -> bool;
-export fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (u16, u16) -> bool;
-export fn min (a: u16, b: u16) = if(a.lte(b), a, b);
-export fn max (a: u16, b: u16) = if(a.gte(b), a, b);
-export fn clamp(v: u16, l: u16, h: u16) = if(v.lte(l), l, if(v.gte(h), h, v));
-export fn{Rs} shl (a: u16, b: u16) = {Method{"wrapping_shl"} :: (u16, Deref{u32}) -> u16}(a, b.u32);
-export fn{Js} shl Method{"wrappingShl"} :: (u16, u16) -> u16;
-export fn{Rs} shr (a: u16, b: u16) = {Method{"wrapping_shr"} :: (u16, Deref{u32}) -> u16}(a, b.u32);
-export fn{Js} shr Method{"wrappingShr"} :: (u16, u16) -> u16;
-export fn{Rs} wrl (a: u16, b: u16) = {Method{"rotate_left"} :: (u16, Deref{u32}) -> u16}(a, b.u32);
-export fn{Js} wrl Method{"rotateLeft"} :: (u16, u16) -> u16;
-export fn{Rs} wrr (a: u16, b: u16) = {Method{"rotate_right"} :: (u16, Deref{u32}) -> u16}(a, b.u32);
-export fn{Js} wrr Method{"rotateRight"} :: (u16, u16) -> u16;
-export fn{Rs} clz (a: u16) = {Method{"leading_zeros"} :: u16 -> u32}(a).u16;
-export fn{Js} clz Method{"clz"} :: u16 -> u16;
-
-export fn{Rs} add Method{"wrapping_add"} :: (u32, Deref{u32}) -> u32;
-export fn{Js} add Method{"wrappingAdd"} :: (u32, u32) -> u32;
-export fn{Rs} sub Method{"wrapping_sub"} :: (u32, Deref{u32}) -> u32;
-export fn{Js} sub Method{"wrappingSub"} :: (u32, u32) -> u32;
-export fn{Rs} mul Method{"wrapping_mul"} :: (u32, Deref{u32}) -> u32;
-export fn{Js} mul Method{"wrappingMul"} :: (u32, u32) -> u32;
-export fn{Rs} div Method{"wrapping_div"} :: (u32, Deref{u32}) -> u32;
-export fn{Js} div Method{"wrappingDiv"} :: (u32, u32) -> u32;
-export fn{Rs} mod Method{"wrapping_rem"} :: (u32, Deref{u32}) -> u32;
-export fn{Js} mod Method{"wrappingMod"} :: (u32, u32) -> u32;
-export fn{Rs} pow (a: u32, b: u32) = {Method{"wrapping_pow"} :: (u32, Deref{u32}) -> u32}(a, b.u32);
-export fn{Js} pow Method{"wrappingPow"} :: (u32, u32) -> u32;
-export fn{Rs} and Infix{"&"} :: (Deref{u32}, Deref{u32}) -> u32;
-export fn{Js} and "((a, b) => new alan_std.U32(a & b))" <- RootBacking :: (u32, u32) -> u32;
-export fn{Rs} or Infix{"|"} :: (Deref{u32}, Deref{u32}) -> u32;
-export fn{Js} or "((a, b) => new alan_std.U32(a | b))" <- RootBacking :: (u32, u32) -> u32;
-export fn{Rs} xor Infix{"^"} :: (Deref{u32}, Deref{u32}) -> u32;
-export fn{Js} xor "((a, b) => new alan_std.U32(a ^ b))" <- RootBacking :: (u32, u32) -> u32;
-export fn{Rs} not Prefix{"!"} :: Deref{u32} -> u32;
-export fn{Js} not Method{"not"} :: u32 -> u32;
-export fn nand (a: u32, b: u32) = a.and(b).not;
-export fn nor (a: u32, b: u32) = a.or(b).not;
-export fn xnor (a: u32, b: u32) = a.xor(b).not;
-export fn{Rs} eq Infix{"=="} :: (Deref{u32}, Deref{u32}) -> bool;
-export fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (u32, u32) -> bool;
-export fn{Rs} neq Infix{"!="} :: (Deref{u32}, Deref{u32}) -> bool;
-export fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (u32, u32) -> bool;
-export fn{Rs} lt Infix{"<"} :: (Deref{u32}, Deref{u32}) -> bool;
-export fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (u32, u32) -> bool;
-export fn{Rs} lte Infix{"<="} :: (Deref{u32}, Deref{u32}) -> bool;
-export fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (u32, u32) -> bool;
-export fn{Rs} gt Infix{">"} :: (Deref{u32}, Deref{u32}) -> bool;
-export fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (u32, u32) -> bool;
-export fn{Rs} gte Infix{">="} :: (Deref{u32}, Deref{u32}) -> bool;
-export fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (u32, u32) -> bool;
-export fn min (a: u32, b: u32) = if(a.lte(b), a, b);
-export fn max (a: u32, b: u32) = if(a.gte(b), a, b);
-export fn clamp(v: u32, l: u32, h: u32) = if(v.lte(l), l, if(v.gte(h), h, v));
-export fn{Rs} shl (a: u32, b: u32) = {Method{"wrapping_shl"} :: (u32, Deref{u32}) -> u32}(a, b.u32);
-export fn{Js} shl Method{"wrappingShl"} :: (u32, u32) -> u32;
-export fn{Rs} shr (a: u32, b: u32) = {Method{"wrapping_shr"} :: (u32, Deref{u32}) -> u32}(a, b.u32);
-export fn{Js} shr Method{"wrappingShr"} :: (u32, u32) -> u32;
-export fn{Rs} wrl (a: u32, b: u32) = {Method{"rotate_left"} :: (u32, Deref{u32}) -> u32}(a, b.u32);
-export fn{Js} wrl Method{"rotateLeft"} :: (u32, u32) -> u32;
-export fn{Rs} wrr (a: u32, b: u32) = {Method{"rotate_right"} :: (u32, Deref{u32}) -> u32}(a, b.u32);
-export fn{Js} wrr Method{"rotateRight"} :: (u32, u32) -> u32;
-export fn{Rs} clz Method{"leading_zeros"} :: u32 -> u32;
-export fn{Js} clz Method{"clz"} :: u32 -> u32;
-
-export fn{Rs} add Method{"wrapping_add"} :: (u64, Deref{u64}) -> u64;
-export fn{Js} add Method{"wrappingAdd"} :: (u64, u64) -> u64;
-export fn{Rs} sub Method{"wrapping_sub"} :: (u64, Deref{u64}) -> u64;
-export fn{Js} sub Method{"wrappingSub"} :: (u64, u64) -> u64;
-export fn{Rs} mul Method{"wrapping_mul"} :: (u64, Deref{u64}) -> u64;
-export fn{Js} mul Method{"wrappingMul"} :: (u64, u64) -> u64;
-export fn{Rs} div Method{"wrapping_div"} :: (u64, Deref{u64}) -> u64;
-export fn{Js} div Method{"wrappingDiv"} :: (u64, u64) -> u64;
-export fn{Rs} mod Method{"wrapping_rem"} :: (u64, Deref{u64}) -> u64;
-export fn{Js} mod Method{"wrappingMod"} :: (u64, u64) -> u64;
-export fn{Rs} pow (a: u64, b: u64) = {Method{"wrapping_pow"} :: (u64, Deref{u32}) -> u64}(a, b.u32);
-export fn{Js} pow Method{"wrappingPow"} :: (u64, u64) -> u64;
-export fn{Rs} and Infix{"&"} :: (Deref{u64}, Deref{u64}) -> u64;
-export fn{Js} and "((a, b) => new alan_std.U64(a & b))" <- RootBacking :: (u64, u64) -> u64;
-export fn{Rs} or Infix{"|"} :: (Deref{u64}, Deref{u64}) -> u64;
-export fn{Js} or "((a, b) => new alan_std.U64(a | b))" <- RootBacking :: (u64, u64) -> u64;
-export fn{Rs} xor Infix{"^"} :: (Deref{u64}, Deref{u64}) -> u64;
-export fn{Js} xor "((a, b) => new alan_std.U64(a ^ b))" <- RootBacking :: (u64, u64) -> u64;
-export fn{Rs} not Prefix{"!"} :: Deref{u64} -> u64;
-export fn{Js} not Method{"not"} :: u64 -> u64;
-export fn nand (a: u64, b: u64) = a.and(b).not;
-export fn nor (a: u64, b: u64) = a.or(b).not;
-export fn xnor (a: u64, b: u64) = a.xor(b).not;
-export fn{Rs} eq Infix{"=="} :: (Deref{u64}, Deref{u64}) -> bool;
-export fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (u64, u64) -> bool;
-export fn{Rs} neq Infix{"!="} :: (Deref{u64}, Deref{u64}) -> bool;
-export fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (u64, u64) -> bool;
-export fn{Rs} lt Infix{"<"} :: (Deref{u64}, Deref{u64}) -> bool;
-export fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (u64, u64) -> bool;
-export fn{Rs} lte Infix{"<="} :: (Deref{u64}, Deref{u64}) -> bool;
-export fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (u64, u64) -> bool;
-export fn{Rs} gt Infix{">"} :: (Deref{u64}, Deref{u64}) -> bool;
-export fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (u64, u64) -> bool;
-export fn{Rs} gte Infix{">="} :: (Deref{u64}, Deref{u64}) -> bool;
-export fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (u64, u64) -> bool;
-export fn min (a: u64, b: u64) = if(a.lte(b), a, b);
-export fn max (a: u64, b: u64) = if(a.gte(b), a, b);
-export fn clamp(v: u64, l: u64, h: u64) = if(v.lte(l), l, if(v.gte(h), h, v));
-export fn{Rs} shl (a: u64, b: u64) = {Method{"wrapping_shl"} :: (u64, Deref{u32}) -> u64}(a, b.u32);
-export fn{Js} shl Method{"wrappingShl"} :: (u64, u64) -> u64;
-export fn{Rs} shr (a: u64, b: u64) = {Method{"wrapping_shr"} :: (u64, Deref{u32}) -> u64}(a, b.u32);
-export fn{Js} shr Method{"wrappingShr"} :: (u64, u64) -> u64;
-export fn{Rs} wrl (a: u64, b: u64) = {Method{"rotate_left"} :: (u64, Deref{u32}) -> u64}(a, b.u32);
-export fn{Js} wrl Method{"rotateLeft"} :: (u64, u64) -> u64;
-export fn{Rs} wrr (a: u64, b: u64) = {Method{"rotate_right"} :: (u64, Deref{u32}) -> u64}(a, b.u32);
-export fn{Js} wrr Method{"rotateRight"} :: (u64, u64) -> u64;
-export fn{Rs} clz (a: u64) = {Method{"leading_zeros"} :: u64 -> u32}(a).u64;
-export fn{Js} clz Method{"clz"} :: u64 -> u64;
+fn{Rs} and Infix{"&&"} :: (Deref{bool}, Deref{bool}) -> bool;
+fn{Js} and "((a, b) => new alan_std.Bool(a.val && b.val))" <- RootBacking :: (bool, bool) -> bool;
+fn{Rs} or Infix{"||"} :: (Deref{bool}, Deref{bool}) -> bool;
+fn{Js} or "((a, b) => new alan_std.Bool(a.val || b.val))" <- RootBacking :: (bool, bool) -> bool;
+fn{Rs} xor Infix{"^"} :: (Deref{bool}, Deref{bool}) -> bool;
+fn{Js} xor "((a, b) => new alan_std.Bool(!!(a.val ^ b.val)))" <- RootBacking :: (bool, bool) -> bool;
+fn{Rs} not Prefix{"!"} :: Deref{bool} -> bool;
+fn{Js} not "((a) => new alan_std.Bool(!a.val))" :: bool -> bool;
+fn nand (a: bool, b: bool) = a.and(b).not;
+fn nor (a: bool, b: bool) = a.or(b).not;
+fn{Rs} xnor Infix{"=="} :: (bool, bool) -> bool;
+fn{Js} xnor "((a, b) => new alan_std.Bool(a.val == b.val))" :: (bool, bool) -> bool;
+fn{Rs} eq Infix{"=="} :: (bool, bool) -> bool;
+fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" :: (bool, bool) -> bool;
+fn{Rs} neq Infix{"!="} :: (bool, bool) -> bool;
+fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" :: (bool, bool) -> bool;
+fn if{T}(c: bool, t: T) = if(c, fn () = Maybe{T}(t), fn () = Maybe{T}());
+fn if{T}(c: bool, t: T, f: T) = if(c, fn () = t, fn () = f);
+fn if{T}(c: bool, t: () -> T) = if(c, fn () = Maybe{T}(t()), fn () = Maybe{T}());
+fn{Rs} if{T} "alan_std::ifbool" <- RootBacking :: (bool, () -> T, () -> T) -> T;
+fn{Js} if{T} "alan_std.ifbool" <- RootBacking :: (bool, () -> T, () -> T) -> T;
 
 /// Float-related functions and function bindings
-export fn{Rs} add Infix{"+"} :: (f32, f32) -> f32;
-export fn{Js} add "((a, b) => new alan_std.F32(a.val + b.val))" <- RootBacking :: (f32, f32) -> f32;
-export fn{Rs} sub Infix{"-"} :: (f32, f32) -> f32;
-export fn{Js} sub "((a, b) => new alan_std.F32(a.val - b.val))" <- RootBacking :: (f32, f32) -> f32;
-export fn{Rs} mul Infix{"*"} :: (f32, f32) -> f32;
-export fn{Js} mul "((a, b) => new alan_std.F32(a.val * b.val))" <- RootBacking :: (f32, f32) -> f32;
-export fn{Rs} div Infix{"/"} :: (f32, f32) -> f32;
-export fn{Js} div "((a, b) => new alan_std.F32(a.val / b.val))" <- RootBacking :: (f32, f32) -> f32;
-export fn{Rs} sqrt Method{"sqrt"} :: f32 -> f32;
-export fn{Js} sqrt "((a) => new alan_std.F32(Math.sqrt(a)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} pow Method{"powf"} :: (f32, Deref{f32}) -> f32;
-export fn{Js} pow "((a, b) => new alan_std.F32(a.val ** b.val))" <- RootBacking :: (f32, f32) -> f32;
-export fn{Rs} abs Method{"abs"} :: f32 -> f32;
-export fn{Js} abs "((a) => new alan_std.F32(Math.abs(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} neg Prefix{"-"} :: Deref{f32} -> f32;
-export fn{Js} neg "((a) => new alan_std.F32(-a.val))" <- RootBacking :: f32 -> f32;
-export fn{Rs} eq Infix{"=="} :: (Deref{f32}, Deref{f32}) -> bool;
-export fn{Js} eq "((a, b) => new alan_std.F32(a.val == b.val))" <- RootBacking :: (f32, f32) -> bool;
-export fn{Rs} neq Infix{"!="} :: (Deref{f32}, Deref{f32}) -> bool;
-export fn{Js} neq "((a, b) => new alan_std.F32(a.val != b.val))" <- RootBacking :: (f32, f32) -> bool;
-export fn{Rs} lt Infix{"<"} :: (Deref{f32}, Deref{f32}) -> bool;
-export fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (f32, f32) -> bool;
-export fn{Rs} lte Infix{"<="} :: (Deref{f32}, Deref{f32}) -> bool;
-export fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (f32, f32) -> bool;
-export fn{Rs} gt Infix{">"} :: (Deref{f32}, Deref{f32}) -> bool;
-export fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (f32, f32) -> bool;
-export fn{Rs} gte Infix{">="} :: (Deref{f32}, Deref{f32}) -> bool;
-export fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (f32, f32) -> bool;
-export fn min (a: f32, b: f32) = if(a.lte(b), a, b);
-export fn max (a: f32, b: f32) = if(a.gte(b), a, b);
-export fn clamp(v: f32, l: f32, h: f32) = if(v.lte(l), l, if(v.gte(h), h, v));
-export fn{Rs} floor Method{"floor"} :: f32 -> f32;
-export fn{Js} floor "((a) => new alan_std.F32(Math.floor(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} ceil Method{"ceil"} :: f32 -> f32;
-export fn{Js} ceil "((a) => new alan_std.F32(Math.ceil(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} acos Method{"acos"} :: f32 -> f32;
-export fn{Js} acos "((a) => new alan_std.F32(Math.acos(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} acosh Method{"acosh"} :: f32 -> f32;
-export fn{Js} acosh "((a) => new alan_std.F32(Math.acosh(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} asin Method{"asin"} :: f32 -> f32;
-export fn{Js} asin "((a) => new alan_std.F32(Math.asin(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} asinh Method{"asinh"} :: f32 -> f32;
-export fn{Js} asinh "((a) => new alan_std.F32(Math.asinh(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} atan Method{"atan"} :: f32 -> f32;
-export fn{Js} atan "((a) => new alan_std.F32(Math.atan(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} atanh Method{"atanh"} :: f32 -> f32;
-export fn{Js} atanh "((a) => new alan_std.F32(Math.atanh(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} atan2 Method{"atan2"} :: (f32, Deref{f32}) -> f32;
-export fn{Js} atan2 "((a, b) => new alan_std.F32(Math.atan2(a.val, b.val)))" <- RootBacking :: (f32, f32) -> f32;
-export fn{Rs} cos Method{"cos"} :: f32 -> f32;
-export fn{Js} cos "((a) => new alan_std.F32(Math.cos(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} cosh Method{"cosh"} :: f32 -> f32;
-export fn{Js} cosh "((a) => new alan_std.F32(Math.cosh(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} sin Method{"sin"} :: f32 -> f32;
-export fn{Js} sin "((a) => new alan_std.F32(Math.sin(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} sinh Method{"sinh"} :: f32 -> f32;
-export fn{Js} sinh "((a) => new alan_std.F32(Math.sinh(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} tan Method{"tan"} :: f32 -> f32;
-export fn{Js} tan "((a) => new alan_std.F32(Math.tan(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} tanh Method{"tanh"} :: f32 -> f32;
-export fn{Js} tanh "((a) => new alan_std.F32(Math.tanh(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} exp Method{"exp"} :: f32 -> f32;
-export fn{Js} exp "((a) => new alan_std.F32(Math.exp(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} ln Method{"ln"} :: f32 -> f32;
-export fn{Js} ln "((a) => new alan_std.F32(Math.log(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} log2 Method{"log2"} :: f32 -> f32;
-export fn{Js} log2 "((a) => new alan_std.F32(Math.log2(a.val)))" <- RootBacking :: f32 -> f32;
-export fn{Rs} log10 Method{"log10"} :: f32 -> f32;
-export fn{Js} log10 "((a) => new alan_std.F32(Math.log10(a.val)))" <- RootBacking :: f32 -> f32;
-export fn sec(x: f32) = 1.0.f32.div(cos(x));
-export fn csc(x: f32) = 1.0.f32.div(sin(x));
-export fn cot(x: f32) = 1.0.f32.div(tan(x));
-export fn asec(x: f32) = acos(1.0.f32.div(x));
-export fn acsc(x: f32) = asin(1.0.f32.div(x));
-export fn acot(x: f32) = pi.f32.div(2.0.f32).sub(atan(x));
-export fn sech(x: f32) = 1.0.f32.div(cosh(x));
-export fn csch(x: f32) = 1.0.f32.div(sinh(x));
-export fn coth(x: f32) = 1.0.f32.div(tanh(x));
-export fn asech(x: f32) = ln(1.0.f32.add(sqrt(1.0.f32.sub(x.pow(2.0.f32)))).div(x));
-export fn acsch(x: f32) = ln(1.0.f32.div(x).add(sqrt(1.0.f32.div(x.pow(2.0.f32)).add(1.0.f32))));
-export fn acoth(x: f32) = ln(x.add(1.0.f32).div(x.sub(1.0.f32))).div(2.0.f32);
+fn{Rs} add Infix{"+"} :: (f32, f32) -> f32;
+fn{Js} add "((a, b) => new alan_std.F32(a.val + b.val))" <- RootBacking :: (f32, f32) -> f32;
+fn{Rs} sub Infix{"-"} :: (f32, f32) -> f32;
+fn{Js} sub "((a, b) => new alan_std.F32(a.val - b.val))" <- RootBacking :: (f32, f32) -> f32;
+fn{Rs} mul Infix{"*"} :: (f32, f32) -> f32;
+fn{Js} mul "((a, b) => new alan_std.F32(a.val * b.val))" <- RootBacking :: (f32, f32) -> f32;
+fn{Rs} div Infix{"/"} :: (f32, f32) -> f32;
+fn{Js} div "((a, b) => new alan_std.F32(a.val / b.val))" <- RootBacking :: (f32, f32) -> f32;
+fn{Rs} sqrt Method{"sqrt"} :: f32 -> f32;
+fn{Js} sqrt "((a) => new alan_std.F32(Math.sqrt(a)))" <- RootBacking :: f32 -> f32;
+fn{Rs} pow Method{"powf"} :: (f32, Deref{f32}) -> f32;
+fn{Js} pow "((a, b) => new alan_std.F32(a.val ** b.val))" <- RootBacking :: (f32, f32) -> f32;
+fn{Rs} abs Method{"abs"} :: f32 -> f32;
+fn{Js} abs "((a) => new alan_std.F32(Math.abs(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} neg Prefix{"-"} :: Deref{f32} -> f32;
+fn{Js} neg "((a) => new alan_std.F32(-a.val))" <- RootBacking :: f32 -> f32;
+fn{Rs} eq Infix{"=="} :: (Deref{f32}, Deref{f32}) -> bool;
+fn{Js} eq "((a, b) => new alan_std.F32(a.val == b.val))" <- RootBacking :: (f32, f32) -> bool;
+fn{Rs} neq Infix{"!="} :: (Deref{f32}, Deref{f32}) -> bool;
+fn{Js} neq "((a, b) => new alan_std.F32(a.val != b.val))" <- RootBacking :: (f32, f32) -> bool;
+fn{Rs} lt Infix{"<"} :: (Deref{f32}, Deref{f32}) -> bool;
+fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (f32, f32) -> bool;
+fn{Rs} lte Infix{"<="} :: (Deref{f32}, Deref{f32}) -> bool;
+fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (f32, f32) -> bool;
+fn{Rs} gt Infix{">"} :: (Deref{f32}, Deref{f32}) -> bool;
+fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (f32, f32) -> bool;
+fn{Rs} gte Infix{">="} :: (Deref{f32}, Deref{f32}) -> bool;
+fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (f32, f32) -> bool;
+fn min (a: f32, b: f32) = if(a <= b, a, b);
+fn max (a: f32, b: f32) = if(a >= b, a, b);
+fn clamp(v: f32, l: f32, h: f32) = if(v <= l, l, if(v >= h, h, v));
+fn{Rs} floor Method{"floor"} :: f32 -> f32;
+fn{Js} floor "((a) => new alan_std.F32(Math.floor(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} ceil Method{"ceil"} :: f32 -> f32;
+fn{Js} ceil "((a) => new alan_std.F32(Math.ceil(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} acos Method{"acos"} :: f32 -> f32;
+fn{Js} acos "((a) => new alan_std.F32(Math.acos(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} acosh Method{"acosh"} :: f32 -> f32;
+fn{Js} acosh "((a) => new alan_std.F32(Math.acosh(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} asin Method{"asin"} :: f32 -> f32;
+fn{Js} asin "((a) => new alan_std.F32(Math.asin(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} asinh Method{"asinh"} :: f32 -> f32;
+fn{Js} asinh "((a) => new alan_std.F32(Math.asinh(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} atan Method{"atan"} :: f32 -> f32;
+fn{Js} atan "((a) => new alan_std.F32(Math.atan(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} atanh Method{"atanh"} :: f32 -> f32;
+fn{Js} atanh "((a) => new alan_std.F32(Math.atanh(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} atan2 Method{"atan2"} :: (f32, Deref{f32}) -> f32;
+fn{Js} atan2 "((a, b) => new alan_std.F32(Math.atan2(a.val, b.val)))" <- RootBacking :: (f32, f32) -> f32;
+fn{Rs} cos Method{"cos"} :: f32 -> f32;
+fn{Js} cos "((a) => new alan_std.F32(Math.cos(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} cosh Method{"cosh"} :: f32 -> f32;
+fn{Js} cosh "((a) => new alan_std.F32(Math.cosh(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} sin Method{"sin"} :: f32 -> f32;
+fn{Js} sin "((a) => new alan_std.F32(Math.sin(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} sinh Method{"sinh"} :: f32 -> f32;
+fn{Js} sinh "((a) => new alan_std.F32(Math.sinh(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} tan Method{"tan"} :: f32 -> f32;
+fn{Js} tan "((a) => new alan_std.F32(Math.tan(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} tanh Method{"tanh"} :: f32 -> f32;
+fn{Js} tanh "((a) => new alan_std.F32(Math.tanh(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} exp Method{"exp"} :: f32 -> f32;
+fn{Js} exp "((a) => new alan_std.F32(Math.exp(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} ln Method{"ln"} :: f32 -> f32;
+fn{Js} ln "((a) => new alan_std.F32(Math.log(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} log2 Method{"log2"} :: f32 -> f32;
+fn{Js} log2 "((a) => new alan_std.F32(Math.log2(a.val)))" <- RootBacking :: f32 -> f32;
+fn{Rs} log10 Method{"log10"} :: f32 -> f32;
+fn{Js} log10 "((a) => new alan_std.F32(Math.log10(a.val)))" <- RootBacking :: f32 -> f32;
+fn sec(x: f32) = 1.0.f32 / cos(x);
+fn csc(x: f32) = 1.0.f32 / sin(x);
+fn cot(x: f32) = 1.0.f32 / tan(x);
+fn asec(x: f32) = acos(1.0.f32 / x);
+fn acsc(x: f32) = asin(1.0.f32 / x);
+fn acot(x: f32) = pi.f32 / 2.0.f32 - atan(x);
+fn sech(x: f32) = 1.0.f32 / cosh(x);
+fn csch(x: f32) = 1.0.f32 / sinh(x);
+fn coth(x: f32) = 1.0.f32 / tanh(x);
+fn asech(x: f32) = ln((1.0.f32 + sqrt(1.0.f32 - x ** 2.0.f32)) / x);
+fn acsch(x: f32) = ln(1.0.f32 / x + sqrt(1.0.f32 / x ** 2.0.f32 + 1.0.f32));
+fn acoth(x: f32) = ln((x + 1.0.f32) / (x - 1.0.f32)) / 2.0.f32;
 
-export fn{Rs} add Infix{"+"} :: (f64, f64) -> f64;
-export fn{Js} add "((a, b) => new alan_std.F64(a.val + b.val))" <- RootBacking :: (f64, f64) -> f64;
-export fn{Rs} sub Infix{"-"} :: (f64, f64) -> f64;
-export fn{Js} sub "((a, b) => new alan_std.F64(a.val - b.val))" <- RootBacking :: (f64, f64) -> f64;
-export fn{Rs} mul Infix{"*"} :: (f64, f64) -> f64;
-export fn{Js} mul "((a, b) => new alan_std.F64(a.val * b.val))" <- RootBacking :: (f64, f64) -> f64;
-export fn{Rs} div Infix{"/"} :: (f64, f64) -> f64;
-export fn{Js} div "((a, b) => new alan_std.F64(a.val / b.val))" <- RootBacking :: (f64, f64) -> f64;
-export fn{Rs} sqrt Method{"sqrt"} :: f64 -> f64;
-export fn{Js} sqrt "((a) => new alan_std.F64(Math.sqrt(a)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} pow Method{"powf"} :: (f64, Deref{f64}) -> f64;
-export fn{Js} pow "((a, b) => new alan_std.F64(a.val ** b.val))" <- RootBacking :: (f64, f64) -> f64;
-export fn{Rs} abs Method{"abs"} :: f64 -> f64;
-export fn{Js} abs "((a) => new alan_std.F64(Math.abs(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} neg Prefix{"-"} :: Deref{f64} -> f64;
-export fn{Js} neg "((a) => new alan_std.F64(-a.val))" <- RootBacking :: f64 -> f64;
-export fn{Rs} eq Infix{"=="} :: (Deref{f64}, Deref{f64}) -> bool;
-export fn{Js} eq "((a, b) => new alan_std.F64(a.val == b.val))" <- RootBacking :: (f64, f64) -> bool;
-export fn{Rs} neq Infix{"!="} :: (Deref{f64}, Deref{f64}) -> bool;
-export fn{Js} neq "((a, b) => new alan_std.F64(a.val != b.val))" <- RootBacking :: (f64, f64) -> bool;
-export fn{Rs} lt Infix{"<"} :: (Deref{f64}, Deref{f64}) -> bool;
-export fn{Js} lt "((a, b) => new alan_std.F64(a.val < b.val))" <- RootBacking :: (f64, f64) -> bool;
-export fn{Rs} lte Infix{"<="} :: (Deref{f64}, Deref{f64}) -> bool;
-export fn{Js} lte "((a, b) => new alan_std.F64(a.val <= b.val))" <- RootBacking :: (f64, f64) -> bool;
-export fn{Rs} gt Infix{">"} :: (Deref{f64}, Deref{f64}) -> bool;
-export fn{Js} gt "((a, b) => new alan_std.F64(a.val > b.val))" <- RootBacking :: (f64, f64) -> bool;
-export fn{Rs} gte Infix{">="} :: (Deref{f64}, Deref{f64}) -> bool;
-export fn{Js} gte "((a, b) => new alan_std.F64(a.val >= b.val))" <- RootBacking :: (f64, f64) -> bool;
-export fn min (a: f64, b: f64) = if(a.lte(b), a, b);
-export fn max (a: f64, b: f64) = if(a.gte(b), a, b);
-export fn clamp(v: f64, l: f64, h: f64) = if(v.lte(l), l, if(v.gte(h), h, v));
-export fn{Rs} floor Method{"floor"} :: f64 -> f64;
-export fn{Js} floor "((a) => new alan_std.F64(Math.floor(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} ceil Method{"ceil"} :: f64 -> f64;
-export fn{Js} ceil "((a) => new alan_std.F64(Math.ceil(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} acos Method{"acos"} :: f64 -> f64;
-export fn{Js} acos "((a) => new alan_std.F64(Math.acos(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} acosh Method{"acosh"} :: f64 -> f64;
-export fn{Js} acosh "((a) => new alan_std.F64(Math.acosh(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} asin Method{"asin"} :: f64 -> f64;
-export fn{Js} asin "((a) => new alan_std.F64(Math.asin(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} asinh Method{"asinh"} :: f64 -> f64;
-export fn{Js} asinh "((a) => new alan_std.F64(Math.asinh(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} atan Method{"atan"} :: f64 -> f64;
-export fn{Js} atan "((a) => new alan_std.F64(Math.atan(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} atanh Method{"atanh"} :: f64 -> f64;
-export fn{Js} atanh "((a) => new alan_std.F64(Math.atanh(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} atan2 Method{"atan2"} :: (f64, Deref{f64}) -> f64;
-export fn{Js} atan2 "((a, b) => new alan_std.F64(Math.atan2(a.val, b.val)))" <- RootBacking :: (f64, f64) -> f64;
-export fn{Rs} cos Method{"cos"} :: f64 -> f64;
-export fn{Js} cos "((a) => new alan_std.F64(Math.cos(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} cosh Method{"cosh"} :: f64 -> f64;
-export fn{Js} cosh "((a) => new alan_std.F64(Math.cosh(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} sin Method{"sin"} :: f64 -> f64;
-export fn{Js} sin "((a) => new alan_std.F64(Math.sin(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} sinh Method{"sinh"} :: f64 -> f64;
-export fn{Js} sinh "((a) => new alan_std.F64(Math.sinh(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} tan Method{"tan"} :: f64 -> f64;
-export fn{Js} tan "((a) => new alan_std.F64(Math.tan(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} tanh Method{"tanh"} :: f64 -> f64;
-export fn{Js} tanh "((a) => new alan_std.F64(Math.tanh(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} exp Method{"exp"} :: f64 -> f64;
-export fn{Js} exp "((a) => new alan_std.F64(Math.exp(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} ln Method{"ln"} :: f64 -> f64;
-export fn{Js} ln "((a) => new alan_std.F64(Math.log(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} log2 Method{"log2"} :: f64 -> f64;
-export fn{Js} log2 "((a) => new alan_std.F64(Math.log2(a.val)))" <- RootBacking :: f64 -> f64;
-export fn{Rs} log10 Method{"log10"} :: f64 -> f64;
-export fn{Js} log10 "((a) => new alan_std.F64(Math.log10(a.val)))" <- RootBacking :: f64 -> f64;
-export fn sec(x: f64) = 1.0.div(cos(x));
-export fn csc(x: f64) = 1.0.div(sin(x));
-export fn cot(x: f64) = 1.0.div(tan(x));
-export fn asec(x: f64) = acos(1.0.div(x));
-export fn acsc(x: f64) = asin(1.0.div(x));
-export fn acot(x: f64) = pi.div(2.0).sub(atan(x));
-export fn sech(x: f64) = 1.0.div(cosh(x));
-export fn csch(x: f64) = 1.0.div(sinh(x));
-export fn coth(x: f64) = 1.0.div(tanh(x));
-export fn asech(x: f64) = ln(1.0.add(sqrt(1.0.sub(x.pow(2.0)))).div(x));
-export fn acsch(x: f64) = ln(1.0.div(x).add(sqrt(1.0.div(x.pow(2.0)).add(1.0))));
-export fn acoth(x: f64) = ln(x.add(1.0).div(x.sub(1.0))).div(2.0);
+fn{Rs} add Infix{"+"} :: (f64, f64) -> f64;
+fn{Js} add "((a, b) => new alan_std.F64(a.val + b.val))" <- RootBacking :: (f64, f64) -> f64;
+fn{Rs} sub Infix{"-"} :: (f64, f64) -> f64;
+fn{Js} sub "((a, b) => new alan_std.F64(a.val - b.val))" <- RootBacking :: (f64, f64) -> f64;
+fn{Rs} mul Infix{"*"} :: (f64, f64) -> f64;
+fn{Js} mul "((a, b) => new alan_std.F64(a.val * b.val))" <- RootBacking :: (f64, f64) -> f64;
+fn{Rs} div Infix{"/"} :: (f64, f64) -> f64;
+fn{Js} div "((a, b) => new alan_std.F64(a.val / b.val))" <- RootBacking :: (f64, f64) -> f64;
+fn{Rs} sqrt Method{"sqrt"} :: f64 -> f64;
+fn{Js} sqrt "((a) => new alan_std.F64(Math.sqrt(a)))" <- RootBacking :: f64 -> f64;
+fn{Rs} pow Method{"powf"} :: (f64, Deref{f64}) -> f64;
+fn{Js} pow "((a, b) => new alan_std.F64(a.val ** b.val))" <- RootBacking :: (f64, f64) -> f64;
+fn{Rs} abs Method{"abs"} :: f64 -> f64;
+fn{Js} abs "((a) => new alan_std.F64(Math.abs(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} neg Prefix{"-"} :: Deref{f64} -> f64;
+fn{Js} neg "((a) => new alan_std.F64(-a.val))" <- RootBacking :: f64 -> f64;
+fn{Rs} eq Infix{"=="} :: (Deref{f64}, Deref{f64}) -> bool;
+fn{Js} eq "((a, b) => new alan_std.F64(a.val == b.val))" <- RootBacking :: (f64, f64) -> bool;
+fn{Rs} neq Infix{"!="} :: (Deref{f64}, Deref{f64}) -> bool;
+fn{Js} neq "((a, b) => new alan_std.F64(a.val != b.val))" <- RootBacking :: (f64, f64) -> bool;
+fn{Rs} lt Infix{"<"} :: (Deref{f64}, Deref{f64}) -> bool;
+fn{Js} lt "((a, b) => new alan_std.F64(a.val < b.val))" <- RootBacking :: (f64, f64) -> bool;
+fn{Rs} lte Infix{"<="} :: (Deref{f64}, Deref{f64}) -> bool;
+fn{Js} lte "((a, b) => new alan_std.F64(a.val <= b.val))" <- RootBacking :: (f64, f64) -> bool;
+fn{Rs} gt Infix{">"} :: (Deref{f64}, Deref{f64}) -> bool;
+fn{Js} gt "((a, b) => new alan_std.F64(a.val > b.val))" <- RootBacking :: (f64, f64) -> bool;
+fn{Rs} gte Infix{">="} :: (Deref{f64}, Deref{f64}) -> bool;
+fn{Js} gte "((a, b) => new alan_std.F64(a.val >= b.val))" <- RootBacking :: (f64, f64) -> bool;
+fn min (a: f64, b: f64) = if(a <= b, a, b);
+fn max (a: f64, b: f64) = if(a >= b, a, b);
+fn clamp(v: f64, l: f64, h: f64) = if(v <= l, l, if(v >= h, h, v));
+fn{Rs} floor Method{"floor"} :: f64 -> f64;
+fn{Js} floor "((a) => new alan_std.F64(Math.floor(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} ceil Method{"ceil"} :: f64 -> f64;
+fn{Js} ceil "((a) => new alan_std.F64(Math.ceil(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} acos Method{"acos"} :: f64 -> f64;
+fn{Js} acos "((a) => new alan_std.F64(Math.acos(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} acosh Method{"acosh"} :: f64 -> f64;
+fn{Js} acosh "((a) => new alan_std.F64(Math.acosh(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} asin Method{"asin"} :: f64 -> f64;
+fn{Js} asin "((a) => new alan_std.F64(Math.asin(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} asinh Method{"asinh"} :: f64 -> f64;
+fn{Js} asinh "((a) => new alan_std.F64(Math.asinh(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} atan Method{"atan"} :: f64 -> f64;
+fn{Js} atan "((a) => new alan_std.F64(Math.atan(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} atanh Method{"atanh"} :: f64 -> f64;
+fn{Js} atanh "((a) => new alan_std.F64(Math.atanh(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} atan2 Method{"atan2"} :: (f64, Deref{f64}) -> f64;
+fn{Js} atan2 "((a, b) => new alan_std.F64(Math.atan2(a.val, b.val)))" <- RootBacking :: (f64, f64) -> f64;
+fn{Rs} cos Method{"cos"} :: f64 -> f64;
+fn{Js} cos "((a) => new alan_std.F64(Math.cos(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} cosh Method{"cosh"} :: f64 -> f64;
+fn{Js} cosh "((a) => new alan_std.F64(Math.cosh(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} sin Method{"sin"} :: f64 -> f64;
+fn{Js} sin "((a) => new alan_std.F64(Math.sin(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} sinh Method{"sinh"} :: f64 -> f64;
+fn{Js} sinh "((a) => new alan_std.F64(Math.sinh(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} tan Method{"tan"} :: f64 -> f64;
+fn{Js} tan "((a) => new alan_std.F64(Math.tan(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} tanh Method{"tanh"} :: f64 -> f64;
+fn{Js} tanh "((a) => new alan_std.F64(Math.tanh(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} exp Method{"exp"} :: f64 -> f64;
+fn{Js} exp "((a) => new alan_std.F64(Math.exp(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} ln Method{"ln"} :: f64 -> f64;
+fn{Js} ln "((a) => new alan_std.F64(Math.log(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} log2 Method{"log2"} :: f64 -> f64;
+fn{Js} log2 "((a) => new alan_std.F64(Math.log2(a.val)))" <- RootBacking :: f64 -> f64;
+fn{Rs} log10 Method{"log10"} :: f64 -> f64;
+fn{Js} log10 "((a) => new alan_std.F64(Math.log10(a.val)))" <- RootBacking :: f64 -> f64;
+fn sec(x: f64) = 1.0 / cos(x);
+fn csc(x: f64) = 1.0 / sin(x);
+fn cot(x: f64) = 1.0 / tan(x);
+fn asec(x: f64) = acos(1.0 / x);
+fn acsc(x: f64) = asin(1.0 / x);
+fn acot(x: f64) = pi / 2.0 - atan(x);
+fn sech(x: f64) = 1.0 / cosh(x);
+fn csch(x: f64) = 1.0 / sinh(x);
+fn coth(x: f64) = 1.0 / tanh(x);
+fn asech(x: f64) = ln((1.0 + sqrt(1.0 - x ** 2.0)) / x);
+fn acsch(x: f64) = ln(1.0 / x + sqrt(1.0 / x ** 2.0 + 1.0));
+fn acoth(x: f64) = ln((x + 1.0) / (x - 1.0)) / 2.0;
+
+/// Unsigned Integer-related functions and function bindings
+fn{Rs} add Method{"wrapping_add"} :: (u8, Deref{u8}) -> u8;
+fn{Js} add Method{"wrappingAdd"} :: (u8, u8) -> u8;
+fn{Rs} sub Method{"wrapping_sub"} :: (u8, Deref{u8}) -> u8;
+fn{Js} sub Method{"wrappingSub"} :: (u8, u8) -> u8;
+fn{Rs} mul Method{"wrapping_mul"} :: (u8, Deref{u8}) -> u8;
+fn{Js} mul Method{"wrappingMul"} :: (u8, u8) -> u8;
+fn{Rs} div Method{"wrapping_div"} :: (u8, Deref{u8}) -> u8;
+fn{Js} div Method{"wrappingDiv"} :: (u8, u8) -> u8;
+fn{Rs} mod Method{"wrapping_rem"} :: (u8, Deref{u8}) -> u8;
+fn{Js} mod Method{"wrappingMod"} :: (u8, u8) -> u8;
+fn{Rs} pow (a: u8, b: u8) = {Method{"wrapping_pow"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
+fn{Js} pow Method{"wrappingPow"} :: (u8, u8) -> u8;
+fn{Rs} and Infix{"&"} :: (Deref{u8}, Deref{u8}) -> u8;
+fn{Js} and "((a, b) => new alan_std.U8(a & b))" <- RootBacking :: (u8, u8) -> u8;
+fn{Rs} or Infix{"|"} :: (Deref{u8}, Deref{u8}) -> u8;
+fn{Js} or "((a, b) => new alan_std.U8(a | b))" <- RootBacking :: (u8, u8) -> u8;
+fn{Rs} xor Infix{"^"} :: (Deref{u8}, Deref{u8}) -> u8;
+fn{Js} xor "((a, b) => new alan_std.U8(a ^ b))" <- RootBacking :: (u8, u8) -> u8;
+fn{Rs} not Prefix{"!"} :: Deref{u8} -> u8;
+fn{Js} not Method{"not"} :: u8 -> u8;
+fn nand (a: u8, b: u8) = !(a & b);
+fn nor (a: u8, b: u8) = !(a | b);
+fn xnor (a: u8, b: u8) = !(a ^ b);
+fn{Rs} eq Infix{"=="} :: (Deref{u8}, Deref{u8}) -> bool;
+fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (u8, u8) -> bool;
+fn{Rs} neq Infix{"!="} :: (Deref{u8}, Deref{u8}) -> bool;
+fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (u8, u8) -> bool;
+fn{Rs} lt Infix{"<"} :: (Deref{u8}, Deref{u8}) -> bool;
+fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (u8, u8) -> bool;
+fn{Rs} lte Infix{"<="} :: (Deref{u8}, Deref{u8}) -> bool;
+fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (u8, u8) -> bool;
+fn{Rs} gt Infix{">"} :: (Deref{u8}, Deref{u8}) -> bool;
+fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (u8, u8) -> bool;
+fn{Rs} gte Infix{">="} :: (Deref{u8}, Deref{u8}) -> bool;
+fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (u8, u8) -> bool;
+fn min (a: u8, b: u8) = if(a <= b, a, b);
+fn max (a: u8, b: u8) = if(a >= b, a, b);
+fn clamp(v: u8, l: u8, h: u8) = if(v <= l, l, if(v >= h, h, v));
+fn{Rs} shl (a: u8, b: u8) = {Method{"wrapping_shl"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
+fn{Js} shl Method{"wrappingShl"} :: (u8, u8) -> u8;
+fn{Rs} shr (a: u8, b: u8) = {Method{"wrapping_shr"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
+fn{Js} shr Method{"wrappingShr"} :: (u8, u8) -> u8;
+fn{Rs} wrl (a: u8, b: u8) = {Method{"rotate_left"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
+fn{Js} wrl Method{"rotateLeft"} :: (u8, u8) -> u8;
+fn{Rs} wrr (a: u8, b: u8) = {Method{"rotate_right"} :: (u8, Deref{u32}) -> u8}(a, b.u32);
+fn{Js} wrr Method{"rotateRight"} :: (u8, u8) -> u8;
+fn{Rs} clz (a: u8) = {Method{"leading_zeros"} :: u8 -> u32}(a).u8;
+fn{Js} clz Method{"clz"} :: u8 -> u8;
+
+fn{Rs} add Method{"wrapping_add"} :: (u16, Deref{u16}) -> u16;
+fn{Js} add Method{"wrappingAdd"} :: (u16, u16) -> u16;
+fn{Rs} sub Method{"wrapping_sub"} :: (u16, Deref{u16}) -> u16;
+fn{Js} sub Method{"wrappingSub"} :: (u16, u16) -> u16;
+fn{Rs} mul Method{"wrapping_mul"} :: (u16, Deref{u16}) -> u16;
+fn{Js} mul Method{"wrappingMul"} :: (u16, u16) -> u16;
+fn{Rs} div Method{"wrapping_div"} :: (u16, Deref{u16}) -> u16;
+fn{Js} div Method{"wrappingDiv"} :: (u16, u16) -> u16;
+fn{Rs} mod Method{"wrapping_rem"} :: (u16, Deref{u16}) -> u16;
+fn{Js} mod Method{"wrappingMod"} :: (u16, u16) -> u16;
+fn{Rs} pow (a: u16, b: u16) = {Method{"wrapping_pow"} :: (u16, Deref{u32}) -> u16}(a, b.u32);
+fn{Js} pow Method{"wrappingPow"} :: (u16, u16) -> u16;
+fn{Rs} and Infix{"&"} :: (Deref{u16}, Deref{u16}) -> u16;
+fn{Js} and "((a, b) => new alan_std.U16(a & b))" <- RootBacking :: (u16, u16) -> u16;
+fn{Rs} or Infix{"|"} :: (Deref{u16}, Deref{u16}) -> u16;
+fn{Js} or "((a, b) => new alan_std.U16(a | b))" <- RootBacking :: (u16, u16) -> u16;
+fn{Rs} xor Infix{"^"} :: (Deref{u16}, Deref{u16}) -> u16;
+fn{Js} xor "((a, b) => new alan_std.U16(a ^ b))" <- RootBacking :: (u16, u16) -> u16;
+fn{Rs} not Prefix{"!"} :: Deref{u16} -> u16;
+fn{Js} not Method{"not"} :: u16 -> u16;
+fn nand (a: u16, b: u16) = !(a & b);
+fn nor (a: u16, b: u16) = !(a | b);
+fn xnor (a: u16, b: u16) = !(a ^ b);
+fn{Rs} eq Infix{"=="} :: (Deref{u16}, Deref{u16}) -> bool;
+fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (u16, u16) -> bool;
+fn{Rs} neq Infix{"!="} :: (Deref{u16}, Deref{u16}) -> bool;
+fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (u16, u16) -> bool;
+fn{Rs} lt Infix{"<"} :: (Deref{u16}, Deref{u16}) -> bool;
+fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (u16, u16) -> bool;
+fn{Rs} lte Infix{"<="} :: (Deref{u16}, Deref{u16}) -> bool;
+fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (u16, u16) -> bool;
+fn{Rs} gt Infix{">"} :: (Deref{u16}, Deref{u16}) -> bool;
+fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (u16, u16) -> bool;
+fn{Rs} gte Infix{">="} :: (Deref{u16}, Deref{u16}) -> bool;
+fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (u16, u16) -> bool;
+fn min (a: u16, b: u16) = if(a <= b, a, b);
+fn max (a: u16, b: u16) = if(a >= b, a, b);
+fn clamp(v: u16, l: u16, h: u16) = if(v <= l, l, if(v >= h, h, v));
+fn{Rs} shl (a: u16, b: u16) = {Method{"wrapping_shl"} :: (u16, Deref{u32}) -> u16}(a, b.u32);
+fn{Js} shl Method{"wrappingShl"} :: (u16, u16) -> u16;
+fn{Rs} shr (a: u16, b: u16) = {Method{"wrapping_shr"} :: (u16, Deref{u32}) -> u16}(a, b.u32);
+fn{Js} shr Method{"wrappingShr"} :: (u16, u16) -> u16;
+fn{Rs} wrl (a: u16, b: u16) = {Method{"rotate_left"} :: (u16, Deref{u32}) -> u16}(a, b.u32);
+fn{Js} wrl Method{"rotateLeft"} :: (u16, u16) -> u16;
+fn{Rs} wrr (a: u16, b: u16) = {Method{"rotate_right"} :: (u16, Deref{u32}) -> u16}(a, b.u32);
+fn{Js} wrr Method{"rotateRight"} :: (u16, u16) -> u16;
+fn{Rs} clz (a: u16) = {Method{"leading_zeros"} :: u16 -> u32}(a).u16;
+fn{Js} clz Method{"clz"} :: u16 -> u16;
+
+fn{Rs} add Method{"wrapping_add"} :: (u32, Deref{u32}) -> u32;
+fn{Js} add Method{"wrappingAdd"} :: (u32, u32) -> u32;
+fn{Rs} sub Method{"wrapping_sub"} :: (u32, Deref{u32}) -> u32;
+fn{Js} sub Method{"wrappingSub"} :: (u32, u32) -> u32;
+fn{Rs} mul Method{"wrapping_mul"} :: (u32, Deref{u32}) -> u32;
+fn{Js} mul Method{"wrappingMul"} :: (u32, u32) -> u32;
+fn{Rs} div Method{"wrapping_div"} :: (u32, Deref{u32}) -> u32;
+fn{Js} div Method{"wrappingDiv"} :: (u32, u32) -> u32;
+fn{Rs} mod Method{"wrapping_rem"} :: (u32, Deref{u32}) -> u32;
+fn{Js} mod Method{"wrappingMod"} :: (u32, u32) -> u32;
+fn{Rs} pow (a: u32, b: u32) = {Method{"wrapping_pow"} :: (u32, Deref{u32}) -> u32}(a, b.u32);
+fn{Js} pow Method{"wrappingPow"} :: (u32, u32) -> u32;
+fn{Rs} and Infix{"&"} :: (Deref{u32}, Deref{u32}) -> u32;
+fn{Js} and "((a, b) => new alan_std.U32(a & b))" <- RootBacking :: (u32, u32) -> u32;
+fn{Rs} or Infix{"|"} :: (Deref{u32}, Deref{u32}) -> u32;
+fn{Js} or "((a, b) => new alan_std.U32(a | b))" <- RootBacking :: (u32, u32) -> u32;
+fn{Rs} xor Infix{"^"} :: (Deref{u32}, Deref{u32}) -> u32;
+fn{Js} xor "((a, b) => new alan_std.U32(a ^ b))" <- RootBacking :: (u32, u32) -> u32;
+fn{Rs} not Prefix{"!"} :: Deref{u32} -> u32;
+fn{Js} not Method{"not"} :: u32 -> u32;
+fn nand (a: u32, b: u32) = !(a & b);
+fn nor (a: u32, b: u32) = !(a | b);
+fn xnor (a: u32, b: u32) = !(a ^ b);
+fn{Rs} eq Infix{"=="} :: (Deref{u32}, Deref{u32}) -> bool;
+fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (u32, u32) -> bool;
+fn{Rs} neq Infix{"!="} :: (Deref{u32}, Deref{u32}) -> bool;
+fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (u32, u32) -> bool;
+fn{Rs} lt Infix{"<"} :: (Deref{u32}, Deref{u32}) -> bool;
+fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (u32, u32) -> bool;
+fn{Rs} lte Infix{"<="} :: (Deref{u32}, Deref{u32}) -> bool;
+fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (u32, u32) -> bool;
+fn{Rs} gt Infix{">"} :: (Deref{u32}, Deref{u32}) -> bool;
+fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (u32, u32) -> bool;
+fn{Rs} gte Infix{">="} :: (Deref{u32}, Deref{u32}) -> bool;
+fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (u32, u32) -> bool;
+fn min (a: u32, b: u32) = if(a <= b, a, b);
+fn max (a: u32, b: u32) = if(a >= b, a, b);
+fn clamp(v: u32, l: u32, h: u32) = if(v <= l, l, if(v >= h, h, v));
+fn{Rs} shl (a: u32, b: u32) = {Method{"wrapping_shl"} :: (u32, Deref{u32}) -> u32}(a, b.u32);
+fn{Js} shl Method{"wrappingShl"} :: (u32, u32) -> u32;
+fn{Rs} shr (a: u32, b: u32) = {Method{"wrapping_shr"} :: (u32, Deref{u32}) -> u32}(a, b.u32);
+fn{Js} shr Method{"wrappingShr"} :: (u32, u32) -> u32;
+fn{Rs} wrl (a: u32, b: u32) = {Method{"rotate_left"} :: (u32, Deref{u32}) -> u32}(a, b.u32);
+fn{Js} wrl Method{"rotateLeft"} :: (u32, u32) -> u32;
+fn{Rs} wrr (a: u32, b: u32) = {Method{"rotate_right"} :: (u32, Deref{u32}) -> u32}(a, b.u32);
+fn{Js} wrr Method{"rotateRight"} :: (u32, u32) -> u32;
+fn{Rs} clz Method{"leading_zeros"} :: u32 -> u32;
+fn{Js} clz Method{"clz"} :: u32 -> u32;
+
+fn{Rs} add Method{"wrapping_add"} :: (u64, Deref{u64}) -> u64;
+fn{Js} add Method{"wrappingAdd"} :: (u64, u64) -> u64;
+fn{Rs} sub Method{"wrapping_sub"} :: (u64, Deref{u64}) -> u64;
+fn{Js} sub Method{"wrappingSub"} :: (u64, u64) -> u64;
+fn{Rs} mul Method{"wrapping_mul"} :: (u64, Deref{u64}) -> u64;
+fn{Js} mul Method{"wrappingMul"} :: (u64, u64) -> u64;
+fn{Rs} div Method{"wrapping_div"} :: (u64, Deref{u64}) -> u64;
+fn{Js} div Method{"wrappingDiv"} :: (u64, u64) -> u64;
+fn{Rs} mod Method{"wrapping_rem"} :: (u64, Deref{u64}) -> u64;
+fn{Js} mod Method{"wrappingMod"} :: (u64, u64) -> u64;
+fn{Rs} pow (a: u64, b: u64) = {Method{"wrapping_pow"} :: (u64, Deref{u32}) -> u64}(a, b.u32);
+fn{Js} pow Method{"wrappingPow"} :: (u64, u64) -> u64;
+fn{Rs} and Infix{"&"} :: (Deref{u64}, Deref{u64}) -> u64;
+fn{Js} and "((a, b) => new alan_std.U64(a & b))" <- RootBacking :: (u64, u64) -> u64;
+fn{Rs} or Infix{"|"} :: (Deref{u64}, Deref{u64}) -> u64;
+fn{Js} or "((a, b) => new alan_std.U64(a | b))" <- RootBacking :: (u64, u64) -> u64;
+fn{Rs} xor Infix{"^"} :: (Deref{u64}, Deref{u64}) -> u64;
+fn{Js} xor "((a, b) => new alan_std.U64(a ^ b))" <- RootBacking :: (u64, u64) -> u64;
+fn{Rs} not Prefix{"!"} :: Deref{u64} -> u64;
+fn{Js} not Method{"not"} :: u64 -> u64;
+fn nand (a: u64, b: u64) = !(a & b);
+fn nor (a: u64, b: u64) = !(a | b);
+fn xnor (a: u64, b: u64) = !(a ^ b);
+fn{Rs} eq Infix{"=="} :: (Deref{u64}, Deref{u64}) -> bool;
+fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (u64, u64) -> bool;
+fn{Rs} neq Infix{"!="} :: (Deref{u64}, Deref{u64}) -> bool;
+fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (u64, u64) -> bool;
+fn{Rs} lt Infix{"<"} :: (Deref{u64}, Deref{u64}) -> bool;
+fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (u64, u64) -> bool;
+fn{Rs} lte Infix{"<="} :: (Deref{u64}, Deref{u64}) -> bool;
+fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (u64, u64) -> bool;
+fn{Rs} gt Infix{">"} :: (Deref{u64}, Deref{u64}) -> bool;
+fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (u64, u64) -> bool;
+fn{Rs} gte Infix{">="} :: (Deref{u64}, Deref{u64}) -> bool;
+fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (u64, u64) -> bool;
+fn min (a: u64, b: u64) = if(a <= b, a, b);
+fn max (a: u64, b: u64) = if(a >= b, a, b);
+fn clamp(v: u64, l: u64, h: u64) = if(v <= l, l, if(v >= h, h, v));
+fn{Rs} shl (a: u64, b: u64) = {Method{"wrapping_shl"} :: (u64, Deref{u32}) -> u64}(a, b.u32);
+fn{Js} shl Method{"wrappingShl"} :: (u64, u64) -> u64;
+fn{Rs} shr (a: u64, b: u64) = {Method{"wrapping_shr"} :: (u64, Deref{u32}) -> u64}(a, b.u32);
+fn{Js} shr Method{"wrappingShr"} :: (u64, u64) -> u64;
+fn{Rs} wrl (a: u64, b: u64) = {Method{"rotate_left"} :: (u64, Deref{u32}) -> u64}(a, b.u32);
+fn{Js} wrl Method{"rotateLeft"} :: (u64, u64) -> u64;
+fn{Rs} wrr (a: u64, b: u64) = {Method{"rotate_right"} :: (u64, Deref{u32}) -> u64}(a, b.u32);
+fn{Js} wrr Method{"rotateRight"} :: (u64, u64) -> u64;
+fn{Rs} clz (a: u64) = {Method{"leading_zeros"} :: u64 -> u32}(a).u64;
+fn{Js} clz Method{"clz"} :: u64 -> u64;
+
+/// Signed Integer-related functions and function bindings
+fn{Rs} add Method{"wrapping_add"} :: (i8, Deref{i8}) -> i8;
+fn{Js} add Method{"wrappingAdd"} :: (i8, i8) -> i8;
+fn{Rs} sub Method{"wrapping_sub"} :: (i8, Deref{i8}) -> i8;
+fn{Js} sub Method{"wrappingSub"} :: (i8, i8) -> i8;
+fn{Rs} mul Method{"wrapping_mul"} :: (i8, Deref{i8}) -> i8;
+fn{Js} mul Method{"wrappingMul"} :: (i8, i8) -> i8;
+fn{Rs} div Method{"wrapping_div"} :: (i8, Deref{i8}) -> i8;
+fn{Js} div Method{"wrappingDiv"} :: (i8, i8) -> i8;
+fn{Rs} mod Method{"wrapping_rem"} :: (i8, Deref{i8}) -> i8;
+fn{Js} mod Method{"wrappingMod"} :: (i8, i8) -> i8;
+fn{Rs} pow (a: i8, b: i8) = {Method{"wrapping_pow"} :: (i8, Deref{u32}) -> i8}(a, b.u32);
+fn{Js} pow Method{"wrappingPow"} :: (i8, i8) -> i8;
+fn{Rs} abs Method{"abs"} :: i8 -> i8;
+fn{Js} abs "((a) => new alan_std.I8(Math.abs(a.val)))" <- RootBacking :: i8 -> i8;
+fn{Rs} neg Prefix{"-"} :: Deref{i8} -> i8;
+fn{Js} neg "((a) => new alan_std.I8(-a))" <- RootBacking :: i8 -> i8;
+fn{Rs} and Infix{"&"} :: (Deref{i8}, Deref{i8}) -> i8;
+fn{Js} and "((a, b) => new alan_std.I8(a & b))" <- RootBacking :: (i8, i8) -> i8;
+fn{Rs} or Infix{"|"} :: (Deref{i8}, Deref{i8}) -> i8;
+fn{Js} or "((a, b) => new alan_std.I8(a | b))" <- RootBacking :: (i8, i8) -> i8;
+fn{Rs} xor Infix{"^"} :: (Deref{i8}, Deref{i8}) -> i8;
+fn{Js} xor "((a, b) => new alan_std.I8(a ^ b))" <- RootBacking :: (i8, i8) -> i8;
+fn{Rs} not Prefix{"!"} :: Deref{i8} -> i8;
+fn{Js} not Method{"not"} :: i8 -> i8;
+fn nand (a: i8, b: i8) = !(a & b);
+fn nor (a: i8, b: i8) = !(a | b);
+fn xnor (a: i8, b: i8) = !(a ^ b);
+fn{Rs} eq Infix{"=="} :: (Deref{i8}, Deref{i8}) -> bool;
+fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (i8, i8) -> bool;
+fn{Rs} neq Infix{"!="} :: (Deref{i8}, Deref{i8}) -> bool;
+fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (i8, i8) -> bool;
+fn{Rs} lt Infix{"<"} :: (Deref{i8}, Deref{i8}) -> bool;
+fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (i8, i8) -> bool;
+fn{Rs} lte Infix{"<="} :: (Deref{i8}, Deref{i8}) -> bool;
+fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (i8, i8) -> bool;
+fn{Rs} gt Infix{">"} :: (Deref{i8}, Deref{i8}) -> bool;
+fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (i8, i8) -> bool;
+fn{Rs} gte Infix{">="} :: (Deref{i8}, Deref{i8}) -> bool;
+fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (i8, i8) -> bool;
+fn min (a: i8, b: i8) = if(a <= b, a, b);
+fn max (a: i8, b: i8) = if(a >= b, a, b);
+fn clamp(v: i8, l: i8, h: i8) = if(v <= l, l, if(v >= h, h, v));
+fn{Rs} shl (a: i8, b: i8) = {Method{"wrapping_shl"} :: (i8, Deref{u32}) -> i8}(a, b.u32);
+fn{Js} shl Method{"wrappingShl"} :: (i8, i8) -> i8;
+fn{Rs} shr (a: i8, b: i8) = {Method{"wrapping_shr"} :: (i8, Deref{u32}) -> i8}(a, b.u32);
+fn{Js} shr Method{"wrappingShr"} :: (i8, i8) -> i8;
+fn{Rs} wrl (a: i8, b: i8) = {Method{"rotate_left"} :: (i8, Deref{u32}) -> i8}(a, b.u32);
+fn{Js} wrl Method{"rotateLeft"} :: (i8, i8) -> i8;
+fn{Rs} wrr (a: i8, b: i8) = {Method{"rotate_right"} :: (i8, Deref{u32}) -> i8}(a, b.u32);
+fn{Js} wrr Method{"rotateRight"} :: (i8, i8) -> i8;
+fn{Rs} clz (a: i8) = {Method{"leading_zeros"} :: i8 -> u32}(a).i8;
+fn{Js} clz Method{"clz"} :: i8 -> i8;
+
+fn{Rs} add Method{"wrapping_add"} :: (i16, Deref{i16}) -> i16;
+fn{Js} add Method{"wrappingAdd"} :: (i16, i16) -> i16;
+fn{Rs} sub Method{"wrapping_sub"} :: (i16, Deref{i16}) -> i16;
+fn{Js} sub Method{"wrappingSub"} :: (i16, i16) -> i16;
+fn{Rs} mul Method{"wrapping_mul"} :: (i16, Deref{i16}) -> i16;
+fn{Js} mul Method{"wrappingMul"} :: (i16, i16) -> i16;
+fn{Rs} div Method{"wrapping_div"} :: (i16, Deref{i16}) -> i16;
+fn{Js} div Method{"wrappingDiv"} :: (i16, i16) -> i16;
+fn{Rs} mod Method{"wrapping_rem"} :: (i16, Deref{i16}) -> i16;
+fn{Js} mod Method{"wrappingMod"} :: (i16, i16) -> i16;
+fn{Rs} pow (a: i16, b: i16) = {Method{"wrapping_pow"} :: (i16, Deref{u32}) -> i16}(a, b.u32);
+fn{Js} pow Method{"wrappingPow"} :: (i16, i16) -> i16;
+fn{Rs} abs Method{"abs"} :: i16 -> i16;
+fn{Js} abs "((a) => new alan_std.I16(Math.abs(a.val)))" <- RootBacking :: i16 -> i16;
+fn{Rs} neg Prefix{"-"} :: Deref{i16} -> i16;
+fn{Js} neg "((a) => new alan_std.I16(-a))" <- RootBacking :: i16 -> i16;
+fn{Rs} and Infix{"&"} :: (Deref{i16}, Deref{i16}) -> i16;
+fn{Js} and "((a, b) => new alan_std.I16(a & b))" <- RootBacking :: (i16, i16) -> i16;
+fn{Rs} or Infix{"|"} :: (Deref{i16}, Deref{i16}) -> i16;
+fn{Js} or "((a, b) => new alan_std.I16(a | b))" <- RootBacking :: (i16, i16) -> i16;
+fn{Rs} xor Infix{"^"} :: (Deref{i16}, Deref{i16}) -> i16;
+fn{Js} xor "((a, b) => new alan_std.I16(a ^ b))" <- RootBacking :: (i16, i16) -> i16;
+fn{Rs} not Prefix{"!"} :: Deref{i16} -> i16;
+fn{Js} not Method{"not"} :: i16 -> i16;
+fn nand (a: i16, b: i16) = !(a & b);
+fn nor (a: i16, b: i16) = !(a | b);
+fn xnor (a: i16, b: i16) = !(a ^ b);
+fn{Rs} eq Infix{"=="} :: (Deref{i16}, Deref{i16}) -> bool;
+fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (i16, i16) -> bool;
+fn{Rs} neq Infix{"!="} :: (Deref{i16}, Deref{i16}) -> bool;
+fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (i16, i16) -> bool;
+fn{Rs} lt Infix{"<"} :: (Deref{i16}, Deref{i16}) -> bool;
+fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (i16, i16) -> bool;
+fn{Rs} lte Infix{"<="} :: (Deref{i16}, Deref{i16}) -> bool;
+fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (i16, i16) -> bool;
+fn{Rs} gt Infix{">"} :: (Deref{i16}, Deref{i16}) -> bool;
+fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (i16, i16) -> bool;
+fn{Rs} gte Infix{">="} :: (Deref{i16}, Deref{i16}) -> bool;
+fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (i16, i16) -> bool;
+fn min (a: i16, b: i16) = if(a <= b, a, b);
+fn max (a: i16, b: i16) = if(a >= b, a, b);
+fn clamp(v: i16, l: i16, h: i16) = if(v <= l, l, if(v >= h, h, v));
+fn{Rs} shl (a: i16, b: i16) = {Method{"wrapping_shl"} :: (i16, Deref{u32}) -> i16}(a, b.u32);
+fn{Js} shl Method{"wrappingShl"} :: (i16, i16) -> i16;
+fn{Rs} shr (a: i16, b: i16) = {Method{"wrapping_shr"} :: (i16, Deref{u32}) -> i16}(a, b.u32);
+fn{Js} shr Method{"wrappingShr"} :: (i16, i16) -> i16;
+fn{Rs} wrl (a: i16, b: i16) = {Method{"rotate_left"} :: (i16, Deref{u32}) -> i16}(a, b.u32);
+fn{Js} wrl Method{"rotateLeft"} :: (i16, i16) -> i16;
+fn{Rs} wrr (a: i16, b: i16) = {Method{"rotate_right"} :: (i16, Deref{u32}) -> i16}(a, b.u32);
+fn{Js} wrr Method{"rotateRight"} :: (i16, i16) -> i16;
+fn{Rs} clz (a: i16) = {Method{"leading_zeros"} :: i16 -> u32}(a).i16;
+fn{Js} clz Method{"clz"} :: i16 -> i16;
+
+fn{Rs} add Method{"wrapping_add"} :: (i32, Deref{i32}) -> i32;
+fn{Js} add Method{"wrappingAdd"} :: (i32, i32) -> i32;
+fn{Rs} sub Method{"wrapping_sub"} :: (i32, Deref{i32}) -> i32;
+fn{Js} sub Method{"wrappingSub"} :: (i32, i32) -> i32;
+fn{Rs} mul Method{"wrapping_mul"} :: (i32, Deref{i32}) -> i32;
+fn{Js} mul Method{"wrappingMul"} :: (i32, i32) -> i32;
+fn{Rs} div Method{"wrapping_div"} :: (i32, Deref{i32}) -> i32;
+fn{Js} div Method{"wrappingDiv"} :: (i32, i32) -> i32;
+fn{Rs} mod Method{"wrapping_rem"} :: (i32, Deref{i32}) -> i32;
+fn{Js} mod Method{"wrappingMod"} :: (i32, i32) -> i32;
+fn{Rs} pow (a: i32, b: i32) = {Method{"wrapping_pow"} :: (i32, Deref{u32}) -> i32}(a, b.u32);
+fn{Js} pow Method{"wrappingPow"} :: (i32, i32) -> i32;
+fn{Rs} abs Method{"abs"} :: i32 -> i32;
+fn{Js} abs "((a) => new alan_std.I32(Math.abs(a.val)))" <- RootBacking :: i32 -> i32;
+fn{Rs} neg Prefix{"-"} :: Deref{i32} -> i32;
+fn{Js} neg "((a) => new alan_std.I32(-a))" <- RootBacking :: i32 -> i32;
+fn{Rs} and Infix{"&"} :: (Deref{i32}, Deref{i32}) -> i32;
+fn{Js} and "((a, b) => new alan_std.I32(a & b))" <- RootBacking :: (i32, i32) -> i32;
+fn{Rs} or Infix{"|"} :: (Deref{i32}, Deref{i32}) -> i32;
+fn{Js} or "((a, b) => new alan_std.I32(a | b))" <- RootBacking :: (i32, i32) -> i32;
+fn{Rs} xor Infix{"^"} :: (Deref{i32}, Deref{i32}) -> i32;
+fn{Js} xor "((a, b) => new alan_std.I32(a ^ b))" <- RootBacking :: (i32, i32) -> i32;
+fn{Rs} not Prefix{"!"} :: Deref{i32} -> i32;
+fn{Js} not Method{"not"} :: i32 -> i32;
+fn nand (a: i32, b: i32) = !(a & b);
+fn nor (a: i32, b: i32) = !(a | b);
+fn xnor (a: i32, b: i32) = !(a ^ b);
+fn{Rs} eq Infix{"=="} :: (Deref{i32}, Deref{i32}) -> bool;
+fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (i32, i32) -> bool;
+fn{Rs} neq Infix{"!="} :: (Deref{i32}, Deref{i32}) -> bool;
+fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (i32, i32) -> bool;
+fn{Rs} lt Infix{"<"} :: (Deref{i32}, Deref{i32}) -> bool;
+fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (i32, i32) -> bool;
+fn{Rs} lte Infix{"<="} :: (Deref{i32}, Deref{i32}) -> bool;
+fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (i32, i32) -> bool;
+fn{Rs} gt Infix{">"} :: (Deref{i32}, Deref{i32}) -> bool;
+fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" :: (i32, i32) -> bool;
+fn{Rs} gte Infix{">="} :: (Deref{i32}, Deref{i32}) -> bool;
+fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" :: (i32, i32) -> bool;
+fn min (a: i32, b: i32) = if(a <= b, a, b);
+fn max (a: i32, b: i32) = if(a >= b, a, b);
+fn clamp(v: i32, l: i32, h: i32) = if(v <= l, l, if(v >= h, h, v));
+fn{Rs} shl (a: i32, b: i32) = {Method{"wrapping_shl"} :: (i32, Deref{u32}) -> i32}(a, b.u32);
+fn{Js} shl Method{"wrappingShl"} :: (i32, i32) -> i32;
+fn{Rs} shr (a: i32, b: i32) = {Method{"wrapping_shr"} :: (i32, Deref{u32}) -> i32}(a, b.u32);
+fn{Js} shr Method{"wrappingShr"} :: (i32, i32) -> i32;
+fn{Rs} wrl (a: i32, b: i32) = {Method{"rotate_left"} :: (i32, Deref{u32}) -> i32}(a, b.u32);
+fn{Js} wrl Method{"rotateLeft"} :: (i32, i32) -> i32;
+fn{Rs} wrr (a: i32, b: i32) = {Method{"rotate_right"} :: (i32, Deref{u32}) -> i32}(a, b.u32);
+fn{Js} wrr Method{"rotateRight"} :: (i32, i32) -> i32;
+fn{Rs} clz (a: i32) = {Method{"leading_zeros"} :: i32 -> u32}(a).i32;
+fn{Js} clz Method{"clz"} :: i32 -> i32;
+
+fn{Rs} add Method{"wrapping_add"} :: (i64, Deref{i64}) -> i64;
+fn{Js} add Method{"wrappingAdd"} :: (i64, i64) -> i64;
+fn{Rs} sub Method{"wrapping_sub"} :: (i64, Deref{i64}) -> i64;
+fn{Js} sub Method{"wrappingSub"} :: (i64, i64) -> i64;
+fn{Rs} mul Method{"wrapping_mul"} :: (i64, Deref{i64}) -> i64;
+fn{Js} mul Method{"wrappingMul"} :: (i64, i64) -> i64;
+fn{Rs} div Method{"wrapping_div"} :: (i64, Deref{i64}) -> i64;
+fn{Js} div Method{"wrappingDiv"} :: (i64, i64) -> i64;
+fn{Rs} mod Method{"wrapping_rem"} :: (i64, Deref{i64}) -> i64;
+fn{Js} mod Method{"wrappingMod"} :: (i64, i64) -> i64;
+fn{Rs} pow (a: i64, b: i64) = {Method{"wrapping_pow"} :: (i64, Deref{u32}) -> i64}(a, b.u32);
+fn{Js} pow Method{"wrappingPow"} :: (i64, i64) -> i64;
+fn{Rs} abs Method{"abs"} :: i64 -> i64;
+fn{Js} abs "((a) => new alan_std.I64(a < 0n ? -a : a))" <- RootBacking :: i64 -> i64;
+fn{Rs} neg Prefix{"-"} :: Deref{i64} -> i64;
+fn{Js} neg "((a) => new alan_std.I64(-a))" <- RootBacking :: i64 -> i64;
+fn{Rs} and Infix{"&"} :: (Deref{i64}, Deref{i64}) -> i64;
+fn{Js} and "((a, b) => new alan_std.I64(a & b))" <- RootBacking :: (i64, i64) -> i64;
+fn{Rs} or Infix{"|"} :: (Deref{i64}, Deref{i64}) -> i64;
+fn{Js} or "((a, b) => new alan_std.I64(a | b))" <- RootBacking :: (i64, i64) -> i64;
+fn{Rs} xor Infix{"^"} :: (Deref{i64}, Deref{i64}) -> i64;
+fn{Js} xor "((a, b) => new alan_std.I64(a ^ b))" <- RootBacking :: (i64, i64) -> i64;
+fn{Rs} not Prefix{"!"} :: Deref{i64} -> i64;
+fn{Js} not Method{"not"} :: i64 -> i64;
+fn nand (a: i64, b: i64) = !(a & b);
+fn nor (a: i64, b: i64) = !(a | b);
+fn xnor (a: i64, b: i64) = !(a ^ b);
+fn{Rs} eq Infix{"=="} :: (Deref{i64}, Deref{i64}) -> bool;
+fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (i64, i64) -> bool;
+fn{Rs} neq Infix{"!="} :: (Deref{i64}, Deref{i64}) -> bool;
+fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (i64, i64) -> bool;
+fn{Rs} lt Infix{"<"} :: (Deref{i64}, Deref{i64}) -> bool;
+fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (i64, i64) -> bool;
+fn{Rs} lte Infix{"<="} :: (Deref{i64}, Deref{i64}) -> bool;
+fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (i64, i64) -> bool;
+fn{Rs} gt Infix{">"} :: (Deref{i64}, Deref{i64}) -> bool;
+fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (i64, i64) -> bool;
+fn{Rs} gte Infix{">="} :: (Deref{i64}, Deref{i64}) -> bool;
+fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (i64, i64) -> bool;
+fn min (a: i64, b: i64) = if(a <= b, a, b);
+fn max (a: i64, b: i64) = if(a >= b, a, b);
+fn clamp(v: i64, l: i64, h: i64) = if(v <= l, l, if(v >= h, h, v));
+fn{Rs} shl (a: i64, b: i64) = {Method{"wrapping_shl"} :: (i64, Deref{u32}) -> i64}(a, b.u32);
+fn{Js} shl Method{"wrappingShl"} :: (i64, i64) -> i64;
+fn{Rs} shr (a: i64, b: i64) = {Method{"wrapping_shr"} :: (i64, Deref{u32}) -> i64}(a, b.u32);
+fn{Js} shr Method{"wrappingShr"} :: (i64, i64) -> i64;
+fn{Rs} wrl (a: i64, b: i64) = {Method{"rotate_left"} :: (i64, Deref{u32}) -> i64}(a, b.u32);
+fn{Js} wrl Method{"rotateLeft"} :: (i64, i64) -> i64;
+fn{Rs} wrr (a: i64, b: i64) = {Method{"rotate_right"} :: (i64, Deref{u32}) -> i64}(a, b.u32);
+fn{Js} wrr Method{"rotateRight"} :: (i64, i64) -> i64;
+fn{Rs} clz (a: i64) = {Method{"leading_zeros"} :: i64 -> u32}(a).i64;
+fn{Js} clz Method{"clz"} :: i64 -> i64;
 
 /// String related bindings
-export fn{Rs} string "format!" :: ("{}", i8) -> string;
-export fn{Js} string "new alan_std.Str" <- RootBacking :: i8 -> string;
-export fn{Rs} string "format!" :: ("{}", i16) -> string;
-export fn{Js} string "new alan_std.Str" <- RootBacking :: i16 -> string;
-export fn{Rs} string "format!" :: ("{}", i32) -> string;
-export fn{Js} string "new alan_std.Str" <- RootBacking :: i32 -> string;
-export fn{Rs} string "format!" :: ("{}", i64) -> string;
-export fn{Js} string "new alan_std.Str" <- RootBacking :: i64 -> string;
-export fn{Rs} string "format!" :: ("{}", u8) -> string;
-export fn{Js} string "new alan_std.Str" <- RootBacking :: u8 -> string;
-export fn{Rs} string "format!" :: ("{}", u16) -> string;
-export fn{Js} string "new alan_std.Str" <- RootBacking :: u16 -> string;
-export fn{Rs} string "format!" :: ("{}", u32) -> string;
-export fn{Js} string "new alan_std.Str" <- RootBacking :: u32 -> string;
-export fn{Rs} string "format!" :: ("{}", u64) -> string;
-export fn{Js} string "new alan_std.Str" <- RootBacking :: u64 -> string;
-export fn{Rs} string "format!" :: ("{}", f32) -> string;
-export fn{Js} string "new alan_std.Str" <- RootBacking :: f32 -> string;
-export fn{Rs} string "format!" :: ("{}", f64) -> string;
-export fn{Js} string "new alan_std.Str" <- RootBacking :: f64 -> string;
+fn{Rs} string "format!" :: ("{}", f32) -> string;
+fn{Js} string "new alan_std.Str" <- RootBacking :: f32 -> string;
+fn{Rs} string "format!" :: ("{}", f64) -> string;
+fn{Js} string "new alan_std.Str" <- RootBacking :: f64 -> string;
+fn{Rs} string "format!" :: ("{}", u8) -> string;
+fn{Js} string "new alan_std.Str" <- RootBacking :: u8 -> string;
+fn{Rs} string "format!" :: ("{}", u16) -> string;
+fn{Js} string "new alan_std.Str" <- RootBacking :: u16 -> string;
+fn{Rs} string "format!" :: ("{}", u32) -> string;
+fn{Js} string "new alan_std.Str" <- RootBacking :: u32 -> string;
+fn{Rs} string "format!" :: ("{}", u64) -> string;
+fn{Js} string "new alan_std.Str" <- RootBacking :: u64 -> string;
+fn{Rs} string "format!" :: ("{}", i8) -> string;
+fn{Js} string "new alan_std.Str" <- RootBacking :: i8 -> string;
+fn{Rs} string "format!" :: ("{}", i16) -> string;
+fn{Js} string "new alan_std.Str" <- RootBacking :: i16 -> string;
+fn{Rs} string "format!" :: ("{}", i32) -> string;
+fn{Js} string "new alan_std.Str" <- RootBacking :: i32 -> string;
+fn{Rs} string "format!" :: ("{}", i64) -> string;
+fn{Js} string "new alan_std.Str" <- RootBacking :: i64 -> string;
 // TODO: Until better printing is ready? Or perhaps this is a better fit for Alan
-export fn{Rs} string (f: f32, p: i64) = {"format!" :: ("{0:.1$}", f32, Deref{Binds{"usize"}}) -> string}(
+fn{Rs} string (f: f32, p: i64) = {"format!" :: ("{0:.1$}", f32, Deref{Binds{"usize"}}) -> string}(
   f,
   {Cast{"usize"} :: Deref{i64} -> Binds{"usize"}}(p));
-export fn{Js} string "((v, p) => new alan_std.Str(v.valueOf().toFixed(Number(p))))" <- RootBacking :: (f32, i64) -> string;
-export fn{Rs} string (f: f64, p: i64) = {"format!" :: ("{0:.1$}", f64, Deref{Binds{"usize"}}) -> string}(
+fn{Js} string "((v, p) => new alan_std.Str(v.valueOf().toFixed(Number(p))))" <- RootBacking :: (f32, i64) -> string;
+fn{Rs} string (f: f64, p: i64) = {"format!" :: ("{0:.1$}", f64, Deref{Binds{"usize"}}) -> string}(
   f,
   {Cast{"usize"} :: Deref{i64} -> Binds{"usize"}}(p));
-export fn{Js} string "((v, p) => new alan_std.Str(v.valueOf().toFixed(Number(p))))" <- RootBacking :: (f64, i64) -> string;
-export fn string(b: bool) = if(b, "true", "false");
-export fn string(s: string) = s;
-export fn{Rs} concat "format!" :: ("{}{}", string, string) -> string;
-export fn{Js} concat "((a, b) => new alan_std.Str(a.val + b.val))" <- RootBacking :: (string, string) -> string;
-export fn{Rs} repeat (a: string, n: i64) = {Method{"repeat"} :: (string, Deref{Binds{"usize"}}) -> string}(
+fn{Js} string "((v, p) => new alan_std.Str(v.valueOf().toFixed(Number(p))))" <- RootBacking :: (f64, i64) -> string;
+fn string(b: bool) = if(b, "true", "false");
+fn string(s: string) = s;
+fn{Rs} concat "format!" :: ("{}{}", string, string) -> string;
+fn{Js} concat "((a, b) => new alan_std.Str(a.val + b.val))" <- RootBacking :: (string, string) -> string;
+fn{Rs} repeat (a: string, n: i64) = {Method{"repeat"} :: (string, Deref{Binds{"usize"}}) -> string}(
   a,
   {Cast{"usize"} :: Deref{i64} -> Binds{"usize"}}(n));
-export fn{Js} repeat "((s, n) => new alan_std.Str(s.val.repeat(Number(n.val))))" <- RootBacking :: (string, i64) -> string;
-export fn{Rs} replace Method{"replace"} :: (string, string, string) -> string;
-export fn{Js} replace "((s, o, n) => new alan_std.Str(s.valueOf().replaceAll(o.valueOf(), n.valueOf())))" :: (string, string, string) -> string;
-export fn{Rs} split "alan_std::splitstring" <- RootBacking :: (string, string) -> string[];
-export fn{Js} split "((a, b) => a.val.split(b.val).map(v => new alan_std.Str(v)))" <- RootBacking :: (string, string) -> string[];
-export fn{Rs} len (s: string) = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}(
+fn{Js} repeat "((s, n) => new alan_std.Str(s.val.repeat(Number(n.val))))" <- RootBacking :: (string, i64) -> string;
+fn{Rs} replace Method{"replace"} :: (string, string, string) -> string;
+fn{Js} replace "((s, o, n) => new alan_std.Str(s.valueOf().replaceAll(o.valueOf(), n.valueOf())))" :: (string, string, string) -> string;
+fn{Rs} split "alan_std::splitstring" <- RootBacking :: (string, string) -> string[];
+fn{Js} split "((a, b) => a.val.split(b.val).map(v => new alan_std.Str(v)))" <- RootBacking :: (string, string) -> string[];
+fn{Rs} len (s: string) = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}(
   {Method{"len"} :: Array{Binds{"char"}} -> Binds{"usize"}}(
     {Method{"collect::<Vec<char>>"} :: Own{Binds{"std::str::Chars"}} -> Array{Binds{"char"}}}(
       {Method{"chars"} :: string -> Binds{"std::str::Chars"}}(s))));
-export fn{Js} len "((s) => new alan_std.I64(s.val.length))" :: string -> i64;
-export fn{Rs} get "alan_std::getstring" <- RootBacking :: (string, i64) -> string!;
-export fn{Js} get "((s, i) => { let idx = Number(i.val); if (idx >= 0 && idx < s.val.length) { return new alan_std.Str(s.val[idx]); } else { return new alan_std.AlanError(new alan_std.Str(`Index ${idx} is out-of-bounds for a string length of ${s.val.length}`)); } })" :: (string, i64) -> string!;
-export fn{Rs} trim Method{"trim"} :: string -> string;
-export fn{Js} trim "((s) => new alan_std.Str(s.val.trim()))" <- RootBacking :: string -> string;
-export fn{Rs} index "alan_std::indexstring" <- RootBacking :: (string, string) -> i64!;
-export fn{Js} index "((a, b) => { let idx = a.val.indexOf(b.val); if (idx < 0) { return new alan_std.AlanError(new alan_std.Str(`Could not find ${b.val} in ${a.val}`)); } else { return new alan_std.I64(idx); } })" <- RootBacking :: (string, string) -> i64!;
+fn{Js} len "((s) => new alan_std.I64(s.val.length))" :: string -> i64;
+fn{Rs} get "alan_std::getstring" <- RootBacking :: (string, i64) -> string!;
+fn{Js} get "((s, i) => { let idx = Number(i.val); if (idx >= 0 && idx < s.val.length) { return new alan_std.Str(s.val[idx]); } else { return new alan_std.AlanError(new alan_std.Str(`Index ${idx} is out-of-bounds for a string length of ${s.val.length}`)); } })" :: (string, i64) -> string!;
+fn{Rs} trim Method{"trim"} :: string -> string;
+fn{Js} trim "((s) => new alan_std.Str(s.val.trim()))" <- RootBacking :: string -> string;
+fn{Rs} index "alan_std::indexstring" <- RootBacking :: (string, string) -> i64!;
+fn{Js} index "((a, b) => { let idx = a.val.indexOf(b.val); if (idx < 0) { return new alan_std.AlanError(new alan_std.Str(`Could not find ${b.val} in ${a.val}`)); } else { return new alan_std.I64(idx); } })" <- RootBacking :: (string, string) -> i64!;
 // TODO: Optimize this by using `as_str` inline, but need a `Str` type, which I *really* don't want to terrorize the user with
-export fn{Rs} eq Infix{"=="} :: (Own{string}, Own{string}) -> bool;
-export fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (string, string) -> bool;
-export fn{Rs} neq Infix{"!="} :: (Own{string}, Own{string}) -> bool;
-export fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (string, string) -> bool;
-export fn{Rs} lt Infix{"<"} :: (Own{string}, Own{string}) -> bool;
-export fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (string, string) -> bool;
-export fn{Rs} lte Infix{"<="} :: (Own{string}, Own{string}) -> bool;
-export fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (string, string) -> bool;
-export fn{Rs} gt Infix{">"} :: (Own{string}, Own{string}) -> bool;
-export fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (string, string) -> bool;
-export fn{Rs} gte Infix{">="} :: (Own{string}, Own{string}) -> bool;
-export fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (string, string) -> bool;
-export fn min (a: string, b: string) = if(a.lte(b), fn () = a.clone(), fn () = b.clone());
-export fn max (a: string, b: string) = if(a.gte(b), fn () = a.clone(), fn () = b.clone());
-export fn{Rs} join Method{"join"} :: (string[], string) -> string;
-export fn{Js} join "((a, b) => new alan_std.Str([...a.map(v => v.val)].join(b.val)))" <- RootBacking :: (string[], string) -> string;
-export fn{Rs} join{S}(a: string[S], s: string) = {Method{"join"} :: (string[S], string) -> string}(a, s);
-export fn{Js} join{S}(a: string[S], s: string) = {"((a, s) => new alan_std.Str(a.map(v => v.val).join(s.val)))" <- RootBacking :: (string[S], string) -> string}(a, s);
+fn{Rs} eq Infix{"=="} :: (Own{string}, Own{string}) -> bool;
+fn{Js} eq "((a, b) => new alan_std.Bool(a.val == b.val))" <- RootBacking :: (string, string) -> bool;
+fn{Rs} neq Infix{"!="} :: (Own{string}, Own{string}) -> bool;
+fn{Js} neq "((a, b) => new alan_std.Bool(a.val != b.val))" <- RootBacking :: (string, string) -> bool;
+fn{Rs} lt Infix{"<"} :: (Own{string}, Own{string}) -> bool;
+fn{Js} lt "((a, b) => new alan_std.Bool(a.val < b.val))" <- RootBacking :: (string, string) -> bool;
+fn{Rs} lte Infix{"<="} :: (Own{string}, Own{string}) -> bool;
+fn{Js} lte "((a, b) => new alan_std.Bool(a.val <= b.val))" <- RootBacking :: (string, string) -> bool;
+fn{Rs} gt Infix{">"} :: (Own{string}, Own{string}) -> bool;
+fn{Js} gt "((a, b) => new alan_std.Bool(a.val > b.val))" <- RootBacking :: (string, string) -> bool;
+fn{Rs} gte Infix{">="} :: (Own{string}, Own{string}) -> bool;
+fn{Js} gte "((a, b) => new alan_std.Bool(a.val >= b.val))" <- RootBacking :: (string, string) -> bool;
+fn min (a: string, b: string) = if(a <= b, fn () = a.clone(), fn () = b.clone());
+fn max (a: string, b: string) = if(a >= b, fn () = a.clone(), fn () = b.clone());
+fn{Rs} join Method{"join"} :: (string[], string) -> string;
+fn{Js} join "((a, b) => new alan_std.Str([...a.map(v => v.val)].join(b.val)))" <- RootBacking :: (string[], string) -> string;
+fn{Rs} join{S}(a: string[S], s: string) = {Method{"join"} :: (string[S], string) -> string}(a, s);
+fn{Js} join{S}(a: string[S], s: string) = {"((a, s) => new alan_std.Str(a.map(v => v.val).join(s.val)))" <- RootBacking :: (string[S], string) -> string}(a, s);
 
 /// Array related bindings
-export fn{Rs} len{T} (a: T[]) = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}(
+fn{Rs} len{T} (a: T[]) = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}(
   {Method{"len"} :: T[] -> Binds{"usize"}}(a));
-export fn{Js} len{T} (a: T[]) = {Property{"length"} :: T[] -> i32}(a).i64;
-export fn{Rs} get{T} "alan_std::getarray" <- RootBacking :: (T[], i64) -> T?;
-export fn{Js} get{T} (a: T[], i: i64) = if(i.gte(0).and(i.lt(a.len)),
+fn{Js} len{T} (a: T[]) = {Property{"length"} :: T[] -> i32}(a).i64;
+fn{Rs} get{T} "alan_std::getarray" <- RootBacking :: (T[], i64) -> T?;
+fn{Js} get{T} (a: T[], i: i64) = if((i >= 0) & (i < a.len),
   fn = {Method{"at"} :: (T[], i32) -> T}(a, i.i32));
-export fn push{T} (a: Mut{T[]}, v: T) = {Method{"push"} :: (Mut{T[]}, Own{T})}(a, v);
-export fn{Rs} pop{T} (a: Mut{T[]}) -> T? = {Method{"pop"} :: Mut{T[]} -> T?}(a);
-export fn{Js} pop{T} (a: Mut{T[]}) -> T? = {"((a) => a || null)" :: T? -> T?}({Method{"pop"} :: Mut{T[]} -> T?}(a));
-export fn{Rs} map{T, U} "alan_std::map_onearg" <- RootBacking :: (T[], T -> U) -> U[];
-export fn{Js} map{T, U} (a: T[], f: T -> U) = {"Promise.all" :: U[] -> U[]}({Method{"map"} :: (T[], T -> U) -> U[]}(a, f));
-export fn{Rs} map{T, U} "alan_std::map_twoarg" <- RootBacking :: (T[], (T, i64) -> U) -> U[];
-export fn{Js} map{T, U} (a: T[], f: (T, i64) -> U) = {"Promise.all" :: U[] -> U[]}({Method{"map"} :: (T[], (T, i32) -> U) -> U[]}(a, fn (v: T, i: i32) = f(v, i.i64)));
-export fn{Rs} parmap{T, U} "alan_std::parmap_onearg" <- RootBacking :: (T[], T -> U) -> U[];
-export fn{Rs} filter{T} "alan_std::filter_onearg" <- RootBacking :: (T[], T -> bool) -> T[];
-export fn{Js} filter{T} (a: T[], f: T -> bool) = {"(async (a, f) => { let out = []; for (let v of a) { if ((await f(v)).val) { out.push(v); } } return out; })" :: (T[], T -> bool) -> T[]}(a, f);
-export fn{Rs} filter{T} "alan_std::filter_twoarg" <- RootBacking :: (T[], (T, i64) -> bool) -> T[];
-export fn{Js} filter{T} (a: T[], f: (T, i64) -> bool) = {"(async (a, f) => { let out = []; for (let i = 0; i < a.length; i++) { if ((await f(a[i], BigInt(i))).val) { out.push(a[i]); } } return out; })" :: (T[], (T, i64) -> bool) -> T[]}(a, f);
-export fn{Rs} reduce{T} "alan_std::reduce_sametype" <- RootBacking :: (T[], (T, T) -> T) -> T?;
-export fn{Js} reduce{T} (a: T[], f: (T, T) -> T) = {"(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i]); } return out; })" :: (T[], (T, T) -> T) -> T?}(a, f);
-export fn{Rs} reduce{T} "alan_std::reduce_sametype_idx" <- RootBacking :: (T[], (T, T, i64) -> T) -> T?;
-export fn{Js} reduce{T} (a: T[], f: (T, T, i64) -> T) = {"(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i], BigInt(i)); } return out; })" :: (T[], (T, T, i64) -> T) -> T?}(a, f);
-export fn{Rs} reduce{T, U} "alan_std::reduce_difftype" <- RootBacking :: (T[], U, (U, T) -> U) -> U;
-export fn{Js} reduce{T, U} (a: T[], i: U, f: (U, T) -> U) = {"(async (a, i, f) => { let out = i; for (let i = 0; i < a.length; i++) { out = await f(out, a[i]); } return out; })" :: (T[], U, (U, T) -> U) -> U}(a, i, f);
-export fn{Rs} reduce{T, U} "alan_std::reduce_difftype_idx" <- RootBacking :: (T[], U, (U, T, i64) -> U) -> U;
-export fn{Js} reduce{T, U} (a: T[], i: U, f: (U, T, i64) -> U) = {"(async (a, i, f) => { let out = i; for (let i = 0; i < a.length; i++) { out = await f(out, a[i], BigInt(i)); } return out; })" :: (T[], U, (U, T, i64) -> U) -> U}(a, i, f);
-export fn{Rs} concat{T} "alan_std::concat" <- RootBacking :: (T[], T[]) -> T[];
-export fn{Js} concat{T} (a: T[], b: T[]) -> T[] = {Method{"concat"} :: (T[], T[]) -> T[]}(a, b);
-export fn{Rs} append{T} "alan_std::append" <- RootBacking :: (Mut{T[]}, T[]);
-export fn{Js} append{T} "((a, b) => { for (let v in b) { a.push(v); } })" :: (Mut{T[]}, T[]);
-export fn{Rs} filled{T} "alan_std::filled" <- RootBacking :: (T, i64) -> T[];
-export fn{Js} filled{T} "((v, c) => { let out = []; for (let i = 0n; i < c; i++) { out.push(v); } return out; })" :: (T, i64) -> T[];
-export fn{Rs} has{T} (a: T[], v: T) = {Method{"contains"} :: (T[], T) -> bool}(a, v);
-export fn{Js} has{T} (a: T[], v: T) = a.reduce(false, fn (out: bool, t: T) = if(out, true, t == v));
-export fn{Rs} has{T} "alan_std::hasfnarray" <- RootBacking :: (T[], T -> bool) -> bool;
-export fn{Js} has{T} (a: T[], f: T -> bool) = {"(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return true; } } return false; })" :: (T[], T -> bool) -> bool}(a, f);
-export fn{Rs} find{T} "alan_std::findarray" <- RootBacking :: (T[], T -> bool) -> T?;
-export fn{Js} find{T} (a: T[], f: T -> bool) -> T? = {"(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return v; } } return null; })" :: (T[], T -> bool) -> T?}(a, f);
+fn push{T} (a: Mut{T[]}, v: T) = {Method{"push"} :: (Mut{T[]}, Own{T})}(a, v);
+fn{Rs} pop{T} (a: Mut{T[]}) -> T? = {Method{"pop"} :: Mut{T[]} -> T?}(a);
+fn{Js} pop{T} (a: Mut{T[]}) -> T? = {"((a) => a || null)" :: T? -> T?}({Method{"pop"} :: Mut{T[]} -> T?}(a));
+fn{Rs} map{T, U} "alan_std::map_onearg" <- RootBacking :: (T[], T -> U) -> U[];
+fn{Js} map{T, U} (a: T[], f: T -> U) = {"Promise.all" :: U[] -> U[]}({Method{"map"} :: (T[], T -> U) -> U[]}(a, f));
+fn{Rs} map{T, U} "alan_std::map_twoarg" <- RootBacking :: (T[], (T, i64) -> U) -> U[];
+fn{Js} map{T, U} (a: T[], f: (T, i64) -> U) = {"Promise.all" :: U[] -> U[]}({Method{"map"} :: (T[], (T, i32) -> U) -> U[]}(a, fn (v: T, i: i32) = f(v, i.i64)));
+fn{Rs} parmap{T, U} "alan_std::parmap_onearg" <- RootBacking :: (T[], T -> U) -> U[];
+fn{Rs} filter{T} "alan_std::filter_onearg" <- RootBacking :: (T[], T -> bool) -> T[];
+fn{Js} filter{T} (a: T[], f: T -> bool) = {"(async (a, f) => { let out = []; for (let v of a) { if ((await f(v)).val) { out.push(v); } } return out; })" :: (T[], T -> bool) -> T[]}(a, f);
+fn{Rs} filter{T} "alan_std::filter_twoarg" <- RootBacking :: (T[], (T, i64) -> bool) -> T[];
+fn{Js} filter{T} (a: T[], f: (T, i64) -> bool) = {"(async (a, f) => { let out = []; for (let i = 0; i < a.length; i++) { if ((await f(a[i], BigInt(i))).val) { out.push(a[i]); } } return out; })" :: (T[], (T, i64) -> bool) -> T[]}(a, f);
+fn{Rs} reduce{T} "alan_std::reduce_sametype" <- RootBacking :: (T[], (T, T) -> T) -> T?;
+fn{Js} reduce{T} (a: T[], f: (T, T) -> T) = {"(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i]); } return out; })" :: (T[], (T, T) -> T) -> T?}(a, f);
+fn{Rs} reduce{T} "alan_std::reduce_sametype_idx" <- RootBacking :: (T[], (T, T, i64) -> T) -> T?;
+fn{Js} reduce{T} (a: T[], f: (T, T, i64) -> T) = {"(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i], BigInt(i)); } return out; })" :: (T[], (T, T, i64) -> T) -> T?}(a, f);
+fn{Rs} reduce{T, U} "alan_std::reduce_difftype" <- RootBacking :: (T[], U, (U, T) -> U) -> U;
+fn{Js} reduce{T, U} (a: T[], i: U, f: (U, T) -> U) = {"(async (a, i, f) => { let out = i; for (let i = 0; i < a.length; i++) { out = await f(out, a[i]); } return out; })" :: (T[], U, (U, T) -> U) -> U}(a, i, f);
+fn{Rs} reduce{T, U} "alan_std::reduce_difftype_idx" <- RootBacking :: (T[], U, (U, T, i64) -> U) -> U;
+fn{Js} reduce{T, U} (a: T[], i: U, f: (U, T, i64) -> U) = {"(async (a, i, f) => { let out = i; for (let i = 0; i < a.length; i++) { out = await f(out, a[i], BigInt(i)); } return out; })" :: (T[], U, (U, T, i64) -> U) -> U}(a, i, f);
+fn{Rs} concat{T} "alan_std::concat" <- RootBacking :: (T[], T[]) -> T[];
+fn{Js} concat{T} (a: T[], b: T[]) -> T[] = {Method{"concat"} :: (T[], T[]) -> T[]}(a, b);
+fn{Rs} append{T} "alan_std::append" <- RootBacking :: (Mut{T[]}, T[]);
+fn{Js} append{T} "((a, b) => { for (let v in b) { a.push(v); } })" :: (Mut{T[]}, T[]);
+fn{Rs} filled{T} "alan_std::filled" <- RootBacking :: (T, i64) -> T[];
+fn{Js} filled{T} "((v, c) => { let out = []; for (let i = 0n; i < c; i++) { out.push(v); } return out; })" :: (T, i64) -> T[];
+fn{Rs} has{T} (a: T[], v: T) = {Method{"contains"} :: (T[], T) -> bool}(a, v);
+fn{Js} has{T} (a: T[], v: T) = a.reduce(false, fn (out: bool, t: T) = if(out, true, t == v));
+fn{Rs} has{T} "alan_std::hasfnarray" <- RootBacking :: (T[], T -> bool) -> bool;
+fn{Js} has{T} (a: T[], f: T -> bool) = {"(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return true; } } return false; })" :: (T[], T -> bool) -> bool}(a, f);
+fn{Rs} find{T} "alan_std::findarray" <- RootBacking :: (T[], T -> bool) -> T?;
+fn{Js} find{T} (a: T[], f: T -> bool) -> T? = {"(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return v; } } return null; })" :: (T[], T -> bool) -> T?}(a, f);
 // TODO: The `if` syntactic sugar will make these `if` calls much nicer
-export fn index{T}(a: Array{T}, v: T) = a.reduce(
+fn index{T}(a: Array{T}, v: T) = a.reduce(
   Maybe{i64}(),
-  fn (out: Maybe{i64}, val: T, idx: i64) = if(out.exists, out, if(val.eq(v), Maybe(idx), out)));
-export fn index{T}(a: Array{T}, f: T -> bool) = a.reduce(
+  fn (out: Maybe{i64}, val: T, idx: i64) = if(out.exists, out, if(val == v, Maybe(idx), out)));
+fn index{T}(a: Array{T}, f: T -> bool) = a.reduce(
   Maybe{i64}(),
   fn (out: Maybe{i64}, val: T, idx: i64) = if(out.exists, out, if(f(val), idx)));
-export fn index{T}(a: Array{T}, f: (T, i64) -> bool) = a.reduce(
+fn index{T}(a: Array{T}, f: (T, i64) -> bool) = a.reduce(
   Maybe{i64}(),
   fn (out: Maybe{i64}, val: T, idx: i64) = if(out.exists, out, if(f(val, idx), idx)));
-export fn{Rs} every{T} "alan_std::everyarray" <- RootBacking :: (T[], T -> bool) -> bool;
-export fn{Js} every{T} (a: T[], f: T -> bool) = {"(async (a, f) => { for (let v of a) { if (!(await f(v)).val) { return false; } } return true; })" :: (T[], T -> bool) -> bool}(a, f);
-export fn{Rs} some{T} "alan_std::somearray" <- RootBacking :: (T[], T -> bool) -> bool;
-export fn{Js} some{T} (a: T[], f: T -> bool) = {"(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return true; } } return false; })" :: (T[], T -> bool) -> bool}(a, f);
-export fn{Rs} repeat{T} "alan_std::repeatarray" <- RootBacking :: (T[], i64) -> T[];
-export fn{Js} repeat{T} (a: T[], c: i64) = {"((a, c) => { let out = []; for (let i = 0n; i < c; i++) { out.push(...a); } return out; })" :: (T[], i64) -> T[]}(a, c);
-export fn{Rs} store{T} "alan_std::storearray" <- RootBacking :: (Mut{T[]}, i64, T) -> void!;
-export fn{Js} store{T} (a: T[], i: i64, v: T) = {"((a, i, v) => { if (i < 0n || i > BigInt(a.length)) { return new alan_std.AlanError(new alan_std.Str(`Provided array index ${i.toString()} is greater than the length of the array`)); } else { a.splice(Number(i), 0, v); } })" :: (T[], i64, T) -> void!}(a, i, v);
-export fn{Rs} delete{T} "alan_std::deletearray" <- RootBacking :: (Mut{T[]}, i64) -> T!;
-export fn{Js} delete{T} (a: T[], i: i64) = {"((a, i) => { if (i < 0n || i >= BigInt(a.length)) { return new alan_std.AlanError(new alan_std.Str(`Provided array index ${i.toString()} is beyond the bounds of the array`)); } else { return a.splice(Number(i), 1)[0]; } })" :: (T[], i64) -> T!}(a, i);
+fn{Rs} every{T} "alan_std::everyarray" <- RootBacking :: (T[], T -> bool) -> bool;
+fn{Js} every{T} (a: T[], f: T -> bool) = {"(async (a, f) => { for (let v of a) { if (!(await f(v)).val) { return false; } } return true; })" :: (T[], T -> bool) -> bool}(a, f);
+fn{Rs} some{T} "alan_std::somearray" <- RootBacking :: (T[], T -> bool) -> bool;
+fn{Js} some{T} (a: T[], f: T -> bool) = {"(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return true; } } return false; })" :: (T[], T -> bool) -> bool}(a, f);
+fn{Rs} repeat{T} "alan_std::repeatarray" <- RootBacking :: (T[], i64) -> T[];
+fn{Js} repeat{T} (a: T[], c: i64) = {"((a, c) => { let out = []; for (let i = 0n; i < c; i++) { out.push(...a); } return out; })" :: (T[], i64) -> T[]}(a, c);
+fn{Rs} store{T} "alan_std::storearray" <- RootBacking :: (Mut{T[]}, i64, T) -> void!;
+fn{Js} store{T} (a: T[], i: i64, v: T) = {"((a, i, v) => { if (i < 0n || i > BigInt(a.length)) { return new alan_std.AlanError(new alan_std.Str(`Provided array index ${i.toString()} is greater than the length of the array`)); } else { a.splice(Number(i), 0, v); } })" :: (T[], i64, T) -> void!}(a, i, v);
+fn{Rs} delete{T} "alan_std::deletearray" <- RootBacking :: (Mut{T[]}, i64) -> T!;
+fn{Js} delete{T} (a: T[], i: i64) = {"((a, i) => { if (i < 0n || i >= BigInt(a.length)) { return new alan_std.AlanError(new alan_std.Str(`Provided array index ${i.toString()} is beyond the bounds of the array`)); } else { return a.splice(Number(i), 1)[0]; } })" :: (T[], i64) -> T!}(a, i);
 
 /// Buffer related bindings
-export fn{Rs} get{T, S} "alan_std::getbuffer" <- RootBacking :: (T[S], i64) -> T?;
-export fn len{T, S}(T[S]) = {S}();
-export fn{Js} get{T, S} "((b, i) => { let idx = Number(i.val); if (idx >= 0 && idx < b.length) { return b[idx]; } else { return null; } })" :: (T[S], i64) -> T?;
-export fn{Rs} map{T, S, U} "alan_std::mapbuffer_onearg" <- RootBacking :: (T[S], T -> U) -> (U[S]);
-export fn{Js} map{T, S, U} (a: T[S], f: T -> U) = {"Promise.all" :: Buffer{U, S} -> Buffer{U, S}}({Method{"map"} :: (Buffer{T, S}, T -> U) -> Buffer{U, S}}(a, f));
-export fn{Rs} map{T, S, U} "alan_std::mapbuffer_twoarg" <- RootBacking :: (T[S], (T, i64) -> U) -> (U[S]);
-export fn{Js} map{T, S, U} (a: T[S], f: (T, i64) -> U) = {"Promise.all" :: Buffer{U, S} -> Buffer{U, S}}({Method{"map"} :: (Buffer{T, S}, (T, i32) -> U) -> Buffer{U, S}}(a, fn (v: T, i: i32) = f(v, i.i64)));
-export fn{Rs} reduce{T, S} "alan_std::reducebuffer_sametype" <- RootBacking :: (T[S], (T, T) -> T) -> T?;
-export fn{Js} reduce{T, S} (a: T[S], f: (T, T) -> T) = {"(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i]); } return out; })" :: (T[S], (T, T) -> T) -> T?}(a, f);
-export fn{Rs} reduce{T, S, U} "alan_std::reducebuffer_difftype" <- RootBacking :: (T[S], U, (U, T) -> U) -> U;
-export fn{Js} reduce{T, S, U} (a: T[S], i: U, f: (U, T) -> U) = {"(async (a, i, f) => { let out = i; for (let i = 0; i < a.length; i++) { out = await f(out, a[i]); } return out; })" :: (T[S], U, (U, T) -> U) -> U}(a, i, f);
-export fn{Rs} has{T, S} "alan_std::hasbuffer" <- RootBacking :: (T[S], T) -> bool;
-export fn{Js} has{T, S} (a: T[S], v: T) = a.reduce(false, fn (out: bool, t: T) = if(out, true, t == v));
-export fn{Rs} has{T, S} "alan_std::hasfnbuffer" <- RootBacking :: (T[S], T -> bool) -> bool;
-export fn{Js} has{T, S} (a: T[S], f: T -> bool) = {"(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return true; } } return false; })" :: (T[S], T -> bool) -> bool}(a, f);
-export fn{Rs} find{T, S} "alan_std::findbuffer" <- RootBacking :: (T[S], T -> bool) -> T?;
-export fn{Js} find{T, S} (a: T[S], f: T -> bool) -> T? = {"(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return v; } } return null; })" :: (T[S], T -> bool) -> T?}(a, f);
-export fn{Rs} every{T, S} "alan_std::everybuffer" <- RootBacking :: (T[S], T -> bool) -> bool;
-export fn{Js} every{T, S} (a: T[S], f: T -> bool) = {"(async (a, f) => { for (let v of a) { if (!(await f(v)).val) { return false; } } return true; })" :: (T[S], T -> bool) -> bool}(a, f);
+fn{Rs} get{T, S} "alan_std::getbuffer" <- RootBacking :: (T[S], i64) -> T?;
+fn len{T, S}(T[S]) = {S}();
+fn{Js} get{T, S} "((b, i) => { let idx = Number(i.val); if (idx >= 0 && idx < b.length) { return b[idx]; } else { return null; } })" :: (T[S], i64) -> T?;
+fn{Rs} map{T, S, U} "alan_std::mapbuffer_onearg" <- RootBacking :: (T[S], T -> U) -> (U[S]);
+fn{Js} map{T, S, U} (a: T[S], f: T -> U) = {"Promise.all" :: Buffer{U, S} -> Buffer{U, S}}({Method{"map"} :: (Buffer{T, S}, T -> U) -> Buffer{U, S}}(a, f));
+fn{Rs} map{T, S, U} "alan_std::mapbuffer_twoarg" <- RootBacking :: (T[S], (T, i64) -> U) -> (U[S]);
+fn{Js} map{T, S, U} (a: T[S], f: (T, i64) -> U) = {"Promise.all" :: Buffer{U, S} -> Buffer{U, S}}({Method{"map"} :: (Buffer{T, S}, (T, i32) -> U) -> Buffer{U, S}}(a, fn (v: T, i: i32) = f(v, i.i64)));
+fn{Rs} reduce{T, S} "alan_std::reducebuffer_sametype" <- RootBacking :: (T[S], (T, T) -> T) -> T?;
+fn{Js} reduce{T, S} (a: T[S], f: (T, T) -> T) = {"(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i]); } return out; })" :: (T[S], (T, T) -> T) -> T?}(a, f);
+fn{Rs} reduce{T, S, U} "alan_std::reducebuffer_difftype" <- RootBacking :: (T[S], U, (U, T) -> U) -> U;
+fn{Js} reduce{T, S, U} (a: T[S], i: U, f: (U, T) -> U) = {"(async (a, i, f) => { let out = i; for (let i = 0; i < a.length; i++) { out = await f(out, a[i]); } return out; })" :: (T[S], U, (U, T) -> U) -> U}(a, i, f);
+fn{Rs} has{T, S} "alan_std::hasbuffer" <- RootBacking :: (T[S], T) -> bool;
+fn{Js} has{T, S} (a: T[S], v: T) = a.reduce(false, fn (out: bool, t: T) = if(out, true, t == v));
+fn{Rs} has{T, S} "alan_std::hasfnbuffer" <- RootBacking :: (T[S], T -> bool) -> bool;
+fn{Js} has{T, S} (a: T[S], f: T -> bool) = {"(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return true; } } return false; })" :: (T[S], T -> bool) -> bool}(a, f);
+fn{Rs} find{T, S} "alan_std::findbuffer" <- RootBacking :: (T[S], T -> bool) -> T?;
+fn{Js} find{T, S} (a: T[S], f: T -> bool) -> T? = {"(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return v; } } return null; })" :: (T[S], T -> bool) -> T?}(a, f);
+fn{Rs} every{T, S} "alan_std::everybuffer" <- RootBacking :: (T[S], T -> bool) -> bool;
+fn{Js} every{T, S} (a: T[S], f: T -> bool) = {"(async (a, f) => { for (let v of a) { if (!(await f(v)).val) { return false; } } return true; })" :: (T[S], T -> bool) -> bool}(a, f);
 fn{Rs} concatInner{T, S, N} "alan_std::concatbuffer" <- RootBacking :: (Mut{T[S + N]}, T[S], T[N]);
 fn{Js} concatInner{T, S, N} "((o, a, b) => { for (let i = 0; i < a.length; i++) { o[i] = a[i]; } for (let i = 0; i < b.length; i++) { o[i+a.length] = b[i]; } })" :: (Mut{T[S + N]}, T[S], T[N]);
-export fn concat{T, S, N}(a: T[S], b: T[N]) {
+fn concat{T, S, N}(a: T[S], b: T[N]) {
   // I can't bind directly into Rust because Rust can't add const integer type parameters together.
   // It's *theoretically* possible to generate a new Rust function in each case with the required
   // sizes, but it will be really difficult, so I'm implementing this for now with the intent to
   // eventually replace it.
-  let o = {T[S + N]}(a[0].getOrExit);
+  let o = {T[S + N]}(a[0]!!);
   concatInner(o, a, b);
   return o;
 }
-export fn{Rs} repeat{T, S} "alan_std::repeatbuffertoarray" <- RootBacking :: (T[S], i64) -> T[];
-export fn{Js} repeat{T, S} (a: T[S], c: i64) = {"((a, c) => { let out = []; for (let i = 0n; i < c; i++) { out.push(...a); } return out; })" :: (T[S], i64) -> T[]}(a, c);
-export fn{Rs} store{T, S} "alan_std::storebuffer" <- RootBacking :: (Mut{T[S]}, i64, T) -> T!;
-export fn{Js} store{T, S} (a: T[S], i: i64, v: T) = {"((a, i, v) => { if (i < 0n || i > BigInt(a.length)) { return new alan_std.AlanError(new alan_std.Str(`Provided array index ${i.toString()} is greater than the length of the array`)); } else { let out = a[Number(i)]; a[Number(i)] = v; return out; } })" :: (T[S], i64, T) -> T!}(a, i, v);
+fn{Rs} repeat{T, S} "alan_std::repeatbuffertoarray" <- RootBacking :: (T[S], i64) -> T[];
+fn{Js} repeat{T, S} (a: T[S], c: i64) = {"((a, c) => { let out = []; for (let i = 0n; i < c; i++) { out.push(...a); } return out; })" :: (T[S], i64) -> T[]}(a, c);
+fn{Rs} store{T, S} "alan_std::storebuffer" <- RootBacking :: (Mut{T[S]}, i64, T) -> T!;
+fn{Js} store{T, S} (a: T[S], i: i64, v: T) = {"((a, i, v) => { if (i < 0n || i > BigInt(a.length)) { return new alan_std.AlanError(new alan_std.Str(`Provided array index ${i.toString()} is greater than the length of the array`)); } else { let out = a[Number(i)]; a[Number(i)] = v; return out; } })" :: (T[S], i64, T) -> T!}(a, i, v);
 
 /// Dictionary-related bindings
-export fn{Rs} Dict{K, V} "alan_std::OrderedHashMap::new" <- RootBacking :: () -> Dict{K, V};
-export fn{Js} Dict{K, V} "new Map" :: () -> Dict{K, V};
-export fn Dict{K, V}(k: K, v: V) {
+fn{Rs} Dict{K, V} "alan_std::OrderedHashMap::new" <- RootBacking :: () -> Dict{K, V};
+fn{Js} Dict{K, V} "new Map" :: () -> Dict{K, V};
+fn Dict{K, V}(k: K, v: V) {
   let out = Dict{K, V}();
   out.store(k, v);
   return out;
 }
-export fn Dict{K, V}(a: Array{(K, V)}) = a.reduce(Dict{K, V}(), fn (d: Dict{K, V}, v: (K, V)) {
+fn Dict{K, V}(a: Array{(K, V)}) = a.reduce(Dict{K, V}(), fn (d: Dict{K, V}, v: (K, V)) {
   d.store(v.0, v.1);
   return d;
 });
-export fn{Rs} has{K, V} (d: Dict{K, V}, k: K) = {Method{"contains_key"} :: (Dict{K, V}, K) -> bool}(d, k);
-export fn{Js} has{K, V} (d: Dict{K, V}, k: K) = {"((d, k) => d.has(k?.val ?? k))" :: (Dict{K, V}, K) -> bool}(d, k);
-export fn{Rs} get{K, V} "alan_std::getdict" <- RootBacking :: (Dict{K, V}, K) -> V?;
-export fn{Js} get{K, V} (d: Dict{K, V}, k: K) = {"((d, k) => d.get(k?.val ?? k) || null)" :: (Dict{K, V}, K) -> V?}(d, k);
-export fn{Rs} store{K, V} (d: Mut{Dict{K, V}}, k: K, v: V) {
+fn{Rs} has{K, V} (d: Dict{K, V}, k: K) = {Method{"contains_key"} :: (Dict{K, V}, K) -> bool}(d, k);
+fn{Js} has{K, V} (d: Dict{K, V}, k: K) = {"((d, k) => d.has(k?.val ?? k))" :: (Dict{K, V}, K) -> bool}(d, k);
+fn{Rs} get{K, V} "alan_std::getdict" <- RootBacking :: (Dict{K, V}, K) -> V?;
+fn{Js} get{K, V} (d: Dict{K, V}, k: K) = {"((d, k) => d.get(k?.val ?? k) || null)" :: (Dict{K, V}, K) -> V?}(d, k);
+fn{Rs} store{K, V} (d: Mut{Dict{K, V}}, k: K, v: V) {
   {Method{"insert"} :: (Mut{Dict{K, V}}, Own{K}, Own{V}) -> V?}(d, k, v);
 }
-export fn{Js} store{K, V} (d: Mut{Dict{K, V}}, k: K, v: V) {
-  let out = d.get(k);
+fn{Js} store{K, V} (d: Mut{Dict{K, V}}, k: K, v: V) {
+  let out = d[k];
   {"((s, k, v) => s.set(k?.val ?? k, v))" :: (Dict{K, V}, K, V) -> void}(d, k, v);
   return out;
 }
-export fn{Rs} len{K, V} (d: Dict{K, V}) = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}(
+fn{Rs} len{K, V} (d: Dict{K, V}) = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}(
   {Method{"len"} :: Dict{K, V} -> Binds{"usize"}}(d));
-export fn{Js} len{K, V} (d: Dict{K, V}) = {Property{"size"} :: Dict{K, V} -> i32}(d).i64;
-export fn{Rs} keys{K, V} "alan_std::keysdict" <- RootBacking :: Dict{K, V} -> K[];
-export fn{Js} keys{K, V} (d: Dict{K, V}) = {"Array.from" :: K[] -> K[]}({Method{"keys"} :: Dict{K, V} -> K[]}(d));
+fn{Js} len{K, V} (d: Dict{K, V}) = {Property{"size"} :: Dict{K, V} -> i32}(d).i64;
+fn{Rs} keys{K, V} "alan_std::keysdict" <- RootBacking :: Dict{K, V} -> K[];
+fn{Js} keys{K, V} (d: Dict{K, V}) = {"Array.from" :: K[] -> K[]}({Method{"keys"} :: Dict{K, V} -> K[]}(d));
 // TODO: Figure out how to eliminate this weirdness
-export fn{Js} keys{V} (d: Dict{i8, V}) = {"((d) => d.keys().map((k) => new alan_std.I8(k)))" :: Dict{i8, V} -> i8[]}(d);
-export fn{Js} keys{V} (d: Dict{i16, V}) = {"((d) => d.keys().map((k) => new alan_std.I16(k)))" :: Dict{i16, V} -> i16[]}(d);
-export fn{Js} keys{V} (d: Dict{i32, V}) = {"((d) => d.keys().map((k) => new alan_std.I32(k)))" :: Dict{i32, V} -> i32[]}(d);
-export fn{Js} keys{V} (d: Dict{i64, V}) = {"((d) => d.keys().map((k) => new alan_std.I64(k)))" :: Dict{i64, V} -> i64[]}(d);
-export fn{Js} keys{V} (d: Dict{u8, V}) = {"((d) => d.keys().map((k) => new alan_std.U8(k)))" :: Dict{u8, V} -> u8[]}(d);
-export fn{Js} keys{V} (d: Dict{u16, V}) = {"((d) => d.keys().map((k) => new alan_std.U16(k)))" :: Dict{u16, V} -> u16[]}(d);
-export fn{Js} keys{V} (d: Dict{u32, V}) = {"((d) => d.keys().map((k) => new alan_std.U32(k)))" :: Dict{u32, V} -> u32[]}(d);
-export fn{Js} keys{V} (d: Dict{u64, V}) = {"((d) => d.keys().map((k) => new alan_std.U64(k)))" :: Dict{u64, V} -> u64[]}(d);
-export fn{Js} keys{V} (d: Dict{f32, V}) = {"((d) => d.keys().map((k) => new alan_std.F32(k)))" :: Dict{f32, V} -> f32[]}(d);
-export fn{Js} keys{V} (d: Dict{f64, V}) = {"((d) => d.keys().map((k) => new alan_std.F64(k)))" :: Dict{f64, V} -> f64[]}(d);
-export fn{Js} keys{V} (d: Dict{bool, V}) = {"((d) => d.keys().map((k) => new alan_std.Bool(k)))" :: Dict{bool, V} -> bool[]}(d);
-export fn{Js} keys{V} (d: Dict{string, V}) = {"((d) => d.keys().map((k) => new alan_std.Str(k)))" :: Dict{string, V} -> string[]}(d);
-export fn{Rs} vals{K, V} "alan_std::valsdict" <- RootBacking :: Dict{K, V} -> V[];
-export fn{Js} vals{K, V} (d: Dict{K, V}) = {"Array.from" :: V[] -> V[]}({Method{"values"} :: Dict{K, V} -> V[]}(d));
-export fn{Rs} Array{K, V} "alan_std::arraydict" <- RootBacking :: Dict{K, V} -> (K, V)[];
+fn{Js} keys{V} (d: Dict{i8, V}) = {"((d) => d.keys().map((k) => new alan_std.I8(k)))" :: Dict{i8, V} -> i8[]}(d);
+fn{Js} keys{V} (d: Dict{i16, V}) = {"((d) => d.keys().map((k) => new alan_std.I16(k)))" :: Dict{i16, V} -> i16[]}(d);
+fn{Js} keys{V} (d: Dict{i32, V}) = {"((d) => d.keys().map((k) => new alan_std.I32(k)))" :: Dict{i32, V} -> i32[]}(d);
+fn{Js} keys{V} (d: Dict{i64, V}) = {"((d) => d.keys().map((k) => new alan_std.I64(k)))" :: Dict{i64, V} -> i64[]}(d);
+fn{Js} keys{V} (d: Dict{u8, V}) = {"((d) => d.keys().map((k) => new alan_std.U8(k)))" :: Dict{u8, V} -> u8[]}(d);
+fn{Js} keys{V} (d: Dict{u16, V}) = {"((d) => d.keys().map((k) => new alan_std.U16(k)))" :: Dict{u16, V} -> u16[]}(d);
+fn{Js} keys{V} (d: Dict{u32, V}) = {"((d) => d.keys().map((k) => new alan_std.U32(k)))" :: Dict{u32, V} -> u32[]}(d);
+fn{Js} keys{V} (d: Dict{u64, V}) = {"((d) => d.keys().map((k) => new alan_std.U64(k)))" :: Dict{u64, V} -> u64[]}(d);
+fn{Js} keys{V} (d: Dict{f32, V}) = {"((d) => d.keys().map((k) => new alan_std.F32(k)))" :: Dict{f32, V} -> f32[]}(d);
+fn{Js} keys{V} (d: Dict{f64, V}) = {"((d) => d.keys().map((k) => new alan_std.F64(k)))" :: Dict{f64, V} -> f64[]}(d);
+fn{Js} keys{V} (d: Dict{bool, V}) = {"((d) => d.keys().map((k) => new alan_std.Bool(k)))" :: Dict{bool, V} -> bool[]}(d);
+fn{Js} keys{V} (d: Dict{string, V}) = {"((d) => d.keys().map((k) => new alan_std.Str(k)))" :: Dict{string, V} -> string[]}(d);
+fn{Rs} vals{K, V} "alan_std::valsdict" <- RootBacking :: Dict{K, V} -> V[];
+fn{Js} vals{K, V} (d: Dict{K, V}) = {"Array.from" :: V[] -> V[]}({Method{"values"} :: Dict{K, V} -> V[]}(d));
+fn{Rs} Array{K, V} "alan_std::arraydict" <- RootBacking :: Dict{K, V} -> (K, V)[];
 // export fn{Js} Array{K, V} "Array.from" :: Dict{K, V} -> (K, V)[];
 // TODO: Figure out how to avoid this map
-export fn{Js} Array{K, V} "((d) => Array.from(d).map(kv => ({ arg0: kv[0], arg1: kv[1] })))" :: Dict{K, V} -> (K, V)[];
-export fn{Js} Array{V} (d: Dict{i8, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.I8(kv[0]), arg1: kv[1] })))" :: Dict{i8, V} -> (i8, V)[]}(d);
-export fn{Js} Array{V} (d: Dict{i16, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.I16(kv[0]), arg1: kv[1] })))" :: Dict{i16, V} -> (i16, V)[]}(d);
-export fn{Js} Array{V} (d: Dict{i32, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.I32(kv[0]), arg1: kv[1] })))" :: Dict{i32, V} -> (i32, V)[]}(d);
-export fn{Js} Array{V} (d: Dict{i64, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.I64(kv[0]), arg1: kv[1] })))" :: Dict{i64, V} -> (i64, V)[]}(d);
-export fn{Js} Array{V} (d: Dict{u8, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.U8(kv[0]), arg1: kv[1] })))" :: Dict{u8, V} -> (u8, V)[]}(d);
-export fn{Js} Array{V} (d: Dict{u16, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.U16(kv[0]), arg1: kv[1] })))" :: Dict{u16, V} -> (u16, V)[]}(d);
-export fn{Js} Array{V} (d: Dict{u32, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.U32(kv[0]), arg1: kv[1] })))" :: Dict{u32, V} -> (u32, V)[]}(d);
-export fn{Js} Array{V} (d: Dict{u64, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.U64(kv[0]), arg1: kv[1] })))" :: Dict{u64, V} -> (u64, V)[]}(d);
-export fn{Js} Array{V} (d: Dict{f32, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.F32(kv[0]), arg1: kv[1] })))" :: Dict{f32, V} -> (f32, V)[]}(d);
-export fn{Js} Array{V} (d: Dict{f64, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.F64(kv[0]), arg1: kv[1] })))" :: Dict{f64, V} -> (f64, V)[]}(d);
-export fn{Js} Array{V} (d: Dict{bool, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.Bool(kv[0]), arg1: kv[1] })))" :: Dict{bool, V} -> (bool, V)[]}(d);
-export fn{Js} Array{V} (d: Dict{string, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.Str(kv[0]), arg1: kv[1] })))" :: Dict{string, V} -> (string, V)[]}(d);
-export fn{Rs} concat{K, V} "alan_std::concatdict" <- RootBacking :: (Dict{K, V}, Dict{K, V}) -> Dict{K, V};
-export fn{Js} concat{K, V} "((a, b) => new Map([...a, ...b]))" :: (Dict{K, V}, Dict{K, V}) -> Dict{K, V};
+fn{Js} Array{K, V} "((d) => Array.from(d).map(kv => ({ arg0: kv[0], arg1: kv[1] })))" :: Dict{K, V} -> (K, V)[];
+fn{Js} Array{V} (d: Dict{i8, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.I8(kv[0]), arg1: kv[1] })))" :: Dict{i8, V} -> (i8, V)[]}(d);
+fn{Js} Array{V} (d: Dict{i16, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.I16(kv[0]), arg1: kv[1] })))" :: Dict{i16, V} -> (i16, V)[]}(d);
+fn{Js} Array{V} (d: Dict{i32, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.I32(kv[0]), arg1: kv[1] })))" :: Dict{i32, V} -> (i32, V)[]}(d);
+fn{Js} Array{V} (d: Dict{i64, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.I64(kv[0]), arg1: kv[1] })))" :: Dict{i64, V} -> (i64, V)[]}(d);
+fn{Js} Array{V} (d: Dict{u8, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.U8(kv[0]), arg1: kv[1] })))" :: Dict{u8, V} -> (u8, V)[]}(d);
+fn{Js} Array{V} (d: Dict{u16, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.U16(kv[0]), arg1: kv[1] })))" :: Dict{u16, V} -> (u16, V)[]}(d);
+fn{Js} Array{V} (d: Dict{u32, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.U32(kv[0]), arg1: kv[1] })))" :: Dict{u32, V} -> (u32, V)[]}(d);
+fn{Js} Array{V} (d: Dict{u64, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.U64(kv[0]), arg1: kv[1] })))" :: Dict{u64, V} -> (u64, V)[]}(d);
+fn{Js} Array{V} (d: Dict{f32, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.F32(kv[0]), arg1: kv[1] })))" :: Dict{f32, V} -> (f32, V)[]}(d);
+fn{Js} Array{V} (d: Dict{f64, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.F64(kv[0]), arg1: kv[1] })))" :: Dict{f64, V} -> (f64, V)[]}(d);
+fn{Js} Array{V} (d: Dict{bool, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.Bool(kv[0]), arg1: kv[1] })))" :: Dict{bool, V} -> (bool, V)[]}(d);
+fn{Js} Array{V} (d: Dict{string, V}) = {"((d) => Array.from(d).map(kv => ({ arg0: new alan_std.Str(kv[0]), arg1: kv[1] })))" :: Dict{string, V} -> (string, V)[]}(d);
+fn{Rs} concat{K, V} "alan_std::concatdict" <- RootBacking :: (Dict{K, V}, Dict{K, V}) -> Dict{K, V};
+fn{Js} concat{K, V} "((a, b) => new Map([...a, ...b]))" :: (Dict{K, V}, Dict{K, V}) -> Dict{K, V};
 
 /// Set-related bindings
-export fn Set{V}(v: V) {
+fn Set{V}(v: V) {
   let out = Set{V}();
   out.store(v);
   return out;
 }
-export fn Set{V}(a: Array{V}) = a.reduce(Set{V}(), fn (s: Set{V}, v: V) {
+fn Set{V}(a: Array{V}) = a.reduce(Set{V}(), fn (s: Set{V}, v: V) {
   s.store(v);
   return s;
 });
-export fn{Rs} Set{V} "std::collections::HashSet::new" :: () -> Set{V};
-export fn{Js} Set{V} "new Set" :: () -> Set{V};
-export fn{Rs} store{V} (s: Mut{Set{V}}, v: V) {
+fn{Rs} Set{V} "std::collections::HashSet::new" :: () -> Set{V};
+fn{Js} Set{V} "new Set" :: () -> Set{V};
+fn{Rs} store{V} (s: Mut{Set{V}}, v: V) {
   {Method{"insert"} :: (Mut{Set{V}}, Own{V}) -> bool}(s, v);
 }
-export fn{Js} store{V} (s: Mut{Set{V}}, v: V) {
+fn{Js} store{V} (s: Mut{Set{V}}, v: V) {
   {"((s, v) => s.add(v?.val ?? v))" :: (Set{V}, V) -> Set{V}}(s, v);
 }
-export fn{Rs} has{V} (s: Set{V}, v: V) = {Method{"contains"} :: (Set{V}, V) -> bool}(s, v);
-export fn{Js} has{V} (s: Set{V}, v: V) = {"((s, v) => s.has(v?.val ?? v))" :: (Set{V}, V) -> bool}(s, v);
-export fn{Rs} len{V} (s: Set{V}) = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}(
+fn{Rs} has{V} (s: Set{V}, v: V) = {Method{"contains"} :: (Set{V}, V) -> bool}(s, v);
+fn{Js} has{V} (s: Set{V}, v: V) = {"((s, v) => s.has(v?.val ?? v))" :: (Set{V}, V) -> bool}(s, v);
+fn{Rs} len{V} (s: Set{V}) = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}(
   {Method{"len"} :: Set{V} -> Binds{"usize"}}(s));
-export fn{Js} len{V} (s: Set{V}) = {Property{"size"} :: Set{V} -> i32}(s).i64;
-export fn{Rs} Array{V} "alan_std::arrayset" <- RootBacking :: Set{V} -> V[];
-export fn{Js} Array{V} "Array.from" :: Set{V} -> V[];
-export fn{Rs} union{V} "alan_std::unionset" <- RootBacking :: (Set{V}, Set{V}) -> Set{V};
-export fn{Js} union{V} (a: Set{V}, b: Set{V}) = {Method{"union"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
-export fn or{V}(a: Set{V}, b: Set{V}) = union(a, b);
-export fn{Rs} intersect{V} "alan_std::intersectset" <- RootBacking :: (Set{V}, Set{V}) -> Set{V};
-export fn{Js} intersect{V} (a: Set{V}, b: Set{V}) = {Method{"intersection"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
-export fn and{V}(a: Set{V}, b: Set{V}) = intersect(a, b);
-export fn{Rs} difference{V} "alan_std::differenceset" <- RootBacking :: (Set{V}, Set{V}) -> Set{V};
-export fn{Js} difference{V} (a: Set{V}, b: Set{V}) = {Method{"difference"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
-export fn div{V}(a: Set{V}, b: Set{V}) = difference(a, b);
-export fn{Rs} symmetricDifference{V} "alan_std::symmetric_differenceset" <- RootBacking :: (Set{V}, Set{V}) -> Set{V};
-export fn{Js} symmetricDifference{V} (a: Set{V}, b: Set{V}) = {Method{"symmetricDifference"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
-export fn xor{V}(a: Set{V}, b: Set{V}) = symmetricDifference(a, b);
-export fn{Rs} product{V} "alan_std::productset" <- RootBacking :: (Set{V}, Set{V}) -> Set{(V, V)};
-export fn{Js} product{V} "((a, b) => { let out = new Set(); for (let arg0 of a) { for (let arg1 of b) { out.add({ arg0, arg1 }); } } return out; })" :: (Set{V}, Set{V}) -> Set{(V, V)};
-export fn mul{V}(a: Set{V}, b: Set{V}) = product(a, b);
+fn{Js} len{V} (s: Set{V}) = {Property{"size"} :: Set{V} -> i32}(s).i64;
+fn{Rs} Array{V} "alan_std::arrayset" <- RootBacking :: Set{V} -> V[];
+fn{Js} Array{V} "Array.from" :: Set{V} -> V[];
+fn{Rs} union{V} "alan_std::unionset" <- RootBacking :: (Set{V}, Set{V}) -> Set{V};
+fn{Js} union{V} (a: Set{V}, b: Set{V}) = {Method{"union"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
+fn or{V}(a: Set{V}, b: Set{V}) = union(a, b);
+fn{Rs} intersect{V} "alan_std::intersectset" <- RootBacking :: (Set{V}, Set{V}) -> Set{V};
+fn{Js} intersect{V} (a: Set{V}, b: Set{V}) = {Method{"intersection"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
+fn and{V}(a: Set{V}, b: Set{V}) = intersect(a, b);
+fn{Rs} difference{V} "alan_std::differenceset" <- RootBacking :: (Set{V}, Set{V}) -> Set{V};
+fn{Js} difference{V} (a: Set{V}, b: Set{V}) = {Method{"difference"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
+fn div{V}(a: Set{V}, b: Set{V}) = difference(a, b);
+fn{Rs} symmetricDifference{V} "alan_std::symmetric_differenceset" <- RootBacking :: (Set{V}, Set{V}) -> Set{V};
+fn{Js} symmetricDifference{V} (a: Set{V}, b: Set{V}) = {Method{"symmetricDifference"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
+fn xor{V}(a: Set{V}, b: Set{V}) = symmetricDifference(a, b);
+fn{Rs} product{V} "alan_std::productset" <- RootBacking :: (Set{V}, Set{V}) -> Set{(V, V)};
+fn{Js} product{V} "((a, b) => { let out = new Set(); for (let arg0 of a) { for (let arg1 of b) { out.add({ arg0, arg1 }); } } return out; })" :: (Set{V}, Set{V}) -> Set{(V, V)};
+fn mul{V}(a: Set{V}, b: Set{V}) = product(a, b);
 
 /// Tree implementation
 
 // The Tree type houses all of the values attached to a tree in an array and two secondary arrays to
 // hold the metadata on which value is the parent and which are children, if any. The parent value
 // `void` if it has no parent and a positive integer otherwise.
-export type Tree{T} =
+type Tree{T} =
   vals: Array{T},
   parents: Array{Maybe{i64}},
   children: Array{Array{i64}};
@@ -1358,15 +1393,15 @@ export type Tree{T} =
 // The Node type simply holds the index to look into the tree for a particular value-parent-children
 // triplet, where that index is reffered to as a node ID. This allows node-based code to be written
 // while not actually having a recursive data structure that a traditional Node type would defined.
-export type Node{T} =
+type Node{T} =
   id: i64,
   tree: Tree{T};
 
-export fn Tree{T}(rootVal: T) = Tree{T}(
+fn Tree{T}(rootVal: T) = Tree{T}(
   Array{T}(rootVal),
   Array{Maybe{i64}}(Maybe{i64}()),
   Array{Array{i64}}(Array{i64}()));
-export fn Tree{T}(n: Node{T}) = n.tree;
+fn Tree{T}(n: Node{T}) = n.tree;
 
 // TODO: This is a more correct solution, but any Tree constructed by us will always have the root
 // node be the first element of the array, so we're just doing that so we don't have a `Maybe` here
@@ -1377,33 +1412,33 @@ export fn Tree{T}(n: Node{T}) = n.tree;
     fn () -> Node{T} = Node{T}(rootIdx.getOrExit, t)
   );
 }*/
-export fn rootNode{T}(t: Tree{T}) = Node{T}(0, t);
+fn rootNode{T}(t: Tree{T}) = Node{T}(0, t);
 
-export fn len{T}(t: Tree{T}) = t.vals.len;
+fn len{T}(t: Tree{T}) = t.vals.len;
 
-export fn Node{T}(t: Tree{T}, i: i64) = if(t.len.gt(i), fn () = Node{T}(i, t));
+fn Node{T}(t: Tree{T}, i: i64) = if(t.len > i, fn () = Node{T}(i, t));
 
-export fn parent{T}(n: Node{T}) {
+fn parent{T}(n: Node{T}) {
   let parentId = n.tree.parents[n.id];
   return if(parentId.exists,
-    if(parentId.getOrExit.exists,
+    if(exists(parentId!!),
       fn () = Node{T}(parentId.getOrExit.getOrExit, n.tree)),
       Maybe{Node{T}}());
 }
 
-export fn children{T}(n: Node{T}) = if(
-  n.tree.len.gt(n.id),
+fn children{T}(n: Node{T}) = if(
+  n.tree.len > n.id,
   fn () {
-    let childIds = n.tree.children[n.id].getOr(Array{i64}());
+    let childIds = n.tree.children[n.id] ?? Array{i64}();
     return childIds
-      .filter(fn (id: i64) = n.tree.parents[id].getOr(-1).eq(n.id))
+      .filter(fn (id: i64) = n.tree.parents[id] ?? -1 == n.id)
       .map(fn (id: i64) = Node{T}(id, n.tree));
   },
   fn () = Array{Node{T}}());
 
-export fn children{T}(t: Tree{T}) = t.rootNode.children;
+fn children{T}(t: Tree{T}) = t.rootNode.children;
 
-export fn addChild{T}(n: Node{T}, val: T) {
+fn addChild{T}(n: Node{T}, val: T) {
   let idx = n.tree.len;
   let parentIdx = n.id;
   n.tree.vals.push(val);
@@ -1411,13 +1446,13 @@ export fn addChild{T}(n: Node{T}, val: T) {
   n.tree.children.push(Array{i64}());
   return Node{T}(idx, n.tree);
 }
-export fn addChild{T}(n: Node{T}, t: Tree{T}) {
+fn addChild{T}(n: Node{T}, t: Tree{T}) {
   let idxOffset = n.tree.len;
   let idx = idxOffset.clone(); // TODO: Lower stage of compiler should be doing this
   let parentIdx = n.id;
   n.tree.vals.append(t.vals);
   n.tree.parents.append(t.parents.map(fn (pId: Maybe{i64}) = if(pId.exists,
-    fn () = Maybe{i64}(pId.getOrExit + idxOffset),
+    fn () = Maybe{i64}(pId!! + idxOffset),
     fn () = Maybe{i64}(idx))));
   n.tree.children.append(
     t.children.map(
@@ -1425,7 +1460,7 @@ export fn addChild{T}(n: Node{T}, t: Tree{T}) {
         fn (id: i64) = id + idxOffset)));
   return Node{T}(idx, n.tree);
 }
-export fn addChild{T}(t: Tree{T}, val: T) = t.rootNode.addChild(val);
+fn addChild{T}(t: Tree{T}, val: T) = t.rootNode.addChild(val);
 
 
 // TODO: Implement `addChild` when the child is itself a `Node{T}`
@@ -1436,80 +1471,80 @@ export fn addChild{T}(t: Tree{T}, val: T) = t.rootNode.addChild(val);
 // TODO: Implement `subtree` to create a new tree consisting of the specified node as its root and
 // only its own children as the children of the tree.
 
-export fn getOr{T}(n: Node{T}, t: T) = n.tree.vals[n.id].getOr(t);
+fn getOr{T}(n: Node{T}, t: T) = n.tree.vals[n.id] ?? t;
 
-export fn Array{T}(t: Tree{T}) = t.vals.map(
-  fn (_: T, i: i64) = Node{T}(t, i).getOrExit);
+fn Array{T}(t: Tree{T}) = t.vals.map(
+  fn (_: T, i: i64) = Node{T}(t, i)!!);
 
-export fn map{T, U}(t: Tree{T}, mapper: (Node{T}) -> Node{U}) = Tree{U}(
+fn map{T, U}(t: Tree{T}, mapper: (Node{T}) -> Node{U}) = Tree{U}(
   t.Array.map(mapper),
   t.parents.clone(),
   t.children.clone());
-export fn map{T, U}(t: Tree{T}, mapper: (Node{T}, i64) -> Node{U}) = Tree{U}(
+fn map{T, U}(t: Tree{T}, mapper: (Node{T}, i64) -> Node{U}) = Tree{U}(
   t.Array.map(mapper),
   t.parents,
   t.children);
 
-export fn every{T}(t: Tree{T}, f: (Node{T}) -> bool) = t.Array.every(f);
+fn every{T}(t: Tree{T}, f: (Node{T}) -> bool) = t.Array.every(f);
 
-export fn some{T}(t: Tree{T}, f: (Node{T}) -> bool) = t.Array.some(f);
+fn some{T}(t: Tree{T}, f: (Node{T}) -> bool) = t.Array.some(f);
 
-export fn reduce{T}(t: Tree{T}, f: (Node{T}, Node{T}) -> Node{T}) = t.Array.reduce(f);
-export fn reduce{T}(t: Tree{T}, f: (Node{T}, Node{T}, i64) -> Node{T}) = t.Array.reduce(f);
-export fn reduce{T, U}(t: Tree{T}, i: U, f: (U, Node{T}) -> U) = t.Array.reduce(i, f);
-export fn reduce{T, U}(t: Tree{T}, i: U, f: (U, Node{T}, i64) -> U) = t.Array.reduce(i, f);
+fn reduce{T}(t: Tree{T}, f: (Node{T}, Node{T}) -> Node{T}) = t.Array.reduce(f);
+fn reduce{T}(t: Tree{T}, f: (Node{T}, Node{T}, i64) -> Node{T}) = t.Array.reduce(f);
+fn reduce{T, U}(t: Tree{T}, i: U, f: (U, Node{T}) -> U) = t.Array.reduce(i, f);
+fn reduce{T, U}(t: Tree{T}, i: U, f: (U, Node{T}, i64) -> U) = t.Array.reduce(i, f);
 
-export fn find{T}(t: Tree{T}, f: (T) -> bool) = t.Array.find(f);
+fn find{T}(t: Tree{T}, f: (T) -> bool) = t.Array.find(f);
 
 /// Thread-related bindings
-export fn{Rs} wait (t: i64) = {"std::thread::sleep" :: Own{Duration}}(
+fn{Rs} wait (t: i64) = {"std::thread::sleep" :: Own{Duration}}(
   {"std::time::Duration::from_millis" :: Own{u64} -> Duration}(t.u64)
 );
-export fn{Js} wait "((t) => new Promise((r) => setTimeout(() => { r(performance.now()) }, Number(t))))" :: i64 -> f64;
+fn{Js} wait "((t) => new Promise((r) => setTimeout(() => { r(performance.now()) }, Number(t))))" :: i64 -> f64;
 
 /// Time-related bindings
-export fn{Rs} now "std::time::Instant::now" :: () -> Instant;
-export fn{Js} now "performance.now" :: () -> Performance;
-export fn{Rs} elapsed Method{"elapsed"} :: Instant -> Duration;
-export fn{Js} elapsed "((p) => (performance.now() - p) / 1000.0)" :: Performance -> f64;
-export fn{Rs} f64 Method{"as_secs_f64"} :: Duration -> f64;
+fn{Rs} now "std::time::Instant::now" :: () -> Instant;
+fn{Js} now "performance.now" :: () -> Performance;
+fn{Rs} elapsed Method{"elapsed"} :: Instant -> Duration;
+fn{Js} elapsed "((p) => (performance.now() - p) / 1000.0)" :: Performance -> f64;
+fn{Rs} f64 Method{"as_secs_f64"} :: Duration -> f64;
 
 /// Uuid-related bindings
-export fn{Rs} uuid "alan_std::Uuid::new_v4" <- RootBacking :: () -> uuid;
-export fn{Js} uuid "alan_std.uuidv4" <- RootBacking :: () -> uuid;
-export fn{Rs} string "format!" :: ("{}", uuid) -> string;
-export fn{Js} string "new alan_std.Str" :: uuid -> string;
+fn{Rs} uuid "alan_std::Uuid::new_v4" <- RootBacking :: () -> uuid;
+fn{Js} uuid "alan_std.uuidv4" <- RootBacking :: () -> uuid;
+fn{Rs} string "format!" :: ("{}", uuid) -> string;
+fn{Js} string "new alan_std.Str" :: uuid -> string;
 
 /// GPU-related bindings
 
 // The base bindings to create buffers of memory on the GPU, construct a plan for a compute shader,
 // execute it, and read the buffer back to the CPU
-export type{Rs} BufferUsages = Binds{"alan_std::BufferUsages" <- RootBacking};
-export type{Js} BufferUsages = Binds{"GPUBufferUsage"};
-export type{Rs} GBuffer = Binds{"alan_std::GBuffer" <- RootBacking};
-export type{Js} GBuffer = Binds{"GPUBuffer"};
-export type{Rs} GPGPU = Binds{"alan_std::GPGPU" <- RootBacking};
-export type{Js} GPGPU = Binds{"alan_std.GPGPU" <- RootBacking};
-export fn{Rs} mapReadBuffer "alan_std::map_read_buffer_type" <- RootBacking :: () -> BufferUsages;
-export fn{Js} mapReadBuffer "alan_std.mapReadBufferType" <- RootBacking :: () -> BufferUsages;
-export fn{Rs} mapWriteBuffer "alan_std::map_write_buffer_type" <- RootBacking :: () -> BufferUsages;
-export fn{Js} mapWriteBuffer "alan_std.mapWriteBufferType" <- RootBacking :: () -> BufferUsages;
-export fn{Rs} storageBuffer "alan_std::storage_buffer_type" <- RootBacking :: () -> BufferUsages;
-export fn{Js} storageBuffer "alan_std.storageBufferType" <- RootBacking :: () -> BufferUsages;
-export fn{Rs} GBuffer{T}(bu: BufferUsages, arr: T[]) = {"alan_std::create_buffer_init" <- RootBacking :: (BufferUsages, T[], i8) -> GBuffer}(bu, arr, {Size{T}}().i8);
-export fn{Js} GBuffer{T}(bu: BufferUsages, arr: T[]) = {"alan_std.createBufferInit" <- RootBacking :: (BufferUsages, T[]) -> GBuffer}(bu, arr);
-export fn{Rs} GBuffer{T}(bu: BufferUsages, size: i64) = {"alan_std::create_empty_buffer" <- RootBacking :: (BufferUsages, i64, i8) -> GBuffer}(bu, size, {Size{T}}().i8);
+type{Rs} BufferUsages = Binds{"alan_std::BufferUsages" <- RootBacking};
+type{Js} BufferUsages = Binds{"GPUBufferUsage"};
+type{Rs} GBuffer = Binds{"alan_std::GBuffer" <- RootBacking};
+type{Js} GBuffer = Binds{"GPUBuffer"};
+type{Rs} GPGPU = Binds{"alan_std::GPGPU" <- RootBacking};
+type{Js} GPGPU = Binds{"alan_std.GPGPU" <- RootBacking};
+fn{Rs} mapReadBuffer "alan_std::map_read_buffer_type" <- RootBacking :: () -> BufferUsages;
+fn{Js} mapReadBuffer "alan_std.mapReadBufferType" <- RootBacking :: () -> BufferUsages;
+fn{Rs} mapWriteBuffer "alan_std::map_write_buffer_type" <- RootBacking :: () -> BufferUsages;
+fn{Js} mapWriteBuffer "alan_std.mapWriteBufferType" <- RootBacking :: () -> BufferUsages;
+fn{Rs} storageBuffer "alan_std::storage_buffer_type" <- RootBacking :: () -> BufferUsages;
+fn{Js} storageBuffer "alan_std.storageBufferType" <- RootBacking :: () -> BufferUsages;
+fn{Rs} GBuffer{T}(bu: BufferUsages, arr: T[]) = {"alan_std::create_buffer_init" <- RootBacking :: (BufferUsages, T[], i8) -> GBuffer}(bu, arr, {Size{T}}().i8);
+fn{Js} GBuffer{T}(bu: BufferUsages, arr: T[]) = {"alan_std.createBufferInit" <- RootBacking :: (BufferUsages, T[]) -> GBuffer}(bu, arr);
+fn{Rs} GBuffer{T}(bu: BufferUsages, size: i64) = {"alan_std::create_empty_buffer" <- RootBacking :: (BufferUsages, i64, i8) -> GBuffer}(bu, size, {Size{T}}().i8);
 // TODO: Get the type into JS
-export fn{Js} GBuffer{T}(bu: BufferUsages, size: i64) = {"alan_std.createEmptyBuffer" <- RootBacking :: (BufferUsages, i32) -> GBuffer}(bu, size.i32);
-export fn GBuffer{T}(vals: T[]) = GBuffer{T}(storageBuffer(), vals);
-export fn GBuffer{T}(size: i64) = GBuffer{T}(storageBuffer(), size);
-export fn{Rs} len "alan_std::bufferlen" <- RootBacking :: GBuffer -> i64;
-export fn{Js} len "alan_std.bufferlen" <- RootBacking :: GBuffer -> i64;
-export fn{Rs} id "alan_std::buffer_id" <- RootBacking :: GBuffer -> string;
-export fn{Js} id "alan_std.bufferid" <- RootBacking :: GBuffer -> string;
-export fn{Rs} GPGPU "alan_std::GPGPU::new" <- RootBacking :: (Own{string}, Own{Array{Array{GBuffer}}}, Deref{i64[3]}) -> GPGPU;
-export fn{Js} GPGPU (src: string, gbuffers: Array{Array{GBuffer}}, idx: i64[3]) = {"new alan_std.GPGPU" <- RootBacking :: (string, Array{Array{GBuffer}}, i32[3]) -> GPGPU}(src, gbuffers, idx.map(i32));
-export fn GPGPU(src: string, buf: GBuffer) -> GPGPU {
+fn{Js} GBuffer{T}(bu: BufferUsages, size: i64) = {"alan_std.createEmptyBuffer" <- RootBacking :: (BufferUsages, i32) -> GBuffer}(bu, size.i32);
+fn GBuffer{T}(vals: T[]) = GBuffer{T}(storageBuffer(), vals);
+fn GBuffer{T}(size: i64) = GBuffer{T}(storageBuffer(), size);
+fn{Rs} len "alan_std::bufferlen" <- RootBacking :: GBuffer -> i64;
+fn{Js} len "alan_std.bufferlen" <- RootBacking :: GBuffer -> i64;
+fn{Rs} id "alan_std::buffer_id" <- RootBacking :: GBuffer -> string;
+fn{Js} id "alan_std.bufferid" <- RootBacking :: GBuffer -> string;
+fn{Rs} GPGPU "alan_std::GPGPU::new" <- RootBacking :: (Own{string}, Own{Array{Array{GBuffer}}}, Deref{i64[3]}) -> GPGPU;
+fn{Js} GPGPU (src: string, gbuffers: Array{Array{GBuffer}}, idx: i64[3]) = {"new alan_std.GPGPU" <- RootBacking :: (string, Array{Array{GBuffer}}, i32[3]) -> GPGPU}(src, gbuffers, idx.map(i32));
+fn GPGPU(src: string, buf: GBuffer) -> GPGPU {
   // In order to support larger arrays, we need to split the buffer length across them. Each of
   // indices is allowed to be up to 65535 (yes, a 16-bit integer) leading to a maximum length of
   // 65535^3, or about 2.815x10^14 elements (about 281 trillion elements). Not quite up to the
@@ -1527,27 +1562,27 @@ export fn GPGPU(src: string, buf: GBuffer) -> GPGPU {
   // and the Z limit becomes the division + 1, while the remainder is executed division and
   // remainder on the A constant, division + 1, and this remainder becomes the X limit (plus 1).
   // Including this big explanation in case I've made an off-by-one error here ;)
-  let l = buf.len();
-  let zDiv = l.div(4_294_836_225);
-  let z = zDiv.add(1);
-  let zRem = l.mod(4_294_836_225);
-  let yDiv = zRem.div(65_535);
-  let y = yDiv.add(1);
-  let yRem = zRem.mod(65_535);
+  let l = buf.len;
+  let zDiv = l / 4_294_836_225;
+  let z = zDiv + 1;
+  let zRem = l % 4_294_836_225;
+  let yDiv = zRem / 65_535;
+  let y = yDiv + 1;
+  let yRem = zRem % 65_535;
   let x = max(yRem, 1);
   return GPGPU(src, [[buf]], {i64[3]}(x, y, z));
 }
-export fn{Rs} run "alan_std::gpu_run" <- RootBacking :: GPGPU;
-export fn{Js} run "alan_std.gpuRun" <- RootBacking :: GPGPU;
-export fn{Rs} read{T}(gb: GBuffer) = {"alan_std::read_buffer" <- RootBacking :: GBuffer -> T[]}(gb);
-export fn{Js} read{T} "alan_std.readBuffer" <- RootBacking :: GBuffer -> T[];
-export fn{Rs} replace{T} "alan_std::replace_buffer" <- RootBacking :: (GBuffer, T[]) -> ()!;
-export fn{Js} replace{T} "alan_std.replaceBuffer" <- RootBacking :: (GBuffer, T[]) -> ()!;
+fn{Rs} run "alan_std::gpu_run" <- RootBacking :: GPGPU;
+fn{Js} run "alan_std.gpuRun" <- RootBacking :: GPGPU;
+fn{Rs} read{T}(gb: GBuffer) = {"alan_std::read_buffer" <- RootBacking :: GBuffer -> T[]}(gb);
+fn{Js} read{T} "alan_std.readBuffer" <- RootBacking :: GBuffer -> T[];
+fn{Rs} replace{T} "alan_std::replace_buffer" <- RootBacking :: (GBuffer, T[]) -> ()!;
+fn{Js} replace{T} "alan_std.replaceBuffer" <- RootBacking :: (GBuffer, T[]) -> ()!;
 
 // The WgpuType provides a mechanism to build up the logic for a compute shader with normal-looking
 // Alan code, not requiring to think in two different languages at the same time. All of the GPU
 // types hereafter are derivative of this type
-export type WgpuType{N} =
+type WgpuType{N} =
   typeName: N,
   varName: string, // Key to the next field
   statements: Dict{string, string},
@@ -1557,7 +1592,7 @@ export type WgpuType{N} =
 // accomplish the desired goal of termining the constructor type fn to use when casting between CPU
 // and GPU memory blocks. This approach locks in only the GPU types defined in the root scope as
 // automatically converting back and forth. That may not be a bad thing, but it is annoying.
-export type WgpuTypeMap =
+type WgpuTypeMap =
   u32: u32,
   i32: i32,
   f32: f32,
@@ -1585,14 +1620,14 @@ export type WgpuTypeMap =
   mat4x4f: Buffer{f32, 16};
 
 // Scalar types and constructors
-export type gu32 = WgpuType{"u32"};
-export type gi32 = WgpuType{"i32"};
-export type gf32 = WgpuType{"f32"};
-export type gbool = WgpuType{"bool"};
+type gu32 = WgpuType{"u32"};
+type gi32 = WgpuType{"i32"};
+type gf32 = WgpuType{"f32"};
+type gbool = WgpuType{"bool"};
 
 // TODO: Better constraining on the input types allowed. It will still fail to compile, but the
 // error message isn't great at the moment.
-export fn build{N}(ret: N) {
+fn build{N}(ret: N) {
   // TODO: Don't assume all of the buffers involved here are storage buffers
   // Also TODO: Support other buffer types than i32
   let bufferArray = Array{GBuffer}().concat(ret.buffers.Array); // TODO: Shouldn't need this concat
@@ -1615,11 +1650,11 @@ export fn build{N}(ret: N) {
     .statements['@builtin(global_invocation_id) id: vec3u']
     .getOr('0,0,0')
     .split(',')
-    .map(fn (s: string) = s.i64.getOr(0));
+    .map(fn (s: string) = s.i64 ?? 0);
   let maxGlobalId = {i64[3]}(
-    maxGlobalIdArray[0].getOr(0),
-    maxGlobalIdArray[1].getOr(0),
-    maxGlobalIdArray[2].getOr(0)
+    maxGlobalIdArray[0] ?? 0,
+    maxGlobalIdArray[1] ?? 0,
+    maxGlobalIdArray[2] ?? 0
   );
   let buffers = Array{Array{GBuffer}}();
   buffers.push(bufferArray);
@@ -1640,43 +1675,43 @@ fn gPrimitiveConvert{I, O}(i: I) {
   let buffers = i.buffers.clone();
   return {O}(varName, statements, buffers);
 }
-export fn gu32(u: u32) = gu32(u.string, Dict{string, string}(), Set{GBuffer}());
-export fn gu32(gi: gi32) = gPrimitiveConvert{gi32, gu32}(gi);
-export fn gu32(gf: gf32) = gPrimitiveConvert{gf32, gu32}(gf);
-export fn gu32(gb: gbool) = gPrimitiveConvert{gbool, gu32}(gb);
-export fn gu32{T}(u: T) = gu32(u.u32);
+fn gu32(u: u32) = gu32(u.string, Dict{string, string}(), Set{GBuffer}());
+fn gu32(gi: gi32) = gPrimitiveConvert{gi32, gu32}(gi);
+fn gu32(gf: gf32) = gPrimitiveConvert{gf32, gu32}(gf);
+fn gu32(gb: gbool) = gPrimitiveConvert{gbool, gu32}(gb);
+fn gu32{T}(u: T) = gu32(u.u32);
 
-export fn gi32(i: i32) = gi32(i.string, Dict{string, string}(), Set{GBuffer}());
-export fn gi32(gu: gu32) = gPrimitiveConvert{gu32, gi32}(gu);
-export fn gi32(gf: gf32) = gPrimitiveConvert{gf32, gi32}(gf);
-export fn gi32(gb: gbool) = gPrimitiveConvert{gbool, gi32}(gb);
-export fn gi32{T}(i: T) = gi32(i.i32);
+fn gi32(i: i32) = gi32(i.string, Dict{string, string}(), Set{GBuffer}());
+fn gi32(gu: gu32) = gPrimitiveConvert{gu32, gi32}(gu);
+fn gi32(gf: gf32) = gPrimitiveConvert{gf32, gi32}(gf);
+fn gi32(gb: gbool) = gPrimitiveConvert{gbool, gi32}(gb);
+fn gi32{T}(i: T) = gi32(i.i32);
 
-export fn gf32(f: f32) = gf32(if(f.string.eq(f.i32.string), f.string(1), f.string), Dict{string, string}(), Set{GBuffer}());
-export fn gf32(gu: gu32) = gPrimitiveConvert{gu32, gf32}(gu);
-export fn gf32(gi: gi32) = gPrimitiveConvert{gi32, gf32}(gi);
-export fn gf32(gb: gbool) = gPrimitiveConvert{gbool, gf32}(gb);
-export fn gf32{T}(f: T) = gf32(f.f32);
+fn gf32(f: f32) = gf32(if(f.string.eq(f.i32.string), f.string(1), f.string), Dict{string, string}(), Set{GBuffer}());
+fn gf32(gu: gu32) = gPrimitiveConvert{gu32, gf32}(gu);
+fn gf32(gi: gi32) = gPrimitiveConvert{gi32, gf32}(gi);
+fn gf32(gb: gbool) = gPrimitiveConvert{gbool, gf32}(gb);
+fn gf32{T}(f: T) = gf32(f.f32);
 
-export fn gbool(b: bool) = gbool(b.string, Dict{string, string}(), Set{GBuffer}());
-export fn gbool(gu: gu32) = gPrimitiveConvert{gu32, gbool}(gu);
-export fn gbool(gi: gi32) = gPrimitiveConvert{gi32, gbool}(gi);
-export fn gbool(gf: gf32) = gPrimitiveConvert{gf32, gbool}(gf);
-export fn gbool{T}(b: T) = gbool(b.bool);
+fn gbool(b: bool) = gbool(b.string, Dict{string, string}(), Set{GBuffer}());
+fn gbool(gu: gu32) = gPrimitiveConvert{gu32, gbool}(gu);
+fn gbool(gi: gi32) = gPrimitiveConvert{gi32, gbool}(gi);
+fn gbool(gf: gf32) = gPrimitiveConvert{gf32, gbool}(gf);
+fn gbool{T}(b: T) = gbool(b.bool);
 
 // Vector types and constructors
-export type gvec2u = WgpuType{"vec2u"};
-export type gvec2i = WgpuType{"vec2i"};
-export type gvec2f = WgpuType{"vec2f"};
-export type gvec2b = WgpuType{"vec2<bool>"};
-export type gvec3u = WgpuType{"vec3u"};
-export type gvec3i = WgpuType{"vec3i"};
-export type gvec3f = WgpuType{"vec3f"};
-export type gvec3b = WgpuType{"vec3<bool>"};
-export type gvec4u = WgpuType{"vec4u"};
-export type gvec4i = WgpuType{"vec4i"};
-export type gvec4f = WgpuType{"vec4f"};
-export type gvec4b = WgpuType{"vec4<bool>"};
+type gvec2u = WgpuType{"vec2u"};
+type gvec2i = WgpuType{"vec2i"};
+type gvec2f = WgpuType{"vec2f"};
+type gvec2b = WgpuType{"vec2<bool>"};
+type gvec3u = WgpuType{"vec3u"};
+type gvec3i = WgpuType{"vec3i"};
+type gvec3f = WgpuType{"vec3f"};
+type gvec3b = WgpuType{"vec3<bool>"};
+type gvec4u = WgpuType{"vec4u"};
+type gvec4i = WgpuType{"vec4i"};
+type gvec4f = WgpuType{"vec4f"};
+type gvec4b = WgpuType{"vec4<bool>"};
 
 fn gvec2Primitive{I, O}(a: I, b: I) {
   let typename = {O.typeName}();
@@ -1691,25 +1726,25 @@ fn gvec2Primitive{I, O}(a: I, b: I) {
   return {O}(statement, statements, buffers);
 }
 
-export fn gvec2u() = gvec2u("vec2u()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec2u(a: gu32, b: gu32) = gvec2Primitive{gu32, gvec2u}(a, b);
-export fn gvec2u{T}(a: T, b: T) = gvec2u(a.gu32, b.gu32);
-export fn gvec2u{T}(a: T) = gvec2u(a, a);
+fn gvec2u() = gvec2u("vec2u()", Dict{string, string}(), Set{GBuffer}());
+fn gvec2u(a: gu32, b: gu32) = gvec2Primitive{gu32, gvec2u}(a, b);
+fn gvec2u{T}(a: T, b: T) = gvec2u(a.gu32, b.gu32);
+fn gvec2u{T}(a: T) = gvec2u(a, a);
 
-export fn gvec2i() = gvec2i("vec2i()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec2i(a: gi32, b: gi32) = gvec2Primitive{gi32, gvec2i}(a, b);
-export fn gvec2i{T}(a: T, b: T) = gvec2i(a.gi32, b.gi32);
-export fn gvec2i{T}(a: T) = gvec2i(a, a);
+fn gvec2i() = gvec2i("vec2i()", Dict{string, string}(), Set{GBuffer}());
+fn gvec2i(a: gi32, b: gi32) = gvec2Primitive{gi32, gvec2i}(a, b);
+fn gvec2i{T}(a: T, b: T) = gvec2i(a.gi32, b.gi32);
+fn gvec2i{T}(a: T) = gvec2i(a, a);
 
-export fn gvec2f() = gvec2f("vec2f()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec2f(a: gf32, b: gf32) = gvec2Primitive{gf32, gvec2f}(a, b);
-export fn gvec2f{T}(a: T, b: T) = gvec2f(a.gf32, b.gf32);
-export fn gvec2f{T}(a: T) = gvec2f(a, a);
+fn gvec2f() = gvec2f("vec2f()", Dict{string, string}(), Set{GBuffer}());
+fn gvec2f(a: gf32, b: gf32) = gvec2Primitive{gf32, gvec2f}(a, b);
+fn gvec2f{T}(a: T, b: T) = gvec2f(a.gf32, b.gf32);
+fn gvec2f{T}(a: T) = gvec2f(a, a);
 
-export fn gvec2b() = gvec2b("vec2<bool>()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec2b(a: gbool, b: gbool) = gvec2Primitive{gbool, gvec2b}(a, b);
-export fn gvec2b{T}(a: T, b: T) = gvec2b(a.gbool, b.gbool);
-export fn gvec2b{T}(a: T) = gvec2b(a, a);
+fn gvec2b() = gvec2b("vec2<bool>()", Dict{string, string}(), Set{GBuffer}());
+fn gvec2b(a: gbool, b: gbool) = gvec2Primitive{gbool, gvec2b}(a, b);
+fn gvec2b{T}(a: T, b: T) = gvec2b(a.gbool, b.gbool);
+fn gvec2b{T}(a: T) = gvec2b(a, a);
 
 fn gvec3Primitive{I, O}(a: I, b: I, c: I) {
   let typename = {O.typeName}();
@@ -1726,25 +1761,25 @@ fn gvec3Primitive{I, O}(a: I, b: I, c: I) {
   return {O}(statement, statements, buffers);
 }
 
-export fn gvec3u() = gvec3u("vec3u()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec3u(a: gu32, b: gu32, c: gu32) = gvec3Primitive{gu32, gvec3u}(a, b, c);
-export fn gvec3u{T}(a: T, b: T, c: T) = gvec3u(a.gu32, b.gu32, c.gu32);
-export fn gvec3u{T}(a: T) = gvec3u(a, a, a);
+fn gvec3u() = gvec3u("vec3u()", Dict{string, string}(), Set{GBuffer}());
+fn gvec3u(a: gu32, b: gu32, c: gu32) = gvec3Primitive{gu32, gvec3u}(a, b, c);
+fn gvec3u{T}(a: T, b: T, c: T) = gvec3u(a.gu32, b.gu32, c.gu32);
+fn gvec3u{T}(a: T) = gvec3u(a, a, a);
 
-export fn gvec3i() = gvec3i("vec3i()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec3i(a: gi32, b: gi32, c: gi32) = gvec3Primitive{gi32, gvec3i}(a, b, c);
-export fn gvec3i{T}(a: T, b: T, c: T) = gvec3i(a.gi32, b.gi32, c.gi32);
-export fn gvec3i{T}(a: T) = gvec3i(a, a, a);
+fn gvec3i() = gvec3i("vec3i()", Dict{string, string}(), Set{GBuffer}());
+fn gvec3i(a: gi32, b: gi32, c: gi32) = gvec3Primitive{gi32, gvec3i}(a, b, c);
+fn gvec3i{T}(a: T, b: T, c: T) = gvec3i(a.gi32, b.gi32, c.gi32);
+fn gvec3i{T}(a: T) = gvec3i(a, a, a);
 
-export fn gvec3f() = gvec3f("vec3f()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec3f(a: gf32, b: gf32, c: gf32) = gvec3Primitive{gf32, gvec3f}(a, b, c);
-export fn gvec3f{T}(a: T, b: T, c: T) = gvec3f(a.gf32, b.gf32, c.gf32);
-export fn gvec3f{T}(a: T) = gvec3f(a, a, a);
+fn gvec3f() = gvec3f("vec3f()", Dict{string, string}(), Set{GBuffer}());
+fn gvec3f(a: gf32, b: gf32, c: gf32) = gvec3Primitive{gf32, gvec3f}(a, b, c);
+fn gvec3f{T}(a: T, b: T, c: T) = gvec3f(a.gf32, b.gf32, c.gf32);
+fn gvec3f{T}(a: T) = gvec3f(a, a, a);
 
-export fn gvec3b() = gvec3b("vec3<bool>()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec3b(a: gbool, b: gbool, c: gbool) = gvec3Primitive{gbool, gvec3b}(a, b, c);
-export fn gvec3b{T}(a: T, b: T, c: T) = gvec3b(a.gbool, b.gbool, c.gbool);
-export fn gvec3b{T}(a: T) = gvec3b(a, a, a);
+fn gvec3b() = gvec3b("vec3<bool>()", Dict{string, string}(), Set{GBuffer}());
+fn gvec3b(a: gbool, b: gbool, c: gbool) = gvec3Primitive{gbool, gvec3b}(a, b, c);
+fn gvec3b{T}(a: T, b: T, c: T) = gvec3b(a.gbool, b.gbool, c.gbool);
+fn gvec3b{T}(a: T) = gvec3b(a, a, a);
 
 fn gvec4Primitive{I, O}(a: I, b: I, c: I, d: I) {
   let typename = {O.typeName}();
@@ -1763,64 +1798,64 @@ fn gvec4Primitive{I, O}(a: I, b: I, c: I, d: I) {
   return {O}(statement, statements, buffers);
 }
 
-export fn gvec4u() = gvec4u("vec4u()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec4u(a: gu32, b: gu32, c: gu32, d: gu32) = gvec4Primitive{gu32, gvec4u}(
+fn gvec4u() = gvec4u("vec4u()", Dict{string, string}(), Set{GBuffer}());
+fn gvec4u(a: gu32, b: gu32, c: gu32, d: gu32) = gvec4Primitive{gu32, gvec4u}(
   a, b, c, d
 );
-export fn gvec4u{T}(a: T, b: T, c: T, d: T) = gvec4u(a.gu32, b.gu32, c.gu32, d.gu32);
-export fn gvec4u{T}(a: T) = gvec4u(a, a, a, a);
+fn gvec4u{T}(a: T, b: T, c: T, d: T) = gvec4u(a.gu32, b.gu32, c.gu32, d.gu32);
+fn gvec4u{T}(a: T) = gvec4u(a, a, a, a);
 
-export fn gvec4i() = gvec4i("vec4i()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec4i(a: gi32, b: gi32, c: gi32, d: gi32) = gvec4Primitive{gi32, gvec4i}(
+fn gvec4i() = gvec4i("vec4i()", Dict{string, string}(), Set{GBuffer}());
+fn gvec4i(a: gi32, b: gi32, c: gi32, d: gi32) = gvec4Primitive{gi32, gvec4i}(
   a, b, c, d
 );
-export fn gvec4i{T}(a: T, b: T, c: T, d: T) = gvec4i(a.gi32, b.gi32, c.gi32, d.gi32);
-export fn gvec4i{T}(a: T) = gvec4i(a, a, a, a);
+fn gvec4i{T}(a: T, b: T, c: T, d: T) = gvec4i(a.gi32, b.gi32, c.gi32, d.gi32);
+fn gvec4i{T}(a: T) = gvec4i(a, a, a, a);
 
-export fn gvec4f() = gvec4f("vec4f()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec4f(a: gf32, b: gf32, c: gf32, d: gf32) = gvec4Primitive{gf32, gvec4f}(
+fn gvec4f() = gvec4f("vec4f()", Dict{string, string}(), Set{GBuffer}());
+fn gvec4f(a: gf32, b: gf32, c: gf32, d: gf32) = gvec4Primitive{gf32, gvec4f}(
   a, b, c, d
 );
-export fn gvec4f{T}(a: T, b: T, c: T, d: T) = gvec4f(a.gf32, b.gf32, c.gf32, d.gf32);
-export fn gvec4f{T}(a: T) = gvec4f(a, a, a, a);
+fn gvec4f{T}(a: T, b: T, c: T, d: T) = gvec4f(a.gf32, b.gf32, c.gf32, d.gf32);
+fn gvec4f{T}(a: T) = gvec4f(a, a, a, a);
 
-export fn gvec4b() = gvec4b("vec4<bool>()", Dict{string, string}(), Set{GBuffer}());
-export fn gvec4b(a: gbool, b: gbool, c: gbool, d: gbool) = gvec4Primitive{gbool, gvec4b}(
+fn gvec4b() = gvec4b("vec4<bool>()", Dict{string, string}(), Set{GBuffer}());
+fn gvec4b(a: gbool, b: gbool, c: gbool, d: gbool) = gvec4Primitive{gbool, gvec4b}(
   a, b, c, d
 );
-export fn gvec4b{T}(a: T, b: T, c: T, d: T) = gvec4b(a.gbool, b.gbool, c.gbool, d.gbool);
-export fn gvec4b{T}(a: T) = gvec4b(a, a, a, a);
+fn gvec4b{T}(a: T, b: T, c: T, d: T) = gvec4b(a.gbool, b.gbool, c.gbool, d.gbool);
+fn gvec4b{T}(a: T) = gvec4b(a, a, a, a);
 
 // The global_invocation_id; the entry value to a compute shader, and it's constructor, a
 // specialized version of gvec3u that initializes a bit differently.
-export fn gFor(x: u32, y: u32, z: u32) {
+fn gFor(x: u32, y: u32, z: u32) {
   let initialStatement = "@builtin(global_invocation_id) id: vec3u";
   let statements = Dict(initialStatement, x.string.concat(',').concat(y.string).concat(',').concat(z.string));
   return gvec3u('id', statements, Set{GBuffer}());
 }
-export fn gFor{T}(x: T, y: T, z: T) = gFor(x.u32, y.u32, z.u32);
-export fn gFor{T}(x: T, y: T) = gFor(x.u32, y.u32, 1.u32);
-export fn gFor{T}(x: T) = gFor(x.u32, 1.u32, 1.u32).x;
+fn gFor{T}(x: T, y: T, z: T) = gFor(x.u32, y.u32, z.u32);
+fn gFor{T}(x: T, y: T) = gFor(x.u32, y.u32, 1.u32);
+fn gFor{T}(x: T) = gFor(x.u32, 1.u32, 1.u32).x;
 
 // Matrix types
-export type gmat2x2f = WgpuType{"mat2x2f"};
-export type gmat2x3f = WgpuType{"mat2x3f"};
-export type gmat2x4f = WgpuType{"mat2x4f"};
-export type gmat3x2f = WgpuType{"mat3x2f"};
-export type gmat3x3f = WgpuType{"mat3x3f"};
-export type gmat3x4f = WgpuType{"mat3x4f"};
-export type gmat4x2f = WgpuType{"mat4x2f"};
-export type gmat4x3f = WgpuType{"mat4x3f"};
-export type gmat4x4f = WgpuType{"mat4x4f"};
+type gmat2x2f = WgpuType{"mat2x2f"};
+type gmat2x3f = WgpuType{"mat2x3f"};
+type gmat2x4f = WgpuType{"mat2x4f"};
+type gmat3x2f = WgpuType{"mat3x2f"};
+type gmat3x3f = WgpuType{"mat3x3f"};
+type gmat3x4f = WgpuType{"mat3x4f"};
+type gmat4x2f = WgpuType{"mat4x2f"};
+type gmat4x3f = WgpuType{"mat4x3f"};
+type gmat4x4f = WgpuType{"mat4x4f"};
 
-export fn gmat2x2f() = gmat2x2f("mat2x2f()", Dict{string, string}(), Set{GBuffer}());
-export fn gmat2x2f(a: gvec2f, b: gvec2f) {
+fn gmat2x2f() = gmat2x2f("mat2x2f()", Dict{string, string}(), Set{GBuffer}());
+fn gmat2x2f(a: gvec2f, b: gvec2f) {
   let statement = "mat2x2f(".concat(a.varName).concat(", ").concat(b.varName).concat(")");
   let statements = a.statements.concat(b.statements);
   let buffers = a.buffers.union(b.buffers);
   return gmat2x2f(statement, statements, buffers);
 }
-export fn gmat2x2f(a: gf32, b: gf32, c: gf32, d: gf32) {
+fn gmat2x2f(a: gf32, b: gf32, c: gf32, d: gf32) {
   let statement = "mat2x2f("
     .concat(a.varName)
     .concat(", ")
@@ -1835,14 +1870,14 @@ export fn gmat2x2f(a: gf32, b: gf32, c: gf32, d: gf32) {
   return gmat2x2f(statement, statements, buffers);
 }
 
-export fn gmat2x3f() = gmat2x3f("mat2x3f()", Dict{string, string}(), Set{GBuffer}());
-export fn gmat2x3f(a: gvec3f, b: gvec3f) {
+fn gmat2x3f() = gmat2x3f("mat2x3f()", Dict{string, string}(), Set{GBuffer}());
+fn gmat2x3f(a: gvec3f, b: gvec3f) {
   let statement = "mat2x3f(".concat(a.varName).concat(", ").concat(b.varName).concat(")");
   let statements = a.statements.concat(b.statements);
   let buffers = a.buffers.union(b.buffers);
   return gmat2x3f(statement, statements, buffers);
 }
-export fn gmat2x3f(a: gf32, b: gf32, c: gf32, d: gf32, e: gf32, f: gf32) {
+fn gmat2x3f(a: gf32, b: gf32, c: gf32, d: gf32, e: gf32, f: gf32) {
   let statement = "mat2x3f("
     .concat(a.varName)
     .concat(", ")
@@ -1871,14 +1906,14 @@ export fn gmat2x3f(a: gf32, b: gf32, c: gf32, d: gf32, e: gf32, f: gf32) {
   return gmat2x3f(statement, statements, buffers);
 }
 
-export fn gmat2x4f() = gmat2x4f("mat2x4f()", Dict{string, string}(), Set{GBuffer}());
-export fn gmat2x4f(a: gvec4f, b: gvec4f) {
+fn gmat2x4f() = gmat2x4f("mat2x4f()", Dict{string, string}(), Set{GBuffer}());
+fn gmat2x4f(a: gvec4f, b: gvec4f) {
   let statement = "mat2x4f(".concat(a.varName).concat(", ").concat(b.varName).concat(")");
   let statements = a.statements.concat(b.statements);
   let buffers = a.buffers.union(b.buffers);
   return gmat2x4f(statement, statements, buffers);
 }
-export fn gmat2x4f(a: gf32, b: gf32, c: gf32, d: gf32, e: gf32, f: gf32, g: gf32, h: gf32) {
+fn gmat2x4f(a: gf32, b: gf32, c: gf32, d: gf32, e: gf32, f: gf32, g: gf32, h: gf32) {
   let statement = "mat2x4f("
     .concat(a.varName)
     .concat(", ")
@@ -1915,8 +1950,8 @@ export fn gmat2x4f(a: gf32, b: gf32, c: gf32, d: gf32, e: gf32, f: gf32, g: gf32
   return gmat2x4f(statement, statements, buffers);
 }
 
-export fn gmat3x2f() = gmat3x2f("mat3x2f()", Dict{string, string}(), Set{GBuffer}());
-export fn gmat3x2f(a: gvec2f, b: gvec2f, c: gvec2f) {
+fn gmat3x2f() = gmat3x2f("mat3x2f()", Dict{string, string}(), Set{GBuffer}());
+fn gmat3x2f(a: gvec2f, b: gvec2f, c: gvec2f) {
   let statement = "mat3x2f("
     .concat(a.varName)
     .concat(", ")
@@ -1928,7 +1963,7 @@ export fn gmat3x2f(a: gvec2f, b: gvec2f, c: gvec2f) {
   let buffers = a.buffers.union(b.buffers).union(c.buffers);
   return gmat3x2f(statement, statements, buffers);
 }
-export fn gmat3x2f(a: gf32, b: gf32, c: gf32, d: gf32, e: gf32, f: gf32) {
+fn gmat3x2f(a: gf32, b: gf32, c: gf32, d: gf32, e: gf32, f: gf32) {
   let statement = "mat3x2f("
     .concat(a.varName)
     .concat(", ")
@@ -1957,8 +1992,8 @@ export fn gmat3x2f(a: gf32, b: gf32, c: gf32, d: gf32, e: gf32, f: gf32) {
   return gmat3x2f(statement, statements, buffers);
 }
 
-export fn gmat3x3f() = gmat3x3f("mat3x3f()", Dict{string, string}(), Set{GBuffer}());
-export fn gmat3x3f(a: gvec3f, b: gvec3f, c: gvec3f) {
+fn gmat3x3f() = gmat3x3f("mat3x3f()", Dict{string, string}(), Set{GBuffer}());
+fn gmat3x3f(a: gvec3f, b: gvec3f, c: gvec3f) {
   let statement = "mat3x3f("
     .concat(a.varName)
     .concat(", ")
@@ -1970,7 +2005,7 @@ export fn gmat3x3f(a: gvec3f, b: gvec3f, c: gvec3f) {
   let buffers = a.buffers.union(b.buffers).union(c.buffers);
   return gmat3x3f(statement, statements, buffers);
 }
-export fn gmat3x3f(
+fn gmat3x3f(
   a: gf32,
   b: gf32,
   c: gf32,
@@ -2021,8 +2056,8 @@ export fn gmat3x3f(
   return gmat3x3f(statement, statements, buffers);
 }
 
-export fn gmat3x4f() = gmat3x4f("mat3x4f()", Dict{string, string}(), Set{GBuffer}());
-export fn gmat3x4f(a: gvec4f, b: gvec4f, c: gvec4f) {
+fn gmat3x4f() = gmat3x4f("mat3x4f()", Dict{string, string}(), Set{GBuffer}());
+fn gmat3x4f(a: gvec4f, b: gvec4f, c: gvec4f) {
   let statement = "mat3x4f("
     .concat(a.varName)
     .concat(", ")
@@ -2034,7 +2069,7 @@ export fn gmat3x4f(a: gvec4f, b: gvec4f, c: gvec4f) {
   let buffers = a.buffers.union(b.buffers).union(c.buffers);
   return gmat3x4f(statement, statements, buffers);
 }
-export fn gmat3x4f(
+fn gmat3x4f(
   a: gf32,
   b: gf32,
   c: gf32,
@@ -2100,8 +2135,8 @@ export fn gmat3x4f(
   return gmat3x4f(statement, statements, buffers);
 }
 
-export fn gmat4x2f() = gmat4x2f("mat4x2f()", Dict{string, string}(), Set{GBuffer}());
-export fn gmat4x2f(a: gvec2f, b: gvec2f, c: gvec2f, d: gvec2f) {
+fn gmat4x2f() = gmat4x2f("mat4x2f()", Dict{string, string}(), Set{GBuffer}());
+fn gmat4x2f(a: gvec2f, b: gvec2f, c: gvec2f, d: gvec2f) {
   let statement = "mat4x2f("
     .concat(a.varName)
     .concat(", ")
@@ -2115,7 +2150,7 @@ export fn gmat4x2f(a: gvec2f, b: gvec2f, c: gvec2f, d: gvec2f) {
   let buffers = a.buffers.union(b.buffers).union(c.buffers).union(d.buffers);
   return gmat4x2f(statement, statements, buffers);
 }
-export fn gmat4x2f(
+fn gmat4x2f(
   a: gf32,
   b: gf32,
   c: gf32,
@@ -2161,8 +2196,8 @@ export fn gmat4x2f(
   return gmat4x2f(statement, statements, buffers);
 }
 
-export fn gmat4x3f() = gmat4x3f("mat4x3f()", Dict{string, string}(), Set{GBuffer}());
-export fn gmat4x3f(a: gvec3f, b: gvec3f, c: gvec3f, d: gvec3f) {
+fn gmat4x3f() = gmat4x3f("mat4x3f()", Dict{string, string}(), Set{GBuffer}());
+fn gmat4x3f(a: gvec3f, b: gvec3f, c: gvec3f, d: gvec3f) {
   let statement = "mat4x3f("
     .concat(a.varName)
     .concat(", ")
@@ -2176,7 +2211,7 @@ export fn gmat4x3f(a: gvec3f, b: gvec3f, c: gvec3f, d: gvec3f) {
   let buffers = a.buffers.union(b.buffers).union(c.buffers).union(d.buffers);
   return gmat4x3f(statement, statements, buffers);
 }
-export fn gmat4x3f(
+fn gmat4x3f(
   a: gf32,
   b: gf32,
   c: gf32,
@@ -2242,8 +2277,8 @@ export fn gmat4x3f(
   return gmat4x3f(statement, statements, buffers);
 }
 
-export fn gmat4x4f() = gmat4x4f("mat4x4f()", Dict{string, string}(), Set{GBuffer}());
-export fn gmat4x4f(a: gvec4f, b: gvec4f, c: gvec4f, d: gvec4f) {
+fn gmat4x4f() = gmat4x4f("mat4x4f()", Dict{string, string}(), Set{GBuffer}());
+fn gmat4x4f(a: gvec4f, b: gvec4f, c: gvec4f, d: gvec4f) {
   let statement = "mat4x4f("
     .concat(a.varName)
     .concat(", ")
@@ -2257,7 +2292,7 @@ export fn gmat4x4f(a: gvec4f, b: gvec4f, c: gvec4f, d: gvec4f) {
   let buffers = a.buffers.union(b.buffers).union(c.buffers).union(d.buffers);
   return gmat4x4f(statement, statements, buffers);
 }
-export fn gmat4x4f(
+fn gmat4x4f(
   a: gf32,
   b: gf32,
   c: gf32,
@@ -2349,440 +2384,440 @@ export fn gmat4x4f(
 
 // GPU Type accessors
 
-export fn x(v: gvec2u) {
+fn x(v: gvec2u) {
   let varName = v.varName.concat('.x');
   return gu32(varName, v.statements, v.buffers);
 }
-export fn y(v: gvec2u) {
+fn y(v: gvec2u) {
   let varName = v.varName.concat('.y');
   return gu32(varName, v.statements, v.buffers);
 }
-export fn i(v: gvec2u) = v.x;
-export fn j(v: gvec2u) = v.y;
-export fn r(v: gvec2u) = v.x;
-export fn g(v: gvec2u) = v.y;
+fn i(v: gvec2u) = v.x;
+fn j(v: gvec2u) = v.y;
+fn r(v: gvec2u) = v.x;
+fn g(v: gvec2u) = v.y;
 
 fn gvec22u(v: gvec2u, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec2u(varName, v.statements, v.buffers);
 }
-export fn xy(v: gvec2u) = gvec22u(v, '.xy');
-export fn yx(v: gvec2u) = gvec22u(v, '.yx');
-export fn ij(v: gvec2u) = v.xy;
-export fn ji(v: gvec2u) = v.yx;
-export fn rg(v: gvec2u) = v.xy;
-export fn gr(v: gvec2u) = v.yx;
+fn xy(v: gvec2u) = gvec22u(v, '.xy');
+fn yx(v: gvec2u) = gvec22u(v, '.yx');
+fn ij(v: gvec2u) = v.xy;
+fn ji(v: gvec2u) = v.yx;
+fn rg(v: gvec2u) = v.xy;
+fn gr(v: gvec2u) = v.yx;
 
-export fn x(v: gvec2i) {
+fn x(v: gvec2i) {
   let varName = v.varName.concat('.x');
   return gi32(varName, v.statements, v.buffers);
 }
-export fn y(v: gvec2i) {
+fn y(v: gvec2i) {
   let varName = v.varName.concat('.y');
   return gi32(varName, v.statements, v.buffers);
 }
-export fn i(v: gvec2i) = v.x;
-export fn j(v: gvec2i) = v.y;
-export fn r(v: gvec2i) = v.x;
-export fn g(v: gvec2i) = v.y;
+fn i(v: gvec2i) = v.x;
+fn j(v: gvec2i) = v.y;
+fn r(v: gvec2i) = v.x;
+fn g(v: gvec2i) = v.y;
 
 fn gvec22i(v: gvec2i, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec2i(varName, v.statements, v.buffers);
 }
-export fn xy(v: gvec2i) = gvec22i(v, '.xy');
-export fn yx(v: gvec2i) = gvec22i(v, '.yx');
-export fn ij(v: gvec2i) = v.xy;
-export fn ji(v: gvec2i) = v.yx;
-export fn rg(v: gvec2i) = v.xy;
-export fn gr(v: gvec2i) = v.yx;
+fn xy(v: gvec2i) = gvec22i(v, '.xy');
+fn yx(v: gvec2i) = gvec22i(v, '.yx');
+fn ij(v: gvec2i) = v.xy;
+fn ji(v: gvec2i) = v.yx;
+fn rg(v: gvec2i) = v.xy;
+fn gr(v: gvec2i) = v.yx;
 
-export fn x(v: gvec2f) {
+fn x(v: gvec2f) {
   let varName = v.varName.concat('.x');
   return gf32(varName, v.statements, v.buffers);
 }
-export fn y(v: gvec2f) {
+fn y(v: gvec2f) {
   let varName = v.varName.concat('.y');
   return gf32(varName, v.statements, v.buffers);
 }
-export fn i(v: gvec2f) = v.x;
-export fn j(v: gvec2f) = v.y;
-export fn r(v: gvec2f) = v.x;
-export fn g(v: gvec2f) = v.y;
+fn i(v: gvec2f) = v.x;
+fn j(v: gvec2f) = v.y;
+fn r(v: gvec2f) = v.x;
+fn g(v: gvec2f) = v.y;
 
 fn gvec22f(v: gvec2f, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec2f(varName, v.statements, v.buffers);
 }
-export fn xy(v: gvec2f) = gvec22f(v, '.xy');
-export fn yx(v: gvec2f) = gvec22f(v, '.yx');
-export fn ij(v: gvec2f) = v.xy;
-export fn ji(v: gvec2f) = v.yx;
-export fn rg(v: gvec2f) = v.xy;
-export fn gr(v: gvec2f) = v.yx;
+fn xy(v: gvec2f) = gvec22f(v, '.xy');
+fn yx(v: gvec2f) = gvec22f(v, '.yx');
+fn ij(v: gvec2f) = v.xy;
+fn ji(v: gvec2f) = v.yx;
+fn rg(v: gvec2f) = v.xy;
+fn gr(v: gvec2f) = v.yx;
 
-export fn x(v: gvec2b) {
+fn x(v: gvec2b) {
   let varName = v.varName.concat('.x');
   return gbool(varName, v.statements, v.buffers);
 }
-export fn y(v: gvec2b) {
+fn y(v: gvec2b) {
   let varName = v.varName.concat('.y');
   return gbool(varName, v.statements, v.buffers);
 }
-export fn i(v: gvec2b) = v.x;
-export fn j(v: gvec2b) = v.y;
-export fn r(v: gvec2b) = v.x;
-export fn g(v: gvec2b) = v.y;
+fn i(v: gvec2b) = v.x;
+fn j(v: gvec2b) = v.y;
+fn r(v: gvec2b) = v.x;
+fn g(v: gvec2b) = v.y;
 
 fn gvec22b(v: gvec2b, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec2b(varName, v.statements, v.buffers);
 }
-export fn xy(v: gvec2b) = gvec22b(v, '.xy');
-export fn yx(v: gvec2b) = gvec22b(v, '.yx');
-export fn ij(v: gvec2b) = v.xy;
-export fn ji(v: gvec2b) = v.yx;
-export fn rg(v: gvec2b) = v.xy;
-export fn gr(v: gvec2b) = v.yx;
+fn xy(v: gvec2b) = gvec22b(v, '.xy');
+fn yx(v: gvec2b) = gvec22b(v, '.yx');
+fn ij(v: gvec2b) = v.xy;
+fn ji(v: gvec2b) = v.yx;
+fn rg(v: gvec2b) = v.xy;
+fn gr(v: gvec2b) = v.yx;
 
-export fn x(v: gvec3u) {
+fn x(v: gvec3u) {
   let varName = v.varName.concat('.x');
   return gu32(varName, v.statements, v.buffers);
 }
-export fn y(v: gvec3u) {
+fn y(v: gvec3u) {
   let varName = v.varName.concat('.y');
   return gu32(varName, v.statements, v.buffers);
 }
-export fn z(v: gvec3u) {
+fn z(v: gvec3u) {
   let varName = v.varName.concat('.z');
   return gu32(varName, v.statements, v.buffers);
 }
-export fn i(v: gvec3u) = v.x;
-export fn j(v: gvec3u) = v.y;
-export fn k(v: gvec3u) = v.z;
-export fn r(v: gvec3u) = v.x;
-export fn g(v: gvec3u) = v.y;
-export fn b(v: gvec3u) = v.z;
+fn i(v: gvec3u) = v.x;
+fn j(v: gvec3u) = v.y;
+fn k(v: gvec3u) = v.z;
+fn r(v: gvec3u) = v.x;
+fn g(v: gvec3u) = v.y;
+fn b(v: gvec3u) = v.z;
 
 fn gvec32u(v: gvec3u, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec2u(varName, v.statements, v.buffers);
 }
-export fn xy(v: gvec3u) = gvec32u(v, '.xy');
-export fn yx(v: gvec3u) = gvec32u(v, '.yx');
-export fn xz(v: gvec3u) = gvec32u(v, '.xz');
-export fn zx(v: gvec3u) = gvec32u(v, '.zx');
-export fn yz(v: gvec3u) = gvec32u(v, '.yz');
-export fn zy(v: gvec3u) = gvec32u(v, '.zy');
-export fn ij(v: gvec3u) = v.xy;
-export fn ji(v: gvec3u) = v.yx;
-export fn ik(v: gvec3u) = v.xz;
-export fn ki(v: gvec3u) = v.zx;
-export fn jk(v: gvec3u) = v.yz;
-export fn kj(v: gvec3u) = v.zy;
-export fn rg(v: gvec3u) = v.xy;
-export fn gr(v: gvec3u) = v.yx;
-export fn rb(v: gvec3u) = v.xz;
-export fn br(v: gvec3u) = v.zx;
-export fn gb(v: gvec3u) = v.yz;
-export fn bg(v: gvec3u) = v.zy;
+fn xy(v: gvec3u) = gvec32u(v, '.xy');
+fn yx(v: gvec3u) = gvec32u(v, '.yx');
+fn xz(v: gvec3u) = gvec32u(v, '.xz');
+fn zx(v: gvec3u) = gvec32u(v, '.zx');
+fn yz(v: gvec3u) = gvec32u(v, '.yz');
+fn zy(v: gvec3u) = gvec32u(v, '.zy');
+fn ij(v: gvec3u) = v.xy;
+fn ji(v: gvec3u) = v.yx;
+fn ik(v: gvec3u) = v.xz;
+fn ki(v: gvec3u) = v.zx;
+fn jk(v: gvec3u) = v.yz;
+fn kj(v: gvec3u) = v.zy;
+fn rg(v: gvec3u) = v.xy;
+fn gr(v: gvec3u) = v.yx;
+fn rb(v: gvec3u) = v.xz;
+fn br(v: gvec3u) = v.zx;
+fn gb(v: gvec3u) = v.yz;
+fn bg(v: gvec3u) = v.zy;
 
 fn gvec33u(v: gvec3u, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec3u(varName, v.statements, v.buffers);
 }
-export fn xyz(v: gvec3u) = gvec33u(v, '.xyz');
-export fn xzy(v: gvec3u) = gvec33u(v, '.xzy');
-export fn yxz(v: gvec3u) = gvec33u(v, '.yxz');
-export fn yzx(v: gvec3u) = gvec33u(v, '.yzx');
-export fn zxy(v: gvec3u) = gvec33u(v, '.zxy');
-export fn zyx(v: gvec3u) = gvec33u(v, '.zyx');
-export fn ijk(v: gvec3u) = v.xyz;
-export fn ikj(v: gvec3u) = v.xzy;
-export fn jik(v: gvec3u) = v.yxz;
-export fn jki(v: gvec3u) = v.yzx;
-export fn kij(v: gvec3u) = v.zxy;
-export fn kji(v: gvec3u) = v.zyx;
-export fn rgb(v: gvec3u) = v.xyz;
-export fn rbg(v: gvec3u) = v.xzy;
-export fn grb(v: gvec3u) = v.yxz;
-export fn gbr(v: gvec3u) = v.yzx;
-export fn brg(v: gvec3u) = v.zxy;
-export fn bgr(v: gvec3u) = v.zyx;
+fn xyz(v: gvec3u) = gvec33u(v, '.xyz');
+fn xzy(v: gvec3u) = gvec33u(v, '.xzy');
+fn yxz(v: gvec3u) = gvec33u(v, '.yxz');
+fn yzx(v: gvec3u) = gvec33u(v, '.yzx');
+fn zxy(v: gvec3u) = gvec33u(v, '.zxy');
+fn zyx(v: gvec3u) = gvec33u(v, '.zyx');
+fn ijk(v: gvec3u) = v.xyz;
+fn ikj(v: gvec3u) = v.xzy;
+fn jik(v: gvec3u) = v.yxz;
+fn jki(v: gvec3u) = v.yzx;
+fn kij(v: gvec3u) = v.zxy;
+fn kji(v: gvec3u) = v.zyx;
+fn rgb(v: gvec3u) = v.xyz;
+fn rbg(v: gvec3u) = v.xzy;
+fn grb(v: gvec3u) = v.yxz;
+fn gbr(v: gvec3u) = v.yzx;
+fn brg(v: gvec3u) = v.zxy;
+fn bgr(v: gvec3u) = v.zyx;
 
-export fn x(v: gvec3i) {
+fn x(v: gvec3i) {
   let varName = v.varName.concat('.x');
   return gi32(varName, v.statements, v.buffers);
 }
-export fn y(v: gvec3i) {
+fn y(v: gvec3i) {
   let varName = v.varName.concat('.y');
   return gi32(varName, v.statements, v.buffers);
 }
-export fn z(v: gvec3i) {
+fn z(v: gvec3i) {
   let varName = v.varName.concat('.z');
   return gi32(varName, v.statements, v.buffers);
 }
-export fn i(v: gvec3i) = v.x;
-export fn j(v: gvec3i) = v.y;
-export fn k(v: gvec3i) = v.z;
-export fn r(v: gvec3i) = v.x;
-export fn g(v: gvec3i) = v.y;
-export fn b(v: gvec3i) = v.z;
+fn i(v: gvec3i) = v.x;
+fn j(v: gvec3i) = v.y;
+fn k(v: gvec3i) = v.z;
+fn r(v: gvec3i) = v.x;
+fn g(v: gvec3i) = v.y;
+fn b(v: gvec3i) = v.z;
 
 fn gvec32i(v: gvec3i, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec2i(varName, v.statements, v.buffers);
 }
-export fn xy(v: gvec3i) = gvec32i(v, '.xy');
-export fn yx(v: gvec3i) = gvec32i(v, '.yx');
-export fn xz(v: gvec3i) = gvec32i(v, '.xz');
-export fn zx(v: gvec3i) = gvec32i(v, '.zx');
-export fn yz(v: gvec3i) = gvec32i(v, '.yz');
-export fn zy(v: gvec3i) = gvec32i(v, '.zy');
-export fn ij(v: gvec3i) = v.xy;
-export fn ji(v: gvec3i) = v.yx;
-export fn ik(v: gvec3i) = v.xz;
-export fn ki(v: gvec3i) = v.zx;
-export fn jk(v: gvec3i) = v.yz;
-export fn kj(v: gvec3i) = v.zy;
-export fn rg(v: gvec3i) = v.xy;
-export fn gr(v: gvec3i) = v.yx;
-export fn rb(v: gvec3i) = v.xz;
-export fn br(v: gvec3i) = v.zx;
-export fn gb(v: gvec3i) = v.yz;
-export fn bg(v: gvec3i) = v.zy;
+fn xy(v: gvec3i) = gvec32i(v, '.xy');
+fn yx(v: gvec3i) = gvec32i(v, '.yx');
+fn xz(v: gvec3i) = gvec32i(v, '.xz');
+fn zx(v: gvec3i) = gvec32i(v, '.zx');
+fn yz(v: gvec3i) = gvec32i(v, '.yz');
+fn zy(v: gvec3i) = gvec32i(v, '.zy');
+fn ij(v: gvec3i) = v.xy;
+fn ji(v: gvec3i) = v.yx;
+fn ik(v: gvec3i) = v.xz;
+fn ki(v: gvec3i) = v.zx;
+fn jk(v: gvec3i) = v.yz;
+fn kj(v: gvec3i) = v.zy;
+fn rg(v: gvec3i) = v.xy;
+fn gr(v: gvec3i) = v.yx;
+fn rb(v: gvec3i) = v.xz;
+fn br(v: gvec3i) = v.zx;
+fn gb(v: gvec3i) = v.yz;
+fn bg(v: gvec3i) = v.zy;
 
 fn gvec33i(v: gvec3i, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec3i(varName, v.statements, v.buffers);
 }
-export fn xyz(v: gvec3i) = gvec33i(v, '.xyz');
-export fn xzy(v: gvec3i) = gvec33i(v, '.xzy');
-export fn yxz(v: gvec3i) = gvec33i(v, '.yxz');
-export fn yzx(v: gvec3i) = gvec33i(v, '.yzx');
-export fn zxy(v: gvec3i) = gvec33i(v, '.zxy');
-export fn zyx(v: gvec3i) = gvec33i(v, '.zyx');
-export fn ijk(v: gvec3i) = v.xyz;
-export fn ikj(v: gvec3i) = v.xzy;
-export fn jik(v: gvec3i) = v.yxz;
-export fn jki(v: gvec3i) = v.yzx;
-export fn kij(v: gvec3i) = v.zxy;
-export fn kji(v: gvec3i) = v.zyx;
-export fn rgb(v: gvec3i) = v.xyz;
-export fn rbg(v: gvec3i) = v.xzy;
-export fn grb(v: gvec3i) = v.yxz;
-export fn gbr(v: gvec3i) = v.yzx;
-export fn brg(v: gvec3i) = v.zxy;
-export fn bgr(v: gvec3i) = v.zyx;
+fn xyz(v: gvec3i) = gvec33i(v, '.xyz');
+fn xzy(v: gvec3i) = gvec33i(v, '.xzy');
+fn yxz(v: gvec3i) = gvec33i(v, '.yxz');
+fn yzx(v: gvec3i) = gvec33i(v, '.yzx');
+fn zxy(v: gvec3i) = gvec33i(v, '.zxy');
+fn zyx(v: gvec3i) = gvec33i(v, '.zyx');
+fn ijk(v: gvec3i) = v.xyz;
+fn ikj(v: gvec3i) = v.xzy;
+fn jik(v: gvec3i) = v.yxz;
+fn jki(v: gvec3i) = v.yzx;
+fn kij(v: gvec3i) = v.zxy;
+fn kji(v: gvec3i) = v.zyx;
+fn rgb(v: gvec3i) = v.xyz;
+fn rbg(v: gvec3i) = v.xzy;
+fn grb(v: gvec3i) = v.yxz;
+fn gbr(v: gvec3i) = v.yzx;
+fn brg(v: gvec3i) = v.zxy;
+fn bgr(v: gvec3i) = v.zyx;
 
-export fn x(v: gvec3f) {
+fn x(v: gvec3f) {
   let varName = v.varName.concat('.x');
   return gf32(varName, v.statements, v.buffers);
 }
-export fn y(v: gvec3f) {
+fn y(v: gvec3f) {
   let varName = v.varName.concat('.y');
   return gf32(varName, v.statements, v.buffers);
 }
-export fn z(v: gvec3f) {
+fn z(v: gvec3f) {
   let varName = v.varName.concat('.z');
   return gf32(varName, v.statements, v.buffers);
 }
-export fn i(v: gvec3f) = v.x;
-export fn j(v: gvec3f) = v.y;
-export fn k(v: gvec3f) = v.z;
-export fn r(v: gvec3f) = v.x;
-export fn g(v: gvec3f) = v.y;
-export fn b(v: gvec3f) = v.z;
+fn i(v: gvec3f) = v.x;
+fn j(v: gvec3f) = v.y;
+fn k(v: gvec3f) = v.z;
+fn r(v: gvec3f) = v.x;
+fn g(v: gvec3f) = v.y;
+fn b(v: gvec3f) = v.z;
 
 fn gvec32f(v: gvec3f, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec2f(varName, v.statements, v.buffers);
 }
-export fn xy(v: gvec3f) = gvec32f(v, '.xy');
-export fn yx(v: gvec3f) = gvec32f(v, '.yx');
-export fn xz(v: gvec3f) = gvec32f(v, '.xz');
-export fn zx(v: gvec3f) = gvec32f(v, '.zx');
-export fn yz(v: gvec3f) = gvec32f(v, '.yz');
-export fn zy(v: gvec3f) = gvec32f(v, '.zy');
-export fn ij(v: gvec3f) = v.xy;
-export fn ji(v: gvec3f) = v.yx;
-export fn ik(v: gvec3f) = v.xz;
-export fn ki(v: gvec3f) = v.zx;
-export fn jk(v: gvec3f) = v.yz;
-export fn kj(v: gvec3f) = v.zy;
-export fn rg(v: gvec3f) = v.xy;
-export fn gr(v: gvec3f) = v.yx;
-export fn rb(v: gvec3f) = v.xz;
-export fn br(v: gvec3f) = v.zx;
-export fn gb(v: gvec3f) = v.yz;
-export fn bg(v: gvec3f) = v.zy;
+fn xy(v: gvec3f) = gvec32f(v, '.xy');
+fn yx(v: gvec3f) = gvec32f(v, '.yx');
+fn xz(v: gvec3f) = gvec32f(v, '.xz');
+fn zx(v: gvec3f) = gvec32f(v, '.zx');
+fn yz(v: gvec3f) = gvec32f(v, '.yz');
+fn zy(v: gvec3f) = gvec32f(v, '.zy');
+fn ij(v: gvec3f) = v.xy;
+fn ji(v: gvec3f) = v.yx;
+fn ik(v: gvec3f) = v.xz;
+fn ki(v: gvec3f) = v.zx;
+fn jk(v: gvec3f) = v.yz;
+fn kj(v: gvec3f) = v.zy;
+fn rg(v: gvec3f) = v.xy;
+fn gr(v: gvec3f) = v.yx;
+fn rb(v: gvec3f) = v.xz;
+fn br(v: gvec3f) = v.zx;
+fn gb(v: gvec3f) = v.yz;
+fn bg(v: gvec3f) = v.zy;
 
 fn gvec33f(v: gvec3f, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec3f(varName, v.statements, v.buffers);
 }
-export fn xyz(v: gvec3f) = gvec33f(v, '.xyz');
-export fn xzy(v: gvec3f) = gvec33f(v, '.xzy');
-export fn yxz(v: gvec3f) = gvec33f(v, '.yxz');
-export fn yzx(v: gvec3f) = gvec33f(v, '.yzx');
-export fn zxy(v: gvec3f) = gvec33f(v, '.zxy');
-export fn zyx(v: gvec3f) = gvec33f(v, '.zyx');
-export fn ijk(v: gvec3f) = v.xyz;
-export fn ikj(v: gvec3f) = v.xzy;
-export fn jik(v: gvec3f) = v.yxz;
-export fn jki(v: gvec3f) = v.yzx;
-export fn kij(v: gvec3f) = v.zxy;
-export fn kji(v: gvec3f) = v.zyx;
-export fn rgb(v: gvec3f) = v.xyz;
-export fn rbg(v: gvec3f) = v.xzy;
-export fn grb(v: gvec3f) = v.yxz;
-export fn gbr(v: gvec3f) = v.yzx;
-export fn brg(v: gvec3f) = v.zxy;
-export fn bgr(v: gvec3f) = v.zyx;
+fn xyz(v: gvec3f) = gvec33f(v, '.xyz');
+fn xzy(v: gvec3f) = gvec33f(v, '.xzy');
+fn yxz(v: gvec3f) = gvec33f(v, '.yxz');
+fn yzx(v: gvec3f) = gvec33f(v, '.yzx');
+fn zxy(v: gvec3f) = gvec33f(v, '.zxy');
+fn zyx(v: gvec3f) = gvec33f(v, '.zyx');
+fn ijk(v: gvec3f) = v.xyz;
+fn ikj(v: gvec3f) = v.xzy;
+fn jik(v: gvec3f) = v.yxz;
+fn jki(v: gvec3f) = v.yzx;
+fn kij(v: gvec3f) = v.zxy;
+fn kji(v: gvec3f) = v.zyx;
+fn rgb(v: gvec3f) = v.xyz;
+fn rbg(v: gvec3f) = v.xzy;
+fn grb(v: gvec3f) = v.yxz;
+fn gbr(v: gvec3f) = v.yzx;
+fn brg(v: gvec3f) = v.zxy;
+fn bgr(v: gvec3f) = v.zyx;
 
-export fn x(v: gvec3b) {
+fn x(v: gvec3b) {
   let varName = v.varName.concat('.x');
   return gbool(varName, v.statements, v.buffers);
 }
-export fn y(v: gvec3b) {
+fn y(v: gvec3b) {
   let varName = v.varName.concat('.y');
   return gbool(varName, v.statements, v.buffers);
 }
-export fn z(v: gvec3b) {
+fn z(v: gvec3b) {
   let varName = v.varName.concat('.z');
   return gbool(varName, v.statements, v.buffers);
 }
-export fn i(v: gvec3b) = v.x;
-export fn j(v: gvec3b) = v.y;
-export fn k(v: gvec3b) = v.z;
-export fn r(v: gvec3b) = v.x;
-export fn g(v: gvec3b) = v.y;
-export fn b(v: gvec3b) = v.z;
+fn i(v: gvec3b) = v.x;
+fn j(v: gvec3b) = v.y;
+fn k(v: gvec3b) = v.z;
+fn r(v: gvec3b) = v.x;
+fn g(v: gvec3b) = v.y;
+fn b(v: gvec3b) = v.z;
 
 fn gvec32b(v: gvec3b, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec2b(varName, v.statements, v.buffers);
 }
-export fn xy(v: gvec3b) = gvec32b(v, '.xy');
-export fn yx(v: gvec3b) = gvec32b(v, '.yx');
-export fn xz(v: gvec3b) = gvec32b(v, '.xz');
-export fn zx(v: gvec3b) = gvec32b(v, '.zx');
-export fn yz(v: gvec3b) = gvec32b(v, '.yz');
-export fn zy(v: gvec3b) = gvec32b(v, '.zy');
-export fn ij(v: gvec3b) = v.xy;
-export fn ji(v: gvec3b) = v.yx;
-export fn ik(v: gvec3b) = v.xz;
-export fn ki(v: gvec3b) = v.zx;
-export fn jk(v: gvec3b) = v.yz;
-export fn kj(v: gvec3b) = v.zy;
-export fn rg(v: gvec3b) = v.xy;
-export fn gr(v: gvec3b) = v.yx;
-export fn rb(v: gvec3b) = v.xz;
-export fn br(v: gvec3b) = v.zx;
-export fn gb(v: gvec3b) = v.yz;
-export fn bg(v: gvec3b) = v.zy;
+fn xy(v: gvec3b) = gvec32b(v, '.xy');
+fn yx(v: gvec3b) = gvec32b(v, '.yx');
+fn xz(v: gvec3b) = gvec32b(v, '.xz');
+fn zx(v: gvec3b) = gvec32b(v, '.zx');
+fn yz(v: gvec3b) = gvec32b(v, '.yz');
+fn zy(v: gvec3b) = gvec32b(v, '.zy');
+fn ij(v: gvec3b) = v.xy;
+fn ji(v: gvec3b) = v.yx;
+fn ik(v: gvec3b) = v.xz;
+fn ki(v: gvec3b) = v.zx;
+fn jk(v: gvec3b) = v.yz;
+fn kj(v: gvec3b) = v.zy;
+fn rg(v: gvec3b) = v.xy;
+fn gr(v: gvec3b) = v.yx;
+fn rb(v: gvec3b) = v.xz;
+fn br(v: gvec3b) = v.zx;
+fn gb(v: gvec3b) = v.yz;
+fn bg(v: gvec3b) = v.zy;
 
 fn gvec33b(v: gvec3b, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec3b(varName, v.statements, v.buffers);
 }
-export fn xyz(v: gvec3b) = gvec33b(v, '.xyz');
-export fn xzy(v: gvec3b) = gvec33b(v, '.xzy');
-export fn yxz(v: gvec3b) = gvec33b(v, '.yxz');
-export fn yzx(v: gvec3b) = gvec33b(v, '.yzx');
-export fn zxy(v: gvec3b) = gvec33b(v, '.zxy');
-export fn zyx(v: gvec3b) = gvec33b(v, '.zyx');
-export fn ijk(v: gvec3b) = v.xyz;
-export fn ikj(v: gvec3b) = v.xzy;
-export fn jik(v: gvec3b) = v.yxz;
-export fn jki(v: gvec3b) = v.yzx;
-export fn kij(v: gvec3b) = v.zxy;
-export fn kji(v: gvec3b) = v.zyx;
-export fn rgb(v: gvec3b) = v.xyz;
-export fn rbg(v: gvec3b) = v.xzy;
-export fn grb(v: gvec3b) = v.yxz;
-export fn gbr(v: gvec3b) = v.yzx;
-export fn brg(v: gvec3b) = v.zxy;
-export fn bgr(v: gvec3b) = v.zyx;
+fn xyz(v: gvec3b) = gvec33b(v, '.xyz');
+fn xzy(v: gvec3b) = gvec33b(v, '.xzy');
+fn yxz(v: gvec3b) = gvec33b(v, '.yxz');
+fn yzx(v: gvec3b) = gvec33b(v, '.yzx');
+fn zxy(v: gvec3b) = gvec33b(v, '.zxy');
+fn zyx(v: gvec3b) = gvec33b(v, '.zyx');
+fn ijk(v: gvec3b) = v.xyz;
+fn ikj(v: gvec3b) = v.xzy;
+fn jik(v: gvec3b) = v.yxz;
+fn jki(v: gvec3b) = v.yzx;
+fn kij(v: gvec3b) = v.zxy;
+fn kji(v: gvec3b) = v.zyx;
+fn rgb(v: gvec3b) = v.xyz;
+fn rbg(v: gvec3b) = v.xzy;
+fn grb(v: gvec3b) = v.yxz;
+fn gbr(v: gvec3b) = v.yzx;
+fn brg(v: gvec3b) = v.zxy;
+fn bgr(v: gvec3b) = v.zyx;
 
-export fn x(v: gvec4u) {
+fn x(v: gvec4u) {
   let varName = v.varName.concat('.x');
   return gu32(varName, v.statements, v.buffers);
 }
-export fn y(v: gvec4u) {
+fn y(v: gvec4u) {
   let varName = v.varName.concat('.y');
   return gu32(varName, v.statements, v.buffers);
 }
-export fn z(v: gvec4u) {
+fn z(v: gvec4u) {
   let varName = v.varName.concat('.z');
   return gu32(varName, v.statements, v.buffers);
 }
-export fn w(v: gvec4u) {
+fn w(v: gvec4u) {
   let varName = v.varName.concat('.w');
   return gu32(varName, v.statements, v.buffers);
 }
-export fn i(v: gvec4u) = v.x;
-export fn j(v: gvec4u) = v.y;
-export fn k(v: gvec4u) = v.z;
-export fn l(v: gvec4u) = v.w;
-export fn r(v: gvec4u) = v.x;
-export fn g(v: gvec4u) = v.y;
-export fn b(v: gvec4u) = v.z;
-export fn a(v: gvec4u) = v.w;
+fn i(v: gvec4u) = v.x;
+fn j(v: gvec4u) = v.y;
+fn k(v: gvec4u) = v.z;
+fn l(v: gvec4u) = v.w;
+fn r(v: gvec4u) = v.x;
+fn g(v: gvec4u) = v.y;
+fn b(v: gvec4u) = v.z;
+fn a(v: gvec4u) = v.w;
 
 fn gvec42u(v: gvec4u, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec2u(varName, v.statements, v.buffers);
 }
-export fn xy(v: gvec4u) = gvec42u(v, '.xy');
-export fn yx(v: gvec4u) = gvec42u(v, '.yx');
-export fn xz(v: gvec4u) = gvec42u(v, '.xz');
-export fn zx(v: gvec4u) = gvec42u(v, '.zx');
-export fn xw(v: gvec4u) = gvec42u(v, '.xw');
-export fn wx(v: gvec4u) = gvec42u(v, '.wx');
-export fn yz(v: gvec4u) = gvec42u(v, '.yz');
-export fn zy(v: gvec4u) = gvec42u(v, '.zy');
-export fn yw(v: gvec4u) = gvec42u(v, '.yw');
-export fn wy(v: gvec4u) = gvec42u(v, '.wy');
-export fn zw(v: gvec4u) = gvec42u(v, '.zw');
-export fn wz(v: gvec4u) = gvec42u(v, '.wz');
-export fn ij(v: gvec4u) = v.xy;
-export fn ji(v: gvec4u) = v.yx;
-export fn ik(v: gvec4u) = v.xz;
-export fn ki(v: gvec4u) = v.zx;
-export fn il(v: gvec4u) = v.xw;
-export fn li(v: gvec4u) = v.wx;
-export fn jk(v: gvec4u) = v.yz;
-export fn kj(v: gvec4u) = v.zy;
-export fn jl(v: gvec4u) = v.yw;
-export fn lj(v: gvec4u) = v.wy;
-export fn kl(v: gvec4u) = v.zw;
-export fn lk(v: gvec4u) = v.wz;
-export fn rg(v: gvec4u) = v.xy;
-export fn gr(v: gvec4u) = v.yx;
-export fn rb(v: gvec4u) = v.xz;
-export fn br(v: gvec4u) = v.zx;
-export fn ra(v: gvec4u) = v.xw;
-export fn ar(v: gvec4u) = v.wx;
-export fn gb(v: gvec4u) = v.yz;
-export fn bg(v: gvec4u) = v.zy;
-export fn ga(v: gvec4u) = v.yw;
-export fn ag(v: gvec4u) = v.wy;
-export fn ba(v: gvec4u) = v.zw;
-export fn ab(v: gvec4u) = v.wz;
+fn xy(v: gvec4u) = gvec42u(v, '.xy');
+fn yx(v: gvec4u) = gvec42u(v, '.yx');
+fn xz(v: gvec4u) = gvec42u(v, '.xz');
+fn zx(v: gvec4u) = gvec42u(v, '.zx');
+fn xw(v: gvec4u) = gvec42u(v, '.xw');
+fn wx(v: gvec4u) = gvec42u(v, '.wx');
+fn yz(v: gvec4u) = gvec42u(v, '.yz');
+fn zy(v: gvec4u) = gvec42u(v, '.zy');
+fn yw(v: gvec4u) = gvec42u(v, '.yw');
+fn wy(v: gvec4u) = gvec42u(v, '.wy');
+fn zw(v: gvec4u) = gvec42u(v, '.zw');
+fn wz(v: gvec4u) = gvec42u(v, '.wz');
+fn ij(v: gvec4u) = v.xy;
+fn ji(v: gvec4u) = v.yx;
+fn ik(v: gvec4u) = v.xz;
+fn ki(v: gvec4u) = v.zx;
+fn il(v: gvec4u) = v.xw;
+fn li(v: gvec4u) = v.wx;
+fn jk(v: gvec4u) = v.yz;
+fn kj(v: gvec4u) = v.zy;
+fn jl(v: gvec4u) = v.yw;
+fn lj(v: gvec4u) = v.wy;
+fn kl(v: gvec4u) = v.zw;
+fn lk(v: gvec4u) = v.wz;
+fn rg(v: gvec4u) = v.xy;
+fn gr(v: gvec4u) = v.yx;
+fn rb(v: gvec4u) = v.xz;
+fn br(v: gvec4u) = v.zx;
+fn ra(v: gvec4u) = v.xw;
+fn ar(v: gvec4u) = v.wx;
+fn gb(v: gvec4u) = v.yz;
+fn bg(v: gvec4u) = v.zy;
+fn ga(v: gvec4u) = v.yw;
+fn ag(v: gvec4u) = v.wy;
+fn ba(v: gvec4u) = v.zw;
+fn ab(v: gvec4u) = v.wz;
 
 fn gvec43u(v: gvec4u, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
@@ -2790,217 +2825,217 @@ fn gvec43u(v: gvec4u, a: string) {
   return gvec3u(varName, v.statements, v.buffers);
 }
 // 1 = x, i, r; 2 = y, j, g; 3 = z, k, b; 4 = w, l, a
-export fn xyz(v: gvec4u) = gvec43u(v, '.xyz'); // 123
-export fn xyw(v: gvec4u) = gvec43u(v, '.xyw'); // 124
-export fn xzy(v: gvec4u) = gvec43u(v, '.xzy'); // 132
-export fn xzw(v: gvec4u) = gvec43u(v, '.xzw'); // 134
-export fn xwy(v: gvec4u) = gvec43u(v, '.xwy'); // 142
-export fn xwz(v: gvec4u) = gvec43u(v, '.xwz'); // 143
-export fn yxz(v: gvec4u) = gvec43u(v, '.yxz'); // 213
-export fn yxw(v: gvec4u) = gvec43u(v, '.yxw'); // 214
-export fn yzx(v: gvec4u) = gvec43u(v, '.yzx'); // 231
-export fn yzw(v: gvec4u) = gvec43u(v, '.yzw'); // 234
-export fn ywx(v: gvec4u) = gvec43u(v, '.ywx'); // 241
-export fn ywz(v: gvec4u) = gvec43u(v, '.ywz'); // 243
-export fn zxy(v: gvec4u) = gvec43u(v, '.zxy'); // 312
-export fn zxw(v: gvec4u) = gvec43u(v, '.zxw'); // 314
-export fn zyx(v: gvec4u) = gvec43u(v, '.zyx'); // 321
-export fn zyw(v: gvec4u) = gvec43u(v, '.zyw'); // 324
-export fn zwx(v: gvec4u) = gvec43u(v, '.zwx'); // 341
-export fn zwy(v: gvec4u) = gvec43u(v, '.zwy'); // 342
-export fn wxy(v: gvec4u) = gvec43u(v, '.wxy'); // 412
-export fn wxz(v: gvec4u) = gvec43u(v, '.wxz'); // 413
-export fn wyx(v: gvec4u) = gvec43u(v, '.wyx'); // 421
-export fn wyz(v: gvec4u) = gvec43u(v, '.wyz'); // 423
-export fn wzx(v: gvec4u) = gvec43u(v, '.wzx'); // 431
-export fn wzy(v: gvec4u) = gvec43u(v, '.wzy'); // 432
-export fn ijk(v: gvec4u) = v.xyz;
-export fn ijl(v: gvec4u) = v.xyw;
-export fn ikj(v: gvec4u) = v.xzy;
-export fn ikl(v: gvec4u) = v.xzw;
-export fn ilj(v: gvec4u) = v.xwy;
-export fn ilk(v: gvec4u) = v.xwz;
-export fn jik(v: gvec4u) = v.yxz;
-export fn jil(v: gvec4u) = v.yxw;
-export fn jki(v: gvec4u) = v.yzx;
-export fn jkl(v: gvec4u) = v.yzw;
-export fn jli(v: gvec4u) = v.ywx;
-export fn jlk(v: gvec4u) = v.ywz;
-export fn kij(v: gvec4u) = v.zxy;
-export fn kil(v: gvec4u) = v.zxw;
-export fn kji(v: gvec4u) = v.zyx;
-export fn kjl(v: gvec4u) = v.zyw;
-export fn kli(v: gvec4u) = v.zwx;
-export fn klj(v: gvec4u) = v.zwy;
-export fn lij(v: gvec4u) = v.wxy;
-export fn lik(v: gvec4u) = v.wxz;
-export fn lji(v: gvec4u) = v.wyx;
-export fn ljk(v: gvec4u) = v.wyz;
-export fn lki(v: gvec4u) = v.wzx;
-export fn lkj(v: gvec4u) = v.wzy;
-export fn rgb(v: gvec4u) = v.xyz;
-export fn rga(v: gvec4u) = v.xyw;
-export fn rbg(v: gvec4u) = v.xzy;
-export fn rba(v: gvec4u) = v.xzw;
-export fn rag(v: gvec4u) = v.xwy;
-export fn rab(v: gvec4u) = v.xwz;
-export fn grb(v: gvec4u) = v.yxz;
-export fn gra(v: gvec4u) = v.yxw;
-export fn gbr(v: gvec4u) = v.yzx;
-export fn gba(v: gvec4u) = v.yzw;
-export fn gar(v: gvec4u) = v.ywx;
-export fn gab(v: gvec4u) = v.ywz;
-export fn brg(v: gvec4u) = v.zxy;
-export fn bra(v: gvec4u) = v.zxw;
-export fn bgr(v: gvec4u) = v.zyx;
-export fn bga(v: gvec4u) = v.zyw;
-export fn bar(v: gvec4u) = v.zwx;
-export fn bag(v: gvec4u) = v.zwy;
-export fn arb(v: gvec4u) = v.wxy;
-export fn arg(v: gvec4u) = v.wxz;
-export fn abr(v: gvec4u) = v.wyx;
-export fn abg(v: gvec4u) = v.wyz;
-export fn agr(v: gvec4u) = v.wzx;
-export fn agb(v: gvec4u) = v.wzy;
+fn xyz(v: gvec4u) = gvec43u(v, '.xyz'); // 123
+fn xyw(v: gvec4u) = gvec43u(v, '.xyw'); // 124
+fn xzy(v: gvec4u) = gvec43u(v, '.xzy'); // 132
+fn xzw(v: gvec4u) = gvec43u(v, '.xzw'); // 134
+fn xwy(v: gvec4u) = gvec43u(v, '.xwy'); // 142
+fn xwz(v: gvec4u) = gvec43u(v, '.xwz'); // 143
+fn yxz(v: gvec4u) = gvec43u(v, '.yxz'); // 213
+fn yxw(v: gvec4u) = gvec43u(v, '.yxw'); // 214
+fn yzx(v: gvec4u) = gvec43u(v, '.yzx'); // 231
+fn yzw(v: gvec4u) = gvec43u(v, '.yzw'); // 234
+fn ywx(v: gvec4u) = gvec43u(v, '.ywx'); // 241
+fn ywz(v: gvec4u) = gvec43u(v, '.ywz'); // 243
+fn zxy(v: gvec4u) = gvec43u(v, '.zxy'); // 312
+fn zxw(v: gvec4u) = gvec43u(v, '.zxw'); // 314
+fn zyx(v: gvec4u) = gvec43u(v, '.zyx'); // 321
+fn zyw(v: gvec4u) = gvec43u(v, '.zyw'); // 324
+fn zwx(v: gvec4u) = gvec43u(v, '.zwx'); // 341
+fn zwy(v: gvec4u) = gvec43u(v, '.zwy'); // 342
+fn wxy(v: gvec4u) = gvec43u(v, '.wxy'); // 412
+fn wxz(v: gvec4u) = gvec43u(v, '.wxz'); // 413
+fn wyx(v: gvec4u) = gvec43u(v, '.wyx'); // 421
+fn wyz(v: gvec4u) = gvec43u(v, '.wyz'); // 423
+fn wzx(v: gvec4u) = gvec43u(v, '.wzx'); // 431
+fn wzy(v: gvec4u) = gvec43u(v, '.wzy'); // 432
+fn ijk(v: gvec4u) = v.xyz;
+fn ijl(v: gvec4u) = v.xyw;
+fn ikj(v: gvec4u) = v.xzy;
+fn ikl(v: gvec4u) = v.xzw;
+fn ilj(v: gvec4u) = v.xwy;
+fn ilk(v: gvec4u) = v.xwz;
+fn jik(v: gvec4u) = v.yxz;
+fn jil(v: gvec4u) = v.yxw;
+fn jki(v: gvec4u) = v.yzx;
+fn jkl(v: gvec4u) = v.yzw;
+fn jli(v: gvec4u) = v.ywx;
+fn jlk(v: gvec4u) = v.ywz;
+fn kij(v: gvec4u) = v.zxy;
+fn kil(v: gvec4u) = v.zxw;
+fn kji(v: gvec4u) = v.zyx;
+fn kjl(v: gvec4u) = v.zyw;
+fn kli(v: gvec4u) = v.zwx;
+fn klj(v: gvec4u) = v.zwy;
+fn lij(v: gvec4u) = v.wxy;
+fn lik(v: gvec4u) = v.wxz;
+fn lji(v: gvec4u) = v.wyx;
+fn ljk(v: gvec4u) = v.wyz;
+fn lki(v: gvec4u) = v.wzx;
+fn lkj(v: gvec4u) = v.wzy;
+fn rgb(v: gvec4u) = v.xyz;
+fn rga(v: gvec4u) = v.xyw;
+fn rbg(v: gvec4u) = v.xzy;
+fn rba(v: gvec4u) = v.xzw;
+fn rag(v: gvec4u) = v.xwy;
+fn rab(v: gvec4u) = v.xwz;
+fn grb(v: gvec4u) = v.yxz;
+fn gra(v: gvec4u) = v.yxw;
+fn gbr(v: gvec4u) = v.yzx;
+fn gba(v: gvec4u) = v.yzw;
+fn gar(v: gvec4u) = v.ywx;
+fn gab(v: gvec4u) = v.ywz;
+fn brg(v: gvec4u) = v.zxy;
+fn bra(v: gvec4u) = v.zxw;
+fn bgr(v: gvec4u) = v.zyx;
+fn bga(v: gvec4u) = v.zyw;
+fn bar(v: gvec4u) = v.zwx;
+fn bag(v: gvec4u) = v.zwy;
+fn arb(v: gvec4u) = v.wxy;
+fn arg(v: gvec4u) = v.wxz;
+fn abr(v: gvec4u) = v.wyx;
+fn abg(v: gvec4u) = v.wyz;
+fn agr(v: gvec4u) = v.wzx;
+fn agb(v: gvec4u) = v.wzy;
 
 fn gvec44u(v: gvec4u, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec4u(varName, v.statements, v.buffers);
 }
-export fn xyzw(v: gvec4u) = gvec44u(v, '.xyzw'); // 1234
-export fn xywz(v: gvec4u) = gvec44u(v, '.xywz'); // 1243
-export fn xzyw(v: gvec4u) = gvec44u(v, '.xzyw'); // 1324
-export fn xzwy(v: gvec4u) = gvec44u(v, '.xzwy'); // 1342
-export fn xwyz(v: gvec4u) = gvec44u(v, '.xwyz'); // 1423
-export fn xwzy(v: gvec4u) = gvec44u(v, '.xwzy'); // 1432
-export fn yxzw(v: gvec4u) = gvec44u(v, '.yxzw'); // 2134
-export fn yxwz(v: gvec4u) = gvec44u(v, '.yxwz'); // 2143
-export fn yzxw(v: gvec4u) = gvec44u(v, '.yzxw'); // 2314
-export fn yzwx(v: gvec4u) = gvec44u(v, '.yzwx'); // 2341
-export fn ywxz(v: gvec4u) = gvec44u(v, '.ywxz'); // 2413
-export fn ywzx(v: gvec4u) = gvec44u(v, '.ywzx'); // 2431
-export fn zxyw(v: gvec4u) = gvec44u(v, '.zxyw'); // 3124
-export fn zxwy(v: gvec4u) = gvec44u(v, '.zxwy'); // 3142
-export fn zyxw(v: gvec4u) = gvec44u(v, '.zyxw'); // 3214
-export fn zywx(v: gvec4u) = gvec44u(v, '.zywx'); // 3241
-export fn zwxy(v: gvec4u) = gvec44u(v, '.zwxy'); // 3412
-export fn zwyx(v: gvec4u) = gvec44u(v, '.zwyx'); // 3421
-export fn wxyz(v: gvec4u) = gvec44u(v, '.wxyz'); // 4123
-export fn wxzy(v: gvec4u) = gvec44u(v, '.wxzy'); // 4132
-export fn wyxz(v: gvec4u) = gvec44u(v, '.wyxz'); // 4213
-export fn wyzx(v: gvec4u) = gvec44u(v, '.wyzx'); // 4231
-export fn wzxy(v: gvec4u) = gvec44u(v, '.wzxy'); // 4312
-export fn wzyx(v: gvec4u) = gvec44u(v, '.wzyx'); // 4321
-export fn ijkl(v: gvec4u) = v.xyzw;
-export fn ijlk(v: gvec4u) = v.xywz;
-export fn ikjl(v: gvec4u) = v.xzyw;
-export fn iklj(v: gvec4u) = v.xzwy;
-export fn iljk(v: gvec4u) = v.xwyz;
-export fn ilkj(v: gvec4u) = v.xwzy;
-export fn jikl(v: gvec4u) = v.yxzw;
-export fn jilk(v: gvec4u) = v.yxwz;
-export fn jkil(v: gvec4u) = v.yzxw;
-export fn jkli(v: gvec4u) = v.yzwx;
-export fn jlik(v: gvec4u) = v.ywxz;
-export fn jlki(v: gvec4u) = v.ywzx;
-export fn kijl(v: gvec4u) = v.zxyw;
-export fn kilj(v: gvec4u) = v.zxwy;
-export fn kjil(v: gvec4u) = v.zyxw;
-export fn kjli(v: gvec4u) = v.zywx;
-export fn klij(v: gvec4u) = v.zwxy;
-export fn klji(v: gvec4u) = v.zwyx;
-export fn lijk(v: gvec4u) = v.wxyz;
-export fn likj(v: gvec4u) = v.wxzy;
-export fn ljik(v: gvec4u) = v.wyxz;
-export fn ljki(v: gvec4u) = v.wyzx;
-export fn lkij(v: gvec4u) = v.wzxy;
-export fn lkji(v: gvec4u) = v.wzyx;
-export fn rgba(v: gvec4u) = v.xyzw;
-export fn rgab(v: gvec4u) = v.xywz;
-export fn rbga(v: gvec4u) = v.xzyw;
-export fn rbag(v: gvec4u) = v.xzwy;
-export fn ragb(v: gvec4u) = v.xwyz;
-export fn rabg(v: gvec4u) = v.xwzy;
-export fn grba(v: gvec4u) = v.yxzw;
-export fn grab(v: gvec4u) = v.yxwz;
-export fn gbra(v: gvec4u) = v.yzxw;
-export fn gbar(v: gvec4u) = v.yzwx;
-export fn garb(v: gvec4u) = v.ywxz;
-export fn gabr(v: gvec4u) = v.ywzx;
-export fn argb(v: gvec4u) = v.wxyz;
-export fn arbg(v: gvec4u) = v.wxzy;
-export fn agrb(v: gvec4u) = v.wyxz;
-export fn agbr(v: gvec4u) = v.wyzx;
-export fn abrg(v: gvec4u) = v.wzxy;
-export fn abgr(v: gvec4u) = v.wzyx;
+fn xyzw(v: gvec4u) = gvec44u(v, '.xyzw'); // 1234
+fn xywz(v: gvec4u) = gvec44u(v, '.xywz'); // 1243
+fn xzyw(v: gvec4u) = gvec44u(v, '.xzyw'); // 1324
+fn xzwy(v: gvec4u) = gvec44u(v, '.xzwy'); // 1342
+fn xwyz(v: gvec4u) = gvec44u(v, '.xwyz'); // 1423
+fn xwzy(v: gvec4u) = gvec44u(v, '.xwzy'); // 1432
+fn yxzw(v: gvec4u) = gvec44u(v, '.yxzw'); // 2134
+fn yxwz(v: gvec4u) = gvec44u(v, '.yxwz'); // 2143
+fn yzxw(v: gvec4u) = gvec44u(v, '.yzxw'); // 2314
+fn yzwx(v: gvec4u) = gvec44u(v, '.yzwx'); // 2341
+fn ywxz(v: gvec4u) = gvec44u(v, '.ywxz'); // 2413
+fn ywzx(v: gvec4u) = gvec44u(v, '.ywzx'); // 2431
+fn zxyw(v: gvec4u) = gvec44u(v, '.zxyw'); // 3124
+fn zxwy(v: gvec4u) = gvec44u(v, '.zxwy'); // 3142
+fn zyxw(v: gvec4u) = gvec44u(v, '.zyxw'); // 3214
+fn zywx(v: gvec4u) = gvec44u(v, '.zywx'); // 3241
+fn zwxy(v: gvec4u) = gvec44u(v, '.zwxy'); // 3412
+fn zwyx(v: gvec4u) = gvec44u(v, '.zwyx'); // 3421
+fn wxyz(v: gvec4u) = gvec44u(v, '.wxyz'); // 4123
+fn wxzy(v: gvec4u) = gvec44u(v, '.wxzy'); // 4132
+fn wyxz(v: gvec4u) = gvec44u(v, '.wyxz'); // 4213
+fn wyzx(v: gvec4u) = gvec44u(v, '.wyzx'); // 4231
+fn wzxy(v: gvec4u) = gvec44u(v, '.wzxy'); // 4312
+fn wzyx(v: gvec4u) = gvec44u(v, '.wzyx'); // 4321
+fn ijkl(v: gvec4u) = v.xyzw;
+fn ijlk(v: gvec4u) = v.xywz;
+fn ikjl(v: gvec4u) = v.xzyw;
+fn iklj(v: gvec4u) = v.xzwy;
+fn iljk(v: gvec4u) = v.xwyz;
+fn ilkj(v: gvec4u) = v.xwzy;
+fn jikl(v: gvec4u) = v.yxzw;
+fn jilk(v: gvec4u) = v.yxwz;
+fn jkil(v: gvec4u) = v.yzxw;
+fn jkli(v: gvec4u) = v.yzwx;
+fn jlik(v: gvec4u) = v.ywxz;
+fn jlki(v: gvec4u) = v.ywzx;
+fn kijl(v: gvec4u) = v.zxyw;
+fn kilj(v: gvec4u) = v.zxwy;
+fn kjil(v: gvec4u) = v.zyxw;
+fn kjli(v: gvec4u) = v.zywx;
+fn klij(v: gvec4u) = v.zwxy;
+fn klji(v: gvec4u) = v.zwyx;
+fn lijk(v: gvec4u) = v.wxyz;
+fn likj(v: gvec4u) = v.wxzy;
+fn ljik(v: gvec4u) = v.wyxz;
+fn ljki(v: gvec4u) = v.wyzx;
+fn lkij(v: gvec4u) = v.wzxy;
+fn lkji(v: gvec4u) = v.wzyx;
+fn rgba(v: gvec4u) = v.xyzw;
+fn rgab(v: gvec4u) = v.xywz;
+fn rbga(v: gvec4u) = v.xzyw;
+fn rbag(v: gvec4u) = v.xzwy;
+fn ragb(v: gvec4u) = v.xwyz;
+fn rabg(v: gvec4u) = v.xwzy;
+fn grba(v: gvec4u) = v.yxzw;
+fn grab(v: gvec4u) = v.yxwz;
+fn gbra(v: gvec4u) = v.yzxw;
+fn gbar(v: gvec4u) = v.yzwx;
+fn garb(v: gvec4u) = v.ywxz;
+fn gabr(v: gvec4u) = v.ywzx;
+fn argb(v: gvec4u) = v.wxyz;
+fn arbg(v: gvec4u) = v.wxzy;
+fn agrb(v: gvec4u) = v.wyxz;
+fn agbr(v: gvec4u) = v.wyzx;
+fn abrg(v: gvec4u) = v.wzxy;
+fn abgr(v: gvec4u) = v.wzyx;
 
-export fn x(v: gvec4i) {
+fn x(v: gvec4i) {
   let varName = v.varName.concat('.x');
   return gi32(varName, v.statements, v.buffers);
 }
-export fn y(v: gvec4i) {
+fn y(v: gvec4i) {
   let varName = v.varName.concat('.y');
   return gi32(varName, v.statements, v.buffers);
 }
-export fn z(v: gvec4i) {
+fn z(v: gvec4i) {
   let varName = v.varName.concat('.z');
   return gi32(varName, v.statements, v.buffers);
 }
-export fn w(v: gvec4i) {
+fn w(v: gvec4i) {
   let varName = v.varName.concat('.w');
   return gi32(varName, v.statements, v.buffers);
 }
-export fn i(v: gvec4i) = v.x;
-export fn j(v: gvec4i) = v.y;
-export fn k(v: gvec4i) = v.z;
-export fn l(v: gvec4i) = v.w;
-export fn r(v: gvec4i) = v.x;
-export fn g(v: gvec4i) = v.y;
-export fn b(v: gvec4i) = v.z;
-export fn a(v: gvec4i) = v.w;
+fn i(v: gvec4i) = v.x;
+fn j(v: gvec4i) = v.y;
+fn k(v: gvec4i) = v.z;
+fn l(v: gvec4i) = v.w;
+fn r(v: gvec4i) = v.x;
+fn g(v: gvec4i) = v.y;
+fn b(v: gvec4i) = v.z;
+fn a(v: gvec4i) = v.w;
 
 fn gvec42i(v: gvec4i, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec2i(varName, v.statements, v.buffers);
 }
-export fn xy(v: gvec4i) = gvec42i(v, '.xy');
-export fn yx(v: gvec4i) = gvec42i(v, '.yx');
-export fn xz(v: gvec4i) = gvec42i(v, '.xz');
-export fn zx(v: gvec4i) = gvec42i(v, '.zx');
-export fn xw(v: gvec4i) = gvec42i(v, '.xw');
-export fn wx(v: gvec4i) = gvec42i(v, '.wx');
-export fn yz(v: gvec4i) = gvec42i(v, '.yz');
-export fn zy(v: gvec4i) = gvec42i(v, '.zy');
-export fn yw(v: gvec4i) = gvec42i(v, '.yw');
-export fn wy(v: gvec4i) = gvec42i(v, '.wy');
-export fn zw(v: gvec4i) = gvec42i(v, '.zw');
-export fn wz(v: gvec4i) = gvec42i(v, '.wz');
-export fn ij(v: gvec4i) = v.xy;
-export fn ji(v: gvec4i) = v.yx;
-export fn ik(v: gvec4i) = v.xz;
-export fn ki(v: gvec4i) = v.zx;
-export fn il(v: gvec4i) = v.xw;
-export fn li(v: gvec4i) = v.wx;
-export fn jk(v: gvec4i) = v.yz;
-export fn kj(v: gvec4i) = v.zy;
-export fn jl(v: gvec4i) = v.yw;
-export fn lj(v: gvec4i) = v.wy;
-export fn kl(v: gvec4i) = v.zw;
-export fn lk(v: gvec4i) = v.wz;
-export fn rg(v: gvec4i) = v.xy;
-export fn gr(v: gvec4i) = v.yx;
-export fn rb(v: gvec4i) = v.xz;
-export fn br(v: gvec4i) = v.zx;
-export fn ra(v: gvec4i) = v.xw;
-export fn ar(v: gvec4i) = v.wx;
-export fn gb(v: gvec4i) = v.yz;
-export fn bg(v: gvec4i) = v.zy;
-export fn ga(v: gvec4i) = v.yw;
-export fn ag(v: gvec4i) = v.wy;
-export fn ba(v: gvec4i) = v.zw;
-export fn ab(v: gvec4i) = v.wz;
+fn xy(v: gvec4i) = gvec42i(v, '.xy');
+fn yx(v: gvec4i) = gvec42i(v, '.yx');
+fn xz(v: gvec4i) = gvec42i(v, '.xz');
+fn zx(v: gvec4i) = gvec42i(v, '.zx');
+fn xw(v: gvec4i) = gvec42i(v, '.xw');
+fn wx(v: gvec4i) = gvec42i(v, '.wx');
+fn yz(v: gvec4i) = gvec42i(v, '.yz');
+fn zy(v: gvec4i) = gvec42i(v, '.zy');
+fn yw(v: gvec4i) = gvec42i(v, '.yw');
+fn wy(v: gvec4i) = gvec42i(v, '.wy');
+fn zw(v: gvec4i) = gvec42i(v, '.zw');
+fn wz(v: gvec4i) = gvec42i(v, '.wz');
+fn ij(v: gvec4i) = v.xy;
+fn ji(v: gvec4i) = v.yx;
+fn ik(v: gvec4i) = v.xz;
+fn ki(v: gvec4i) = v.zx;
+fn il(v: gvec4i) = v.xw;
+fn li(v: gvec4i) = v.wx;
+fn jk(v: gvec4i) = v.yz;
+fn kj(v: gvec4i) = v.zy;
+fn jl(v: gvec4i) = v.yw;
+fn lj(v: gvec4i) = v.wy;
+fn kl(v: gvec4i) = v.zw;
+fn lk(v: gvec4i) = v.wz;
+fn rg(v: gvec4i) = v.xy;
+fn gr(v: gvec4i) = v.yx;
+fn rb(v: gvec4i) = v.xz;
+fn br(v: gvec4i) = v.zx;
+fn ra(v: gvec4i) = v.xw;
+fn ar(v: gvec4i) = v.wx;
+fn gb(v: gvec4i) = v.yz;
+fn bg(v: gvec4i) = v.zy;
+fn ga(v: gvec4i) = v.yw;
+fn ag(v: gvec4i) = v.wy;
+fn ba(v: gvec4i) = v.zw;
+fn ab(v: gvec4i) = v.wz;
 
 fn gvec43i(v: gvec4i, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
@@ -3008,217 +3043,217 @@ fn gvec43i(v: gvec4i, a: string) {
   return gvec3i(varName, v.statements, v.buffers);
 }
 // 1 = x, i, r; 2 = y, j, g; 3 = z, k, b; 4 = w, l, a
-export fn xyz(v: gvec4i) = gvec43i(v, '.xyz'); // 123
-export fn xyw(v: gvec4i) = gvec43i(v, '.xyw'); // 124
-export fn xzy(v: gvec4i) = gvec43i(v, '.xzy'); // 132
-export fn xzw(v: gvec4i) = gvec43i(v, '.xzw'); // 134
-export fn xwy(v: gvec4i) = gvec43i(v, '.xwy'); // 142
-export fn xwz(v: gvec4i) = gvec43i(v, '.xwz'); // 143
-export fn yxz(v: gvec4i) = gvec43i(v, '.yxz'); // 213
-export fn yxw(v: gvec4i) = gvec43i(v, '.yxw'); // 214
-export fn yzx(v: gvec4i) = gvec43i(v, '.yzx'); // 231
-export fn yzw(v: gvec4i) = gvec43i(v, '.yzw'); // 234
-export fn ywx(v: gvec4i) = gvec43i(v, '.ywx'); // 241
-export fn ywz(v: gvec4i) = gvec43i(v, '.ywz'); // 243
-export fn zxy(v: gvec4i) = gvec43i(v, '.zxy'); // 312
-export fn zxw(v: gvec4i) = gvec43i(v, '.zxw'); // 314
-export fn zyx(v: gvec4i) = gvec43i(v, '.zyx'); // 321
-export fn zyw(v: gvec4i) = gvec43i(v, '.zyw'); // 324
-export fn zwx(v: gvec4i) = gvec43i(v, '.zwx'); // 341
-export fn zwy(v: gvec4i) = gvec43i(v, '.zwy'); // 342
-export fn wxy(v: gvec4i) = gvec43i(v, '.wxy'); // 412
-export fn wxz(v: gvec4i) = gvec43i(v, '.wxz'); // 413
-export fn wyx(v: gvec4i) = gvec43i(v, '.wyx'); // 421
-export fn wyz(v: gvec4i) = gvec43i(v, '.wyz'); // 423
-export fn wzx(v: gvec4i) = gvec43i(v, '.wzx'); // 431
-export fn wzy(v: gvec4i) = gvec43i(v, '.wzy'); // 432
-export fn ijk(v: gvec4i) = v.xyz;
-export fn ijl(v: gvec4i) = v.xyw;
-export fn ikj(v: gvec4i) = v.xzy;
-export fn ikl(v: gvec4i) = v.xzw;
-export fn ilj(v: gvec4i) = v.xwy;
-export fn ilk(v: gvec4i) = v.xwz;
-export fn jik(v: gvec4i) = v.yxz;
-export fn jil(v: gvec4i) = v.yxw;
-export fn jki(v: gvec4i) = v.yzx;
-export fn jkl(v: gvec4i) = v.yzw;
-export fn jli(v: gvec4i) = v.ywx;
-export fn jlk(v: gvec4i) = v.ywz;
-export fn kij(v: gvec4i) = v.zxy;
-export fn kil(v: gvec4i) = v.zxw;
-export fn kji(v: gvec4i) = v.zyx;
-export fn kjl(v: gvec4i) = v.zyw;
-export fn kli(v: gvec4i) = v.zwx;
-export fn klj(v: gvec4i) = v.zwy;
-export fn lij(v: gvec4i) = v.wxy;
-export fn lik(v: gvec4i) = v.wxz;
-export fn lji(v: gvec4i) = v.wyx;
-export fn ljk(v: gvec4i) = v.wyz;
-export fn lki(v: gvec4i) = v.wzx;
-export fn lkj(v: gvec4i) = v.wzy;
-export fn rgb(v: gvec4i) = v.xyz;
-export fn rga(v: gvec4i) = v.xyw;
-export fn rbg(v: gvec4i) = v.xzy;
-export fn rba(v: gvec4i) = v.xzw;
-export fn rag(v: gvec4i) = v.xwy;
-export fn rab(v: gvec4i) = v.xwz;
-export fn grb(v: gvec4i) = v.yxz;
-export fn gra(v: gvec4i) = v.yxw;
-export fn gbr(v: gvec4i) = v.yzx;
-export fn gba(v: gvec4i) = v.yzw;
-export fn gar(v: gvec4i) = v.ywx;
-export fn gab(v: gvec4i) = v.ywz;
-export fn brg(v: gvec4i) = v.zxy;
-export fn bra(v: gvec4i) = v.zxw;
-export fn bgr(v: gvec4i) = v.zyx;
-export fn bga(v: gvec4i) = v.zyw;
-export fn bar(v: gvec4i) = v.zwx;
-export fn bag(v: gvec4i) = v.zwy;
-export fn arb(v: gvec4i) = v.wxy;
-export fn arg(v: gvec4i) = v.wxz;
-export fn abr(v: gvec4i) = v.wyx;
-export fn abg(v: gvec4i) = v.wyz;
-export fn agr(v: gvec4i) = v.wzx;
-export fn agb(v: gvec4i) = v.wzy;
+fn xyz(v: gvec4i) = gvec43i(v, '.xyz'); // 123
+fn xyw(v: gvec4i) = gvec43i(v, '.xyw'); // 124
+fn xzy(v: gvec4i) = gvec43i(v, '.xzy'); // 132
+fn xzw(v: gvec4i) = gvec43i(v, '.xzw'); // 134
+fn xwy(v: gvec4i) = gvec43i(v, '.xwy'); // 142
+fn xwz(v: gvec4i) = gvec43i(v, '.xwz'); // 143
+fn yxz(v: gvec4i) = gvec43i(v, '.yxz'); // 213
+fn yxw(v: gvec4i) = gvec43i(v, '.yxw'); // 214
+fn yzx(v: gvec4i) = gvec43i(v, '.yzx'); // 231
+fn yzw(v: gvec4i) = gvec43i(v, '.yzw'); // 234
+fn ywx(v: gvec4i) = gvec43i(v, '.ywx'); // 241
+fn ywz(v: gvec4i) = gvec43i(v, '.ywz'); // 243
+fn zxy(v: gvec4i) = gvec43i(v, '.zxy'); // 312
+fn zxw(v: gvec4i) = gvec43i(v, '.zxw'); // 314
+fn zyx(v: gvec4i) = gvec43i(v, '.zyx'); // 321
+fn zyw(v: gvec4i) = gvec43i(v, '.zyw'); // 324
+fn zwx(v: gvec4i) = gvec43i(v, '.zwx'); // 341
+fn zwy(v: gvec4i) = gvec43i(v, '.zwy'); // 342
+fn wxy(v: gvec4i) = gvec43i(v, '.wxy'); // 412
+fn wxz(v: gvec4i) = gvec43i(v, '.wxz'); // 413
+fn wyx(v: gvec4i) = gvec43i(v, '.wyx'); // 421
+fn wyz(v: gvec4i) = gvec43i(v, '.wyz'); // 423
+fn wzx(v: gvec4i) = gvec43i(v, '.wzx'); // 431
+fn wzy(v: gvec4i) = gvec43i(v, '.wzy'); // 432
+fn ijk(v: gvec4i) = v.xyz;
+fn ijl(v: gvec4i) = v.xyw;
+fn ikj(v: gvec4i) = v.xzy;
+fn ikl(v: gvec4i) = v.xzw;
+fn ilj(v: gvec4i) = v.xwy;
+fn ilk(v: gvec4i) = v.xwz;
+fn jik(v: gvec4i) = v.yxz;
+fn jil(v: gvec4i) = v.yxw;
+fn jki(v: gvec4i) = v.yzx;
+fn jkl(v: gvec4i) = v.yzw;
+fn jli(v: gvec4i) = v.ywx;
+fn jlk(v: gvec4i) = v.ywz;
+fn kij(v: gvec4i) = v.zxy;
+fn kil(v: gvec4i) = v.zxw;
+fn kji(v: gvec4i) = v.zyx;
+fn kjl(v: gvec4i) = v.zyw;
+fn kli(v: gvec4i) = v.zwx;
+fn klj(v: gvec4i) = v.zwy;
+fn lij(v: gvec4i) = v.wxy;
+fn lik(v: gvec4i) = v.wxz;
+fn lji(v: gvec4i) = v.wyx;
+fn ljk(v: gvec4i) = v.wyz;
+fn lki(v: gvec4i) = v.wzx;
+fn lkj(v: gvec4i) = v.wzy;
+fn rgb(v: gvec4i) = v.xyz;
+fn rga(v: gvec4i) = v.xyw;
+fn rbg(v: gvec4i) = v.xzy;
+fn rba(v: gvec4i) = v.xzw;
+fn rag(v: gvec4i) = v.xwy;
+fn rab(v: gvec4i) = v.xwz;
+fn grb(v: gvec4i) = v.yxz;
+fn gra(v: gvec4i) = v.yxw;
+fn gbr(v: gvec4i) = v.yzx;
+fn gba(v: gvec4i) = v.yzw;
+fn gar(v: gvec4i) = v.ywx;
+fn gab(v: gvec4i) = v.ywz;
+fn brg(v: gvec4i) = v.zxy;
+fn bra(v: gvec4i) = v.zxw;
+fn bgr(v: gvec4i) = v.zyx;
+fn bga(v: gvec4i) = v.zyw;
+fn bar(v: gvec4i) = v.zwx;
+fn bag(v: gvec4i) = v.zwy;
+fn arb(v: gvec4i) = v.wxy;
+fn arg(v: gvec4i) = v.wxz;
+fn abr(v: gvec4i) = v.wyx;
+fn abg(v: gvec4i) = v.wyz;
+fn agr(v: gvec4i) = v.wzx;
+fn agb(v: gvec4i) = v.wzy;
 
 fn gvec44i(v: gvec4i, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec4i(varName, v.statements, v.buffers);
 }
-export fn xyzw(v: gvec4i) = gvec44i(v, '.xyzw'); // 1234
-export fn xywz(v: gvec4i) = gvec44i(v, '.xywz'); // 1243
-export fn xzyw(v: gvec4i) = gvec44i(v, '.xzyw'); // 1324
-export fn xzwy(v: gvec4i) = gvec44i(v, '.xzwy'); // 1342
-export fn xwyz(v: gvec4i) = gvec44i(v, '.xwyz'); // 1423
-export fn xwzy(v: gvec4i) = gvec44i(v, '.xwzy'); // 1432
-export fn yxzw(v: gvec4i) = gvec44i(v, '.yxzw'); // 2134
-export fn yxwz(v: gvec4i) = gvec44i(v, '.yxwz'); // 2143
-export fn yzxw(v: gvec4i) = gvec44i(v, '.yzxw'); // 2314
-export fn yzwx(v: gvec4i) = gvec44i(v, '.yzwx'); // 2341
-export fn ywxz(v: gvec4i) = gvec44i(v, '.ywxz'); // 2413
-export fn ywzx(v: gvec4i) = gvec44i(v, '.ywzx'); // 2431
-export fn zxyw(v: gvec4i) = gvec44i(v, '.zxyw'); // 3124
-export fn zxwy(v: gvec4i) = gvec44i(v, '.zxwy'); // 3142
-export fn zyxw(v: gvec4i) = gvec44i(v, '.zyxw'); // 3214
-export fn zywx(v: gvec4i) = gvec44i(v, '.zywx'); // 3241
-export fn zwxy(v: gvec4i) = gvec44i(v, '.zwxy'); // 3412
-export fn zwyx(v: gvec4i) = gvec44i(v, '.zwyx'); // 3421
-export fn wxyz(v: gvec4i) = gvec44i(v, '.wxyz'); // 4123
-export fn wxzy(v: gvec4i) = gvec44i(v, '.wxzy'); // 4132
-export fn wyxz(v: gvec4i) = gvec44i(v, '.wyxz'); // 4213
-export fn wyzx(v: gvec4i) = gvec44i(v, '.wyzx'); // 4231
-export fn wzxy(v: gvec4i) = gvec44i(v, '.wzxy'); // 4312
-export fn wzyx(v: gvec4i) = gvec44i(v, '.wzyx'); // 4321
-export fn ijkl(v: gvec4i) = v.xyzw;
-export fn ijlk(v: gvec4i) = v.xywz;
-export fn ikjl(v: gvec4i) = v.xzyw;
-export fn iklj(v: gvec4i) = v.xzwy;
-export fn iljk(v: gvec4i) = v.xwyz;
-export fn ilkj(v: gvec4i) = v.xwzy;
-export fn jikl(v: gvec4i) = v.yxzw;
-export fn jilk(v: gvec4i) = v.yxwz;
-export fn jkil(v: gvec4i) = v.yzxw;
-export fn jkli(v: gvec4i) = v.yzwx;
-export fn jlik(v: gvec4i) = v.ywxz;
-export fn jlki(v: gvec4i) = v.ywzx;
-export fn kijl(v: gvec4i) = v.zxyw;
-export fn kilj(v: gvec4i) = v.zxwy;
-export fn kjil(v: gvec4i) = v.zyxw;
-export fn kjli(v: gvec4i) = v.zywx;
-export fn klij(v: gvec4i) = v.zwxy;
-export fn klji(v: gvec4i) = v.zwyx;
-export fn lijk(v: gvec4i) = v.wxyz;
-export fn likj(v: gvec4i) = v.wxzy;
-export fn ljik(v: gvec4i) = v.wyxz;
-export fn ljki(v: gvec4i) = v.wyzx;
-export fn lkij(v: gvec4i) = v.wzxy;
-export fn lkji(v: gvec4i) = v.wzyx;
-export fn rgba(v: gvec4i) = v.xyzw;
-export fn rgab(v: gvec4i) = v.xywz;
-export fn rbga(v: gvec4i) = v.xzyw;
-export fn rbag(v: gvec4i) = v.xzwy;
-export fn ragb(v: gvec4i) = v.xwyz;
-export fn rabg(v: gvec4i) = v.xwzy;
-export fn grba(v: gvec4i) = v.yxzw;
-export fn grab(v: gvec4i) = v.yxwz;
-export fn gbra(v: gvec4i) = v.yzxw;
-export fn gbar(v: gvec4i) = v.yzwx;
-export fn garb(v: gvec4i) = v.ywxz;
-export fn gabr(v: gvec4i) = v.ywzx;
-export fn argb(v: gvec4i) = v.wxyz;
-export fn arbg(v: gvec4i) = v.wxzy;
-export fn agrb(v: gvec4i) = v.wyxz;
-export fn agbr(v: gvec4i) = v.wyzx;
-export fn abrg(v: gvec4i) = v.wzxy;
-export fn abgr(v: gvec4i) = v.wzyx;
+fn xyzw(v: gvec4i) = gvec44i(v, '.xyzw'); // 1234
+fn xywz(v: gvec4i) = gvec44i(v, '.xywz'); // 1243
+fn xzyw(v: gvec4i) = gvec44i(v, '.xzyw'); // 1324
+fn xzwy(v: gvec4i) = gvec44i(v, '.xzwy'); // 1342
+fn xwyz(v: gvec4i) = gvec44i(v, '.xwyz'); // 1423
+fn xwzy(v: gvec4i) = gvec44i(v, '.xwzy'); // 1432
+fn yxzw(v: gvec4i) = gvec44i(v, '.yxzw'); // 2134
+fn yxwz(v: gvec4i) = gvec44i(v, '.yxwz'); // 2143
+fn yzxw(v: gvec4i) = gvec44i(v, '.yzxw'); // 2314
+fn yzwx(v: gvec4i) = gvec44i(v, '.yzwx'); // 2341
+fn ywxz(v: gvec4i) = gvec44i(v, '.ywxz'); // 2413
+fn ywzx(v: gvec4i) = gvec44i(v, '.ywzx'); // 2431
+fn zxyw(v: gvec4i) = gvec44i(v, '.zxyw'); // 3124
+fn zxwy(v: gvec4i) = gvec44i(v, '.zxwy'); // 3142
+fn zyxw(v: gvec4i) = gvec44i(v, '.zyxw'); // 3214
+fn zywx(v: gvec4i) = gvec44i(v, '.zywx'); // 3241
+fn zwxy(v: gvec4i) = gvec44i(v, '.zwxy'); // 3412
+fn zwyx(v: gvec4i) = gvec44i(v, '.zwyx'); // 3421
+fn wxyz(v: gvec4i) = gvec44i(v, '.wxyz'); // 4123
+fn wxzy(v: gvec4i) = gvec44i(v, '.wxzy'); // 4132
+fn wyxz(v: gvec4i) = gvec44i(v, '.wyxz'); // 4213
+fn wyzx(v: gvec4i) = gvec44i(v, '.wyzx'); // 4231
+fn wzxy(v: gvec4i) = gvec44i(v, '.wzxy'); // 4312
+fn wzyx(v: gvec4i) = gvec44i(v, '.wzyx'); // 4321
+fn ijkl(v: gvec4i) = v.xyzw;
+fn ijlk(v: gvec4i) = v.xywz;
+fn ikjl(v: gvec4i) = v.xzyw;
+fn iklj(v: gvec4i) = v.xzwy;
+fn iljk(v: gvec4i) = v.xwyz;
+fn ilkj(v: gvec4i) = v.xwzy;
+fn jikl(v: gvec4i) = v.yxzw;
+fn jilk(v: gvec4i) = v.yxwz;
+fn jkil(v: gvec4i) = v.yzxw;
+fn jkli(v: gvec4i) = v.yzwx;
+fn jlik(v: gvec4i) = v.ywxz;
+fn jlki(v: gvec4i) = v.ywzx;
+fn kijl(v: gvec4i) = v.zxyw;
+fn kilj(v: gvec4i) = v.zxwy;
+fn kjil(v: gvec4i) = v.zyxw;
+fn kjli(v: gvec4i) = v.zywx;
+fn klij(v: gvec4i) = v.zwxy;
+fn klji(v: gvec4i) = v.zwyx;
+fn lijk(v: gvec4i) = v.wxyz;
+fn likj(v: gvec4i) = v.wxzy;
+fn ljik(v: gvec4i) = v.wyxz;
+fn ljki(v: gvec4i) = v.wyzx;
+fn lkij(v: gvec4i) = v.wzxy;
+fn lkji(v: gvec4i) = v.wzyx;
+fn rgba(v: gvec4i) = v.xyzw;
+fn rgab(v: gvec4i) = v.xywz;
+fn rbga(v: gvec4i) = v.xzyw;
+fn rbag(v: gvec4i) = v.xzwy;
+fn ragb(v: gvec4i) = v.xwyz;
+fn rabg(v: gvec4i) = v.xwzy;
+fn grba(v: gvec4i) = v.yxzw;
+fn grab(v: gvec4i) = v.yxwz;
+fn gbra(v: gvec4i) = v.yzxw;
+fn gbar(v: gvec4i) = v.yzwx;
+fn garb(v: gvec4i) = v.ywxz;
+fn gabr(v: gvec4i) = v.ywzx;
+fn argb(v: gvec4i) = v.wxyz;
+fn arbg(v: gvec4i) = v.wxzy;
+fn agrb(v: gvec4i) = v.wyxz;
+fn agbr(v: gvec4i) = v.wyzx;
+fn abrg(v: gvec4i) = v.wzxy;
+fn abgr(v: gvec4i) = v.wzyx;
 
-export fn x(v: gvec4f) {
+fn x(v: gvec4f) {
   let varName = v.varName.concat('.x');
   return gf32(varName, v.statements, v.buffers);
 }
-export fn y(v: gvec4f) {
+fn y(v: gvec4f) {
   let varName = v.varName.concat('.y');
   return gf32(varName, v.statements, v.buffers);
 }
-export fn z(v: gvec4f) {
+fn z(v: gvec4f) {
   let varName = v.varName.concat('.z');
   return gf32(varName, v.statements, v.buffers);
 }
-export fn w(v: gvec4f) {
+fn w(v: gvec4f) {
   let varName = v.varName.concat('.w');
   return gf32(varName, v.statements, v.buffers);
 }
-export fn i(v: gvec4f) = v.x;
-export fn j(v: gvec4f) = v.y;
-export fn k(v: gvec4f) = v.z;
-export fn l(v: gvec4f) = v.w;
-export fn r(v: gvec4f) = v.x;
-export fn g(v: gvec4f) = v.y;
-export fn b(v: gvec4f) = v.z;
-export fn a(v: gvec4f) = v.w;
+fn i(v: gvec4f) = v.x;
+fn j(v: gvec4f) = v.y;
+fn k(v: gvec4f) = v.z;
+fn l(v: gvec4f) = v.w;
+fn r(v: gvec4f) = v.x;
+fn g(v: gvec4f) = v.y;
+fn b(v: gvec4f) = v.z;
+fn a(v: gvec4f) = v.w;
 
 fn gvec42f(v: gvec4f, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec2f(varName, v.statements, v.buffers);
 }
-export fn xy(v: gvec4f) = gvec42f(v, '.xy');
-export fn yx(v: gvec4f) = gvec42f(v, '.yx');
-export fn xz(v: gvec4f) = gvec42f(v, '.xz');
-export fn zx(v: gvec4f) = gvec42f(v, '.zx');
-export fn xw(v: gvec4f) = gvec42f(v, '.xw');
-export fn wx(v: gvec4f) = gvec42f(v, '.wx');
-export fn yz(v: gvec4f) = gvec42f(v, '.yz');
-export fn zy(v: gvec4f) = gvec42f(v, '.zy');
-export fn yw(v: gvec4f) = gvec42f(v, '.yw');
-export fn wy(v: gvec4f) = gvec42f(v, '.wy');
-export fn zw(v: gvec4f) = gvec42f(v, '.zw');
-export fn wz(v: gvec4f) = gvec42f(v, '.wz');
-export fn ij(v: gvec4f) = v.xy;
-export fn ji(v: gvec4f) = v.yx;
-export fn ik(v: gvec4f) = v.xz;
-export fn ki(v: gvec4f) = v.zx;
-export fn il(v: gvec4f) = v.xw;
-export fn li(v: gvec4f) = v.wx;
-export fn jk(v: gvec4f) = v.yz;
-export fn kj(v: gvec4f) = v.zy;
-export fn jl(v: gvec4f) = v.yw;
-export fn lj(v: gvec4f) = v.wy;
-export fn kl(v: gvec4f) = v.zw;
-export fn lk(v: gvec4f) = v.wz;
-export fn rg(v: gvec4f) = v.xy;
-export fn gr(v: gvec4f) = v.yx;
-export fn rb(v: gvec4f) = v.xz;
-export fn br(v: gvec4f) = v.zx;
-export fn ra(v: gvec4f) = v.xw;
-export fn ar(v: gvec4f) = v.wx;
-export fn gb(v: gvec4f) = v.yz;
-export fn bg(v: gvec4f) = v.zy;
-export fn ga(v: gvec4f) = v.yw;
-export fn ag(v: gvec4f) = v.wy;
-export fn ba(v: gvec4f) = v.zw;
-export fn ab(v: gvec4f) = v.wz;
+fn xy(v: gvec4f) = gvec42f(v, '.xy');
+fn yx(v: gvec4f) = gvec42f(v, '.yx');
+fn xz(v: gvec4f) = gvec42f(v, '.xz');
+fn zx(v: gvec4f) = gvec42f(v, '.zx');
+fn xw(v: gvec4f) = gvec42f(v, '.xw');
+fn wx(v: gvec4f) = gvec42f(v, '.wx');
+fn yz(v: gvec4f) = gvec42f(v, '.yz');
+fn zy(v: gvec4f) = gvec42f(v, '.zy');
+fn yw(v: gvec4f) = gvec42f(v, '.yw');
+fn wy(v: gvec4f) = gvec42f(v, '.wy');
+fn zw(v: gvec4f) = gvec42f(v, '.zw');
+fn wz(v: gvec4f) = gvec42f(v, '.wz');
+fn ij(v: gvec4f) = v.xy;
+fn ji(v: gvec4f) = v.yx;
+fn ik(v: gvec4f) = v.xz;
+fn ki(v: gvec4f) = v.zx;
+fn il(v: gvec4f) = v.xw;
+fn li(v: gvec4f) = v.wx;
+fn jk(v: gvec4f) = v.yz;
+fn kj(v: gvec4f) = v.zy;
+fn jl(v: gvec4f) = v.yw;
+fn lj(v: gvec4f) = v.wy;
+fn kl(v: gvec4f) = v.zw;
+fn lk(v: gvec4f) = v.wz;
+fn rg(v: gvec4f) = v.xy;
+fn gr(v: gvec4f) = v.yx;
+fn rb(v: gvec4f) = v.xz;
+fn br(v: gvec4f) = v.zx;
+fn ra(v: gvec4f) = v.xw;
+fn ar(v: gvec4f) = v.wx;
+fn gb(v: gvec4f) = v.yz;
+fn bg(v: gvec4f) = v.zy;
+fn ga(v: gvec4f) = v.yw;
+fn ag(v: gvec4f) = v.wy;
+fn ba(v: gvec4f) = v.zw;
+fn ab(v: gvec4f) = v.wz;
 
 fn gvec43f(v: gvec4f, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
@@ -3226,217 +3261,217 @@ fn gvec43f(v: gvec4f, a: string) {
   return gvec3f(varName, v.statements, v.buffers);
 }
 // 1 = x, i, r; 2 = y, j, g; 3 = z, k, b; 4 = w, l, a
-export fn xyz(v: gvec4f) = gvec43f(v, '.xyz'); // 123
-export fn xyw(v: gvec4f) = gvec43f(v, '.xyw'); // 124
-export fn xzy(v: gvec4f) = gvec43f(v, '.xzy'); // 132
-export fn xzw(v: gvec4f) = gvec43f(v, '.xzw'); // 134
-export fn xwy(v: gvec4f) = gvec43f(v, '.xwy'); // 142
-export fn xwz(v: gvec4f) = gvec43f(v, '.xwz'); // 143
-export fn yxz(v: gvec4f) = gvec43f(v, '.yxz'); // 213
-export fn yxw(v: gvec4f) = gvec43f(v, '.yxw'); // 214
-export fn yzx(v: gvec4f) = gvec43f(v, '.yzx'); // 231
-export fn yzw(v: gvec4f) = gvec43f(v, '.yzw'); // 234
-export fn ywx(v: gvec4f) = gvec43f(v, '.ywx'); // 241
-export fn ywz(v: gvec4f) = gvec43f(v, '.ywz'); // 243
-export fn zxy(v: gvec4f) = gvec43f(v, '.zxy'); // 312
-export fn zxw(v: gvec4f) = gvec43f(v, '.zxw'); // 314
-export fn zyx(v: gvec4f) = gvec43f(v, '.zyx'); // 321
-export fn zyw(v: gvec4f) = gvec43f(v, '.zyw'); // 324
-export fn zwx(v: gvec4f) = gvec43f(v, '.zwx'); // 341
-export fn zwy(v: gvec4f) = gvec43f(v, '.zwy'); // 342
-export fn wxy(v: gvec4f) = gvec43f(v, '.wxy'); // 412
-export fn wxz(v: gvec4f) = gvec43f(v, '.wxz'); // 413
-export fn wyx(v: gvec4f) = gvec43f(v, '.wyx'); // 421
-export fn wyz(v: gvec4f) = gvec43f(v, '.wyz'); // 423
-export fn wzx(v: gvec4f) = gvec43f(v, '.wzx'); // 431
-export fn wzy(v: gvec4f) = gvec43f(v, '.wzy'); // 432
-export fn ijk(v: gvec4f) = v.xyz;
-export fn ijl(v: gvec4f) = v.xyw;
-export fn ikj(v: gvec4f) = v.xzy;
-export fn ikl(v: gvec4f) = v.xzw;
-export fn ilj(v: gvec4f) = v.xwy;
-export fn ilk(v: gvec4f) = v.xwz;
-export fn jik(v: gvec4f) = v.yxz;
-export fn jil(v: gvec4f) = v.yxw;
-export fn jki(v: gvec4f) = v.yzx;
-export fn jkl(v: gvec4f) = v.yzw;
-export fn jli(v: gvec4f) = v.ywx;
-export fn jlk(v: gvec4f) = v.ywz;
-export fn kij(v: gvec4f) = v.zxy;
-export fn kil(v: gvec4f) = v.zxw;
-export fn kji(v: gvec4f) = v.zyx;
-export fn kjl(v: gvec4f) = v.zyw;
-export fn kli(v: gvec4f) = v.zwx;
-export fn klj(v: gvec4f) = v.zwy;
-export fn lij(v: gvec4f) = v.wxy;
-export fn lik(v: gvec4f) = v.wxz;
-export fn lji(v: gvec4f) = v.wyx;
-export fn ljk(v: gvec4f) = v.wyz;
-export fn lki(v: gvec4f) = v.wzx;
-export fn lkj(v: gvec4f) = v.wzy;
-export fn rgb(v: gvec4f) = v.xyz;
-export fn rga(v: gvec4f) = v.xyw;
-export fn rbg(v: gvec4f) = v.xzy;
-export fn rba(v: gvec4f) = v.xzw;
-export fn rag(v: gvec4f) = v.xwy;
-export fn rab(v: gvec4f) = v.xwz;
-export fn grb(v: gvec4f) = v.yxz;
-export fn gra(v: gvec4f) = v.yxw;
-export fn gbr(v: gvec4f) = v.yzx;
-export fn gba(v: gvec4f) = v.yzw;
-export fn gar(v: gvec4f) = v.ywx;
-export fn gab(v: gvec4f) = v.ywz;
-export fn brg(v: gvec4f) = v.zxy;
-export fn bra(v: gvec4f) = v.zxw;
-export fn bgr(v: gvec4f) = v.zyx;
-export fn bga(v: gvec4f) = v.zyw;
-export fn bar(v: gvec4f) = v.zwx;
-export fn bag(v: gvec4f) = v.zwy;
-export fn arb(v: gvec4f) = v.wxy;
-export fn arg(v: gvec4f) = v.wxz;
-export fn abr(v: gvec4f) = v.wyx;
-export fn abg(v: gvec4f) = v.wyz;
-export fn agr(v: gvec4f) = v.wzx;
-export fn agb(v: gvec4f) = v.wzy;
+fn xyz(v: gvec4f) = gvec43f(v, '.xyz'); // 123
+fn xyw(v: gvec4f) = gvec43f(v, '.xyw'); // 124
+fn xzy(v: gvec4f) = gvec43f(v, '.xzy'); // 132
+fn xzw(v: gvec4f) = gvec43f(v, '.xzw'); // 134
+fn xwy(v: gvec4f) = gvec43f(v, '.xwy'); // 142
+fn xwz(v: gvec4f) = gvec43f(v, '.xwz'); // 143
+fn yxz(v: gvec4f) = gvec43f(v, '.yxz'); // 213
+fn yxw(v: gvec4f) = gvec43f(v, '.yxw'); // 214
+fn yzx(v: gvec4f) = gvec43f(v, '.yzx'); // 231
+fn yzw(v: gvec4f) = gvec43f(v, '.yzw'); // 234
+fn ywx(v: gvec4f) = gvec43f(v, '.ywx'); // 241
+fn ywz(v: gvec4f) = gvec43f(v, '.ywz'); // 243
+fn zxy(v: gvec4f) = gvec43f(v, '.zxy'); // 312
+fn zxw(v: gvec4f) = gvec43f(v, '.zxw'); // 314
+fn zyx(v: gvec4f) = gvec43f(v, '.zyx'); // 321
+fn zyw(v: gvec4f) = gvec43f(v, '.zyw'); // 324
+fn zwx(v: gvec4f) = gvec43f(v, '.zwx'); // 341
+fn zwy(v: gvec4f) = gvec43f(v, '.zwy'); // 342
+fn wxy(v: gvec4f) = gvec43f(v, '.wxy'); // 412
+fn wxz(v: gvec4f) = gvec43f(v, '.wxz'); // 413
+fn wyx(v: gvec4f) = gvec43f(v, '.wyx'); // 421
+fn wyz(v: gvec4f) = gvec43f(v, '.wyz'); // 423
+fn wzx(v: gvec4f) = gvec43f(v, '.wzx'); // 431
+fn wzy(v: gvec4f) = gvec43f(v, '.wzy'); // 432
+fn ijk(v: gvec4f) = v.xyz;
+fn ijl(v: gvec4f) = v.xyw;
+fn ikj(v: gvec4f) = v.xzy;
+fn ikl(v: gvec4f) = v.xzw;
+fn ilj(v: gvec4f) = v.xwy;
+fn ilk(v: gvec4f) = v.xwz;
+fn jik(v: gvec4f) = v.yxz;
+fn jil(v: gvec4f) = v.yxw;
+fn jki(v: gvec4f) = v.yzx;
+fn jkl(v: gvec4f) = v.yzw;
+fn jli(v: gvec4f) = v.ywx;
+fn jlk(v: gvec4f) = v.ywz;
+fn kij(v: gvec4f) = v.zxy;
+fn kil(v: gvec4f) = v.zxw;
+fn kji(v: gvec4f) = v.zyx;
+fn kjl(v: gvec4f) = v.zyw;
+fn kli(v: gvec4f) = v.zwx;
+fn klj(v: gvec4f) = v.zwy;
+fn lij(v: gvec4f) = v.wxy;
+fn lik(v: gvec4f) = v.wxz;
+fn lji(v: gvec4f) = v.wyx;
+fn ljk(v: gvec4f) = v.wyz;
+fn lki(v: gvec4f) = v.wzx;
+fn lkj(v: gvec4f) = v.wzy;
+fn rgb(v: gvec4f) = v.xyz;
+fn rga(v: gvec4f) = v.xyw;
+fn rbg(v: gvec4f) = v.xzy;
+fn rba(v: gvec4f) = v.xzw;
+fn rag(v: gvec4f) = v.xwy;
+fn rab(v: gvec4f) = v.xwz;
+fn grb(v: gvec4f) = v.yxz;
+fn gra(v: gvec4f) = v.yxw;
+fn gbr(v: gvec4f) = v.yzx;
+fn gba(v: gvec4f) = v.yzw;
+fn gar(v: gvec4f) = v.ywx;
+fn gab(v: gvec4f) = v.ywz;
+fn brg(v: gvec4f) = v.zxy;
+fn bra(v: gvec4f) = v.zxw;
+fn bgr(v: gvec4f) = v.zyx;
+fn bga(v: gvec4f) = v.zyw;
+fn bar(v: gvec4f) = v.zwx;
+fn bag(v: gvec4f) = v.zwy;
+fn arb(v: gvec4f) = v.wxy;
+fn arg(v: gvec4f) = v.wxz;
+fn abr(v: gvec4f) = v.wyx;
+fn abg(v: gvec4f) = v.wyz;
+fn agr(v: gvec4f) = v.wzx;
+fn agb(v: gvec4f) = v.wzy;
 
 fn gvec44f(v: gvec4f, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec4f(varName, v.statements, v.buffers);
 }
-export fn xyzw(v: gvec4f) = gvec44f(v, '.xyzw'); // 1234
-export fn xywz(v: gvec4f) = gvec44f(v, '.xywz'); // 1243
-export fn xzyw(v: gvec4f) = gvec44f(v, '.xzyw'); // 1324
-export fn xzwy(v: gvec4f) = gvec44f(v, '.xzwy'); // 1342
-export fn xwyz(v: gvec4f) = gvec44f(v, '.xwyz'); // 1423
-export fn xwzy(v: gvec4f) = gvec44f(v, '.xwzy'); // 1432
-export fn yxzw(v: gvec4f) = gvec44f(v, '.yxzw'); // 2134
-export fn yxwz(v: gvec4f) = gvec44f(v, '.yxwz'); // 2143
-export fn yzxw(v: gvec4f) = gvec44f(v, '.yzxw'); // 2314
-export fn yzwx(v: gvec4f) = gvec44f(v, '.yzwx'); // 2341
-export fn ywxz(v: gvec4f) = gvec44f(v, '.ywxz'); // 2413
-export fn ywzx(v: gvec4f) = gvec44f(v, '.ywzx'); // 2431
-export fn zxyw(v: gvec4f) = gvec44f(v, '.zxyw'); // 3124
-export fn zxwy(v: gvec4f) = gvec44f(v, '.zxwy'); // 3142
-export fn zyxw(v: gvec4f) = gvec44f(v, '.zyxw'); // 3214
-export fn zywx(v: gvec4f) = gvec44f(v, '.zywx'); // 3241
-export fn zwxy(v: gvec4f) = gvec44f(v, '.zwxy'); // 3412
-export fn zwyx(v: gvec4f) = gvec44f(v, '.zwyx'); // 3421
-export fn wxyz(v: gvec4f) = gvec44f(v, '.wxyz'); // 4123
-export fn wxzy(v: gvec4f) = gvec44f(v, '.wxzy'); // 4132
-export fn wyxz(v: gvec4f) = gvec44f(v, '.wyxz'); // 4213
-export fn wyzx(v: gvec4f) = gvec44f(v, '.wyzx'); // 4231
-export fn wzxy(v: gvec4f) = gvec44f(v, '.wzxy'); // 4312
-export fn wzyx(v: gvec4f) = gvec44f(v, '.wzyx'); // 4321
-export fn ijkl(v: gvec4f) = v.xyzw;
-export fn ijlk(v: gvec4f) = v.xywz;
-export fn ikjl(v: gvec4f) = v.xzyw;
-export fn iklj(v: gvec4f) = v.xzwy;
-export fn iljk(v: gvec4f) = v.xwyz;
-export fn ilkj(v: gvec4f) = v.xwzy;
-export fn jikl(v: gvec4f) = v.yxzw;
-export fn jilk(v: gvec4f) = v.yxwz;
-export fn jkil(v: gvec4f) = v.yzxw;
-export fn jkli(v: gvec4f) = v.yzwx;
-export fn jlik(v: gvec4f) = v.ywxz;
-export fn jlki(v: gvec4f) = v.ywzx;
-export fn kijl(v: gvec4f) = v.zxyw;
-export fn kilj(v: gvec4f) = v.zxwy;
-export fn kjil(v: gvec4f) = v.zyxw;
-export fn kjli(v: gvec4f) = v.zywx;
-export fn klij(v: gvec4f) = v.zwxy;
-export fn klji(v: gvec4f) = v.zwyx;
-export fn lijk(v: gvec4f) = v.wxyz;
-export fn likj(v: gvec4f) = v.wxzy;
-export fn ljik(v: gvec4f) = v.wyxz;
-export fn ljki(v: gvec4f) = v.wyzx;
-export fn lkij(v: gvec4f) = v.wzxy;
-export fn lkji(v: gvec4f) = v.wzyx;
-export fn rgba(v: gvec4f) = v.xyzw;
-export fn rgab(v: gvec4f) = v.xywz;
-export fn rbga(v: gvec4f) = v.xzyw;
-export fn rbag(v: gvec4f) = v.xzwy;
-export fn ragb(v: gvec4f) = v.xwyz;
-export fn rabg(v: gvec4f) = v.xwzy;
-export fn grba(v: gvec4f) = v.yxzw;
-export fn grab(v: gvec4f) = v.yxwz;
-export fn gbra(v: gvec4f) = v.yzxw;
-export fn gbar(v: gvec4f) = v.yzwx;
-export fn garb(v: gvec4f) = v.ywxz;
-export fn gabr(v: gvec4f) = v.ywzx;
-export fn argb(v: gvec4f) = v.wxyz;
-export fn arbg(v: gvec4f) = v.wxzy;
-export fn agrb(v: gvec4f) = v.wyxz;
-export fn agbr(v: gvec4f) = v.wyzx;
-export fn abrg(v: gvec4f) = v.wzxy;
-export fn abgr(v: gvec4f) = v.wzyx;
+fn xyzw(v: gvec4f) = gvec44f(v, '.xyzw'); // 1234
+fn xywz(v: gvec4f) = gvec44f(v, '.xywz'); // 1243
+fn xzyw(v: gvec4f) = gvec44f(v, '.xzyw'); // 1324
+fn xzwy(v: gvec4f) = gvec44f(v, '.xzwy'); // 1342
+fn xwyz(v: gvec4f) = gvec44f(v, '.xwyz'); // 1423
+fn xwzy(v: gvec4f) = gvec44f(v, '.xwzy'); // 1432
+fn yxzw(v: gvec4f) = gvec44f(v, '.yxzw'); // 2134
+fn yxwz(v: gvec4f) = gvec44f(v, '.yxwz'); // 2143
+fn yzxw(v: gvec4f) = gvec44f(v, '.yzxw'); // 2314
+fn yzwx(v: gvec4f) = gvec44f(v, '.yzwx'); // 2341
+fn ywxz(v: gvec4f) = gvec44f(v, '.ywxz'); // 2413
+fn ywzx(v: gvec4f) = gvec44f(v, '.ywzx'); // 2431
+fn zxyw(v: gvec4f) = gvec44f(v, '.zxyw'); // 3124
+fn zxwy(v: gvec4f) = gvec44f(v, '.zxwy'); // 3142
+fn zyxw(v: gvec4f) = gvec44f(v, '.zyxw'); // 3214
+fn zywx(v: gvec4f) = gvec44f(v, '.zywx'); // 3241
+fn zwxy(v: gvec4f) = gvec44f(v, '.zwxy'); // 3412
+fn zwyx(v: gvec4f) = gvec44f(v, '.zwyx'); // 3421
+fn wxyz(v: gvec4f) = gvec44f(v, '.wxyz'); // 4123
+fn wxzy(v: gvec4f) = gvec44f(v, '.wxzy'); // 4132
+fn wyxz(v: gvec4f) = gvec44f(v, '.wyxz'); // 4213
+fn wyzx(v: gvec4f) = gvec44f(v, '.wyzx'); // 4231
+fn wzxy(v: gvec4f) = gvec44f(v, '.wzxy'); // 4312
+fn wzyx(v: gvec4f) = gvec44f(v, '.wzyx'); // 4321
+fn ijkl(v: gvec4f) = v.xyzw;
+fn ijlk(v: gvec4f) = v.xywz;
+fn ikjl(v: gvec4f) = v.xzyw;
+fn iklj(v: gvec4f) = v.xzwy;
+fn iljk(v: gvec4f) = v.xwyz;
+fn ilkj(v: gvec4f) = v.xwzy;
+fn jikl(v: gvec4f) = v.yxzw;
+fn jilk(v: gvec4f) = v.yxwz;
+fn jkil(v: gvec4f) = v.yzxw;
+fn jkli(v: gvec4f) = v.yzwx;
+fn jlik(v: gvec4f) = v.ywxz;
+fn jlki(v: gvec4f) = v.ywzx;
+fn kijl(v: gvec4f) = v.zxyw;
+fn kilj(v: gvec4f) = v.zxwy;
+fn kjil(v: gvec4f) = v.zyxw;
+fn kjli(v: gvec4f) = v.zywx;
+fn klij(v: gvec4f) = v.zwxy;
+fn klji(v: gvec4f) = v.zwyx;
+fn lijk(v: gvec4f) = v.wxyz;
+fn likj(v: gvec4f) = v.wxzy;
+fn ljik(v: gvec4f) = v.wyxz;
+fn ljki(v: gvec4f) = v.wyzx;
+fn lkij(v: gvec4f) = v.wzxy;
+fn lkji(v: gvec4f) = v.wzyx;
+fn rgba(v: gvec4f) = v.xyzw;
+fn rgab(v: gvec4f) = v.xywz;
+fn rbga(v: gvec4f) = v.xzyw;
+fn rbag(v: gvec4f) = v.xzwy;
+fn ragb(v: gvec4f) = v.xwyz;
+fn rabg(v: gvec4f) = v.xwzy;
+fn grba(v: gvec4f) = v.yxzw;
+fn grab(v: gvec4f) = v.yxwz;
+fn gbra(v: gvec4f) = v.yzxw;
+fn gbar(v: gvec4f) = v.yzwx;
+fn garb(v: gvec4f) = v.ywxz;
+fn gabr(v: gvec4f) = v.ywzx;
+fn argb(v: gvec4f) = v.wxyz;
+fn arbg(v: gvec4f) = v.wxzy;
+fn agrb(v: gvec4f) = v.wyxz;
+fn agbr(v: gvec4f) = v.wyzx;
+fn abrg(v: gvec4f) = v.wzxy;
+fn abgr(v: gvec4f) = v.wzyx;
 
-export fn x(v: gvec4b) {
+fn x(v: gvec4b) {
   let varName = v.varName.concat('.x');
   return gbool(varName, v.statements, v.buffers);
 }
-export fn y(v: gvec4b) {
+fn y(v: gvec4b) {
   let varName = v.varName.concat('.y');
   return gbool(varName, v.statements, v.buffers);
 }
-export fn z(v: gvec4b) {
+fn z(v: gvec4b) {
   let varName = v.varName.concat('.z');
   return gbool(varName, v.statements, v.buffers);
 }
-export fn w(v: gvec4b) {
+fn w(v: gvec4b) {
   let varName = v.varName.concat('.w');
   return gbool(varName, v.statements, v.buffers);
 }
-export fn i(v: gvec4b) = v.x;
-export fn j(v: gvec4b) = v.y;
-export fn k(v: gvec4b) = v.z;
-export fn l(v: gvec4b) = v.w;
-export fn r(v: gvec4b) = v.x;
-export fn g(v: gvec4b) = v.y;
-export fn b(v: gvec4b) = v.z;
-export fn a(v: gvec4b) = v.w;
+fn i(v: gvec4b) = v.x;
+fn j(v: gvec4b) = v.y;
+fn k(v: gvec4b) = v.z;
+fn l(v: gvec4b) = v.w;
+fn r(v: gvec4b) = v.x;
+fn g(v: gvec4b) = v.y;
+fn b(v: gvec4b) = v.z;
+fn a(v: gvec4b) = v.w;
 
 fn gvec42b(v: gvec4b, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec2b(varName, v.statements, v.buffers);
 }
-export fn xy(v: gvec4b) = gvec42b(v, '.xy');
-export fn yx(v: gvec4b) = gvec42b(v, '.yx');
-export fn xz(v: gvec4b) = gvec42b(v, '.xz');
-export fn zx(v: gvec4b) = gvec42b(v, '.zx');
-export fn xw(v: gvec4b) = gvec42b(v, '.xw');
-export fn wx(v: gvec4b) = gvec42b(v, '.wx');
-export fn yz(v: gvec4b) = gvec42b(v, '.yz');
-export fn zy(v: gvec4b) = gvec42b(v, '.zy');
-export fn yw(v: gvec4b) = gvec42b(v, '.yw');
-export fn wy(v: gvec4b) = gvec42b(v, '.wy');
-export fn zw(v: gvec4b) = gvec42b(v, '.zw');
-export fn wz(v: gvec4b) = gvec42b(v, '.wz');
-export fn ij(v: gvec4b) = v.xy;
-export fn ji(v: gvec4b) = v.yx;
-export fn ik(v: gvec4b) = v.xz;
-export fn ki(v: gvec4b) = v.zx;
-export fn il(v: gvec4b) = v.xw;
-export fn li(v: gvec4b) = v.wx;
-export fn jk(v: gvec4b) = v.yz;
-export fn kj(v: gvec4b) = v.zy;
-export fn jl(v: gvec4b) = v.yw;
-export fn lj(v: gvec4b) = v.wy;
-export fn kl(v: gvec4b) = v.zw;
-export fn lk(v: gvec4b) = v.wz;
-export fn rg(v: gvec4b) = v.xy;
-export fn gr(v: gvec4b) = v.yx;
-export fn rb(v: gvec4b) = v.xz;
-export fn br(v: gvec4b) = v.zx;
-export fn ra(v: gvec4b) = v.xw;
-export fn ar(v: gvec4b) = v.wx;
-export fn gb(v: gvec4b) = v.yz;
-export fn bg(v: gvec4b) = v.zy;
-export fn ga(v: gvec4b) = v.yw;
-export fn ag(v: gvec4b) = v.wy;
-export fn ba(v: gvec4b) = v.zw;
-export fn ab(v: gvec4b) = v.wz;
+fn xy(v: gvec4b) = gvec42b(v, '.xy');
+fn yx(v: gvec4b) = gvec42b(v, '.yx');
+fn xz(v: gvec4b) = gvec42b(v, '.xz');
+fn zx(v: gvec4b) = gvec42b(v, '.zx');
+fn xw(v: gvec4b) = gvec42b(v, '.xw');
+fn wx(v: gvec4b) = gvec42b(v, '.wx');
+fn yz(v: gvec4b) = gvec42b(v, '.yz');
+fn zy(v: gvec4b) = gvec42b(v, '.zy');
+fn yw(v: gvec4b) = gvec42b(v, '.yw');
+fn wy(v: gvec4b) = gvec42b(v, '.wy');
+fn zw(v: gvec4b) = gvec42b(v, '.zw');
+fn wz(v: gvec4b) = gvec42b(v, '.wz');
+fn ij(v: gvec4b) = v.xy;
+fn ji(v: gvec4b) = v.yx;
+fn ik(v: gvec4b) = v.xz;
+fn ki(v: gvec4b) = v.zx;
+fn il(v: gvec4b) = v.xw;
+fn li(v: gvec4b) = v.wx;
+fn jk(v: gvec4b) = v.yz;
+fn kj(v: gvec4b) = v.zy;
+fn jl(v: gvec4b) = v.yw;
+fn lj(v: gvec4b) = v.wy;
+fn kl(v: gvec4b) = v.zw;
+fn lk(v: gvec4b) = v.wz;
+fn rg(v: gvec4b) = v.xy;
+fn gr(v: gvec4b) = v.yx;
+fn rb(v: gvec4b) = v.xz;
+fn br(v: gvec4b) = v.zx;
+fn ra(v: gvec4b) = v.xw;
+fn ar(v: gvec4b) = v.wx;
+fn gb(v: gvec4b) = v.yz;
+fn bg(v: gvec4b) = v.zy;
+fn ga(v: gvec4b) = v.yw;
+fn ag(v: gvec4b) = v.wy;
+fn ba(v: gvec4b) = v.zw;
+fn ab(v: gvec4b) = v.wz;
 
 fn gvec43b(v: gvec4b, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
@@ -3444,165 +3479,165 @@ fn gvec43b(v: gvec4b, a: string) {
   return gvec3b(varName, v.statements, v.buffers);
 }
 // 1 = x, i, r; 2 = y, j, g; 3 = z, k, b; 4 = w, l, a
-export fn xyz(v: gvec4b) = gvec43b(v, '.xyz'); // 123
-export fn xyw(v: gvec4b) = gvec43b(v, '.xyw'); // 124
-export fn xzy(v: gvec4b) = gvec43b(v, '.xzy'); // 132
-export fn xzw(v: gvec4b) = gvec43b(v, '.xzw'); // 134
-export fn xwy(v: gvec4b) = gvec43b(v, '.xwy'); // 142
-export fn xwz(v: gvec4b) = gvec43b(v, '.xwz'); // 143
-export fn yxz(v: gvec4b) = gvec43b(v, '.yxz'); // 213
-export fn yxw(v: gvec4b) = gvec43b(v, '.yxw'); // 214
-export fn yzx(v: gvec4b) = gvec43b(v, '.yzx'); // 231
-export fn yzw(v: gvec4b) = gvec43b(v, '.yzw'); // 234
-export fn ywx(v: gvec4b) = gvec43b(v, '.ywx'); // 241
-export fn ywz(v: gvec4b) = gvec43b(v, '.ywz'); // 243
-export fn zxy(v: gvec4b) = gvec43b(v, '.zxy'); // 312
-export fn zxw(v: gvec4b) = gvec43b(v, '.zxw'); // 314
-export fn zyx(v: gvec4b) = gvec43b(v, '.zyx'); // 321
-export fn zyw(v: gvec4b) = gvec43b(v, '.zyw'); // 324
-export fn zwx(v: gvec4b) = gvec43b(v, '.zwx'); // 341
-export fn zwy(v: gvec4b) = gvec43b(v, '.zwy'); // 342
-export fn wxy(v: gvec4b) = gvec43b(v, '.wxy'); // 412
-export fn wxz(v: gvec4b) = gvec43b(v, '.wxz'); // 413
-export fn wyx(v: gvec4b) = gvec43b(v, '.wyx'); // 421
-export fn wyz(v: gvec4b) = gvec43b(v, '.wyz'); // 423
-export fn wzx(v: gvec4b) = gvec43b(v, '.wzx'); // 431
-export fn wzy(v: gvec4b) = gvec43b(v, '.wzy'); // 432
-export fn ijk(v: gvec4b) = v.xyz;
-export fn ijl(v: gvec4b) = v.xyw;
-export fn ikj(v: gvec4b) = v.xzy;
-export fn ikl(v: gvec4b) = v.xzw;
-export fn ilj(v: gvec4b) = v.xwy;
-export fn ilk(v: gvec4b) = v.xwz;
-export fn jik(v: gvec4b) = v.yxz;
-export fn jil(v: gvec4b) = v.yxw;
-export fn jki(v: gvec4b) = v.yzx;
-export fn jkl(v: gvec4b) = v.yzw;
-export fn jli(v: gvec4b) = v.ywx;
-export fn jlk(v: gvec4b) = v.ywz;
-export fn kij(v: gvec4b) = v.zxy;
-export fn kil(v: gvec4b) = v.zxw;
-export fn kji(v: gvec4b) = v.zyx;
-export fn kjl(v: gvec4b) = v.zyw;
-export fn kli(v: gvec4b) = v.zwx;
-export fn klj(v: gvec4b) = v.zwy;
-export fn lij(v: gvec4b) = v.wxy;
-export fn lik(v: gvec4b) = v.wxz;
-export fn lji(v: gvec4b) = v.wyx;
-export fn ljk(v: gvec4b) = v.wyz;
-export fn lki(v: gvec4b) = v.wzx;
-export fn lkj(v: gvec4b) = v.wzy;
-export fn rgb(v: gvec4b) = v.xyz;
-export fn rga(v: gvec4b) = v.xyw;
-export fn rbg(v: gvec4b) = v.xzy;
-export fn rba(v: gvec4b) = v.xzw;
-export fn rag(v: gvec4b) = v.xwy;
-export fn rab(v: gvec4b) = v.xwz;
-export fn grb(v: gvec4b) = v.yxz;
-export fn gra(v: gvec4b) = v.yxw;
-export fn gbr(v: gvec4b) = v.yzx;
-export fn gba(v: gvec4b) = v.yzw;
-export fn gar(v: gvec4b) = v.ywx;
-export fn gab(v: gvec4b) = v.ywz;
-export fn brg(v: gvec4b) = v.zxy;
-export fn bra(v: gvec4b) = v.zxw;
-export fn bgr(v: gvec4b) = v.zyx;
-export fn bga(v: gvec4b) = v.zyw;
-export fn bar(v: gvec4b) = v.zwx;
-export fn bag(v: gvec4b) = v.zwy;
-export fn arb(v: gvec4b) = v.wxy;
-export fn arg(v: gvec4b) = v.wxz;
-export fn abr(v: gvec4b) = v.wyx;
-export fn abg(v: gvec4b) = v.wyz;
-export fn agr(v: gvec4b) = v.wzx;
-export fn agb(v: gvec4b) = v.wzy;
+fn xyz(v: gvec4b) = gvec43b(v, '.xyz'); // 123
+fn xyw(v: gvec4b) = gvec43b(v, '.xyw'); // 124
+fn xzy(v: gvec4b) = gvec43b(v, '.xzy'); // 132
+fn xzw(v: gvec4b) = gvec43b(v, '.xzw'); // 134
+fn xwy(v: gvec4b) = gvec43b(v, '.xwy'); // 142
+fn xwz(v: gvec4b) = gvec43b(v, '.xwz'); // 143
+fn yxz(v: gvec4b) = gvec43b(v, '.yxz'); // 213
+fn yxw(v: gvec4b) = gvec43b(v, '.yxw'); // 214
+fn yzx(v: gvec4b) = gvec43b(v, '.yzx'); // 231
+fn yzw(v: gvec4b) = gvec43b(v, '.yzw'); // 234
+fn ywx(v: gvec4b) = gvec43b(v, '.ywx'); // 241
+fn ywz(v: gvec4b) = gvec43b(v, '.ywz'); // 243
+fn zxy(v: gvec4b) = gvec43b(v, '.zxy'); // 312
+fn zxw(v: gvec4b) = gvec43b(v, '.zxw'); // 314
+fn zyx(v: gvec4b) = gvec43b(v, '.zyx'); // 321
+fn zyw(v: gvec4b) = gvec43b(v, '.zyw'); // 324
+fn zwx(v: gvec4b) = gvec43b(v, '.zwx'); // 341
+fn zwy(v: gvec4b) = gvec43b(v, '.zwy'); // 342
+fn wxy(v: gvec4b) = gvec43b(v, '.wxy'); // 412
+fn wxz(v: gvec4b) = gvec43b(v, '.wxz'); // 413
+fn wyx(v: gvec4b) = gvec43b(v, '.wyx'); // 421
+fn wyz(v: gvec4b) = gvec43b(v, '.wyz'); // 423
+fn wzx(v: gvec4b) = gvec43b(v, '.wzx'); // 431
+fn wzy(v: gvec4b) = gvec43b(v, '.wzy'); // 432
+fn ijk(v: gvec4b) = v.xyz;
+fn ijl(v: gvec4b) = v.xyw;
+fn ikj(v: gvec4b) = v.xzy;
+fn ikl(v: gvec4b) = v.xzw;
+fn ilj(v: gvec4b) = v.xwy;
+fn ilk(v: gvec4b) = v.xwz;
+fn jik(v: gvec4b) = v.yxz;
+fn jil(v: gvec4b) = v.yxw;
+fn jki(v: gvec4b) = v.yzx;
+fn jkl(v: gvec4b) = v.yzw;
+fn jli(v: gvec4b) = v.ywx;
+fn jlk(v: gvec4b) = v.ywz;
+fn kij(v: gvec4b) = v.zxy;
+fn kil(v: gvec4b) = v.zxw;
+fn kji(v: gvec4b) = v.zyx;
+fn kjl(v: gvec4b) = v.zyw;
+fn kli(v: gvec4b) = v.zwx;
+fn klj(v: gvec4b) = v.zwy;
+fn lij(v: gvec4b) = v.wxy;
+fn lik(v: gvec4b) = v.wxz;
+fn lji(v: gvec4b) = v.wyx;
+fn ljk(v: gvec4b) = v.wyz;
+fn lki(v: gvec4b) = v.wzx;
+fn lkj(v: gvec4b) = v.wzy;
+fn rgb(v: gvec4b) = v.xyz;
+fn rga(v: gvec4b) = v.xyw;
+fn rbg(v: gvec4b) = v.xzy;
+fn rba(v: gvec4b) = v.xzw;
+fn rag(v: gvec4b) = v.xwy;
+fn rab(v: gvec4b) = v.xwz;
+fn grb(v: gvec4b) = v.yxz;
+fn gra(v: gvec4b) = v.yxw;
+fn gbr(v: gvec4b) = v.yzx;
+fn gba(v: gvec4b) = v.yzw;
+fn gar(v: gvec4b) = v.ywx;
+fn gab(v: gvec4b) = v.ywz;
+fn brg(v: gvec4b) = v.zxy;
+fn bra(v: gvec4b) = v.zxw;
+fn bgr(v: gvec4b) = v.zyx;
+fn bga(v: gvec4b) = v.zyw;
+fn bar(v: gvec4b) = v.zwx;
+fn bag(v: gvec4b) = v.zwy;
+fn arb(v: gvec4b) = v.wxy;
+fn arg(v: gvec4b) = v.wxz;
+fn abr(v: gvec4b) = v.wyx;
+fn abg(v: gvec4b) = v.wyz;
+fn agr(v: gvec4b) = v.wzx;
+fn agb(v: gvec4b) = v.wzy;
 
 fn gvec44b(v: gvec4b, a: string) {
   // TODO: Add some type safety on the kinds of strings you can pass in here
   let varName = v.varName.concat(a);
   return gvec4b(varName, v.statements, v.buffers);
 }
-export fn xyzw(v: gvec4b) = gvec44b(v, '.xyzw'); // 1234
-export fn xywz(v: gvec4b) = gvec44b(v, '.xywz'); // 1243
-export fn xzyw(v: gvec4b) = gvec44b(v, '.xzyw'); // 1324
-export fn xzwy(v: gvec4b) = gvec44b(v, '.xzwy'); // 1342
-export fn xwyz(v: gvec4b) = gvec44b(v, '.xwyz'); // 1423
-export fn xwzy(v: gvec4b) = gvec44b(v, '.xwzy'); // 1432
-export fn yxzw(v: gvec4b) = gvec44b(v, '.yxzw'); // 2134
-export fn yxwz(v: gvec4b) = gvec44b(v, '.yxwz'); // 2143
-export fn yzxw(v: gvec4b) = gvec44b(v, '.yzxw'); // 2314
-export fn yzwx(v: gvec4b) = gvec44b(v, '.yzwx'); // 2341
-export fn ywxz(v: gvec4b) = gvec44b(v, '.ywxz'); // 2413
-export fn ywzx(v: gvec4b) = gvec44b(v, '.ywzx'); // 2431
-export fn zxyw(v: gvec4b) = gvec44b(v, '.zxyw'); // 3124
-export fn zxwy(v: gvec4b) = gvec44b(v, '.zxwy'); // 3142
-export fn zyxw(v: gvec4b) = gvec44b(v, '.zyxw'); // 3214
-export fn zywx(v: gvec4b) = gvec44b(v, '.zywx'); // 3241
-export fn zwxy(v: gvec4b) = gvec44b(v, '.zwxy'); // 3412
-export fn zwyx(v: gvec4b) = gvec44b(v, '.zwyx'); // 3421
-export fn wxyz(v: gvec4b) = gvec44b(v, '.wxyz'); // 4123
-export fn wxzy(v: gvec4b) = gvec44b(v, '.wxzy'); // 4132
-export fn wyxz(v: gvec4b) = gvec44b(v, '.wyxz'); // 4213
-export fn wyzx(v: gvec4b) = gvec44b(v, '.wyzx'); // 4231
-export fn wzxy(v: gvec4b) = gvec44b(v, '.wzxy'); // 4312
-export fn wzyx(v: gvec4b) = gvec44b(v, '.wzyx'); // 4321
-export fn ijkl(v: gvec4b) = v.xyzw;
-export fn ijlk(v: gvec4b) = v.xywz;
-export fn ikjl(v: gvec4b) = v.xzyw;
-export fn iklj(v: gvec4b) = v.xzwy;
-export fn iljk(v: gvec4b) = v.xwyz;
-export fn ilkj(v: gvec4b) = v.xwzy;
-export fn jikl(v: gvec4b) = v.yxzw;
-export fn jilk(v: gvec4b) = v.yxwz;
-export fn jkil(v: gvec4b) = v.yzxw;
-export fn jkli(v: gvec4b) = v.yzwx;
-export fn jlik(v: gvec4b) = v.ywxz;
-export fn jlki(v: gvec4b) = v.ywzx;
-export fn kijl(v: gvec4b) = v.zxyw;
-export fn kilj(v: gvec4b) = v.zxwy;
-export fn kjil(v: gvec4b) = v.zyxw;
-export fn kjli(v: gvec4b) = v.zywx;
-export fn klij(v: gvec4b) = v.zwxy;
-export fn klji(v: gvec4b) = v.zwyx;
-export fn lijk(v: gvec4b) = v.wxyz;
-export fn likj(v: gvec4b) = v.wxzy;
-export fn ljik(v: gvec4b) = v.wyxz;
-export fn ljki(v: gvec4b) = v.wyzx;
-export fn lkij(v: gvec4b) = v.wzxy;
-export fn lkji(v: gvec4b) = v.wzyx;
-export fn rgba(v: gvec4b) = v.xyzw;
-export fn rgab(v: gvec4b) = v.xywz;
-export fn rbga(v: gvec4b) = v.xzyw;
-export fn rbag(v: gvec4b) = v.xzwy;
-export fn ragb(v: gvec4b) = v.xwyz;
-export fn rabg(v: gvec4b) = v.xwzy;
-export fn grba(v: gvec4b) = v.yxzw;
-export fn grab(v: gvec4b) = v.yxwz;
-export fn gbra(v: gvec4b) = v.yzxw;
-export fn gbar(v: gvec4b) = v.yzwx;
-export fn garb(v: gvec4b) = v.ywxz;
-export fn gabr(v: gvec4b) = v.ywzx;
-export fn brga(v: gvec4b) = v.zxyw;
-export fn brag(v: gvec4b) = v.zxwy;
-export fn bgra(v: gvec4b) = v.zyxw;
-export fn bgar(v: gvec4b) = v.zywx;
-export fn barg(v: gvec4b) = v.zwxy;
-export fn bagr(v: gvec4b) = v.zwyx;
-export fn argb(v: gvec4b) = v.wxyz;
-export fn arbg(v: gvec4b) = v.wxzy;
-export fn agrb(v: gvec4b) = v.wyxz;
-export fn agbr(v: gvec4b) = v.wyzx;
-export fn abrg(v: gvec4b) = v.wzxy;
-export fn abgr(v: gvec4b) = v.wzyx;
+fn xyzw(v: gvec4b) = gvec44b(v, '.xyzw'); // 1234
+fn xywz(v: gvec4b) = gvec44b(v, '.xywz'); // 1243
+fn xzyw(v: gvec4b) = gvec44b(v, '.xzyw'); // 1324
+fn xzwy(v: gvec4b) = gvec44b(v, '.xzwy'); // 1342
+fn xwyz(v: gvec4b) = gvec44b(v, '.xwyz'); // 1423
+fn xwzy(v: gvec4b) = gvec44b(v, '.xwzy'); // 1432
+fn yxzw(v: gvec4b) = gvec44b(v, '.yxzw'); // 2134
+fn yxwz(v: gvec4b) = gvec44b(v, '.yxwz'); // 2143
+fn yzxw(v: gvec4b) = gvec44b(v, '.yzxw'); // 2314
+fn yzwx(v: gvec4b) = gvec44b(v, '.yzwx'); // 2341
+fn ywxz(v: gvec4b) = gvec44b(v, '.ywxz'); // 2413
+fn ywzx(v: gvec4b) = gvec44b(v, '.ywzx'); // 2431
+fn zxyw(v: gvec4b) = gvec44b(v, '.zxyw'); // 3124
+fn zxwy(v: gvec4b) = gvec44b(v, '.zxwy'); // 3142
+fn zyxw(v: gvec4b) = gvec44b(v, '.zyxw'); // 3214
+fn zywx(v: gvec4b) = gvec44b(v, '.zywx'); // 3241
+fn zwxy(v: gvec4b) = gvec44b(v, '.zwxy'); // 3412
+fn zwyx(v: gvec4b) = gvec44b(v, '.zwyx'); // 3421
+fn wxyz(v: gvec4b) = gvec44b(v, '.wxyz'); // 4123
+fn wxzy(v: gvec4b) = gvec44b(v, '.wxzy'); // 4132
+fn wyxz(v: gvec4b) = gvec44b(v, '.wyxz'); // 4213
+fn wyzx(v: gvec4b) = gvec44b(v, '.wyzx'); // 4231
+fn wzxy(v: gvec4b) = gvec44b(v, '.wzxy'); // 4312
+fn wzyx(v: gvec4b) = gvec44b(v, '.wzyx'); // 4321
+fn ijkl(v: gvec4b) = v.xyzw;
+fn ijlk(v: gvec4b) = v.xywz;
+fn ikjl(v: gvec4b) = v.xzyw;
+fn iklj(v: gvec4b) = v.xzwy;
+fn iljk(v: gvec4b) = v.xwyz;
+fn ilkj(v: gvec4b) = v.xwzy;
+fn jikl(v: gvec4b) = v.yxzw;
+fn jilk(v: gvec4b) = v.yxwz;
+fn jkil(v: gvec4b) = v.yzxw;
+fn jkli(v: gvec4b) = v.yzwx;
+fn jlik(v: gvec4b) = v.ywxz;
+fn jlki(v: gvec4b) = v.ywzx;
+fn kijl(v: gvec4b) = v.zxyw;
+fn kilj(v: gvec4b) = v.zxwy;
+fn kjil(v: gvec4b) = v.zyxw;
+fn kjli(v: gvec4b) = v.zywx;
+fn klij(v: gvec4b) = v.zwxy;
+fn klji(v: gvec4b) = v.zwyx;
+fn lijk(v: gvec4b) = v.wxyz;
+fn likj(v: gvec4b) = v.wxzy;
+fn ljik(v: gvec4b) = v.wyxz;
+fn ljki(v: gvec4b) = v.wyzx;
+fn lkij(v: gvec4b) = v.wzxy;
+fn lkji(v: gvec4b) = v.wzyx;
+fn rgba(v: gvec4b) = v.xyzw;
+fn rgab(v: gvec4b) = v.xywz;
+fn rbga(v: gvec4b) = v.xzyw;
+fn rbag(v: gvec4b) = v.xzwy;
+fn ragb(v: gvec4b) = v.xwyz;
+fn rabg(v: gvec4b) = v.xwzy;
+fn grba(v: gvec4b) = v.yxzw;
+fn grab(v: gvec4b) = v.yxwz;
+fn gbra(v: gvec4b) = v.yzxw;
+fn gbar(v: gvec4b) = v.yzwx;
+fn garb(v: gvec4b) = v.ywxz;
+fn gabr(v: gvec4b) = v.ywzx;
+fn brga(v: gvec4b) = v.zxyw;
+fn brag(v: gvec4b) = v.zxwy;
+fn bgra(v: gvec4b) = v.zyxw;
+fn bgar(v: gvec4b) = v.zywx;
+fn barg(v: gvec4b) = v.zwxy;
+fn bagr(v: gvec4b) = v.zwyx;
+fn argb(v: gvec4b) = v.wxyz;
+fn arbg(v: gvec4b) = v.wxzy;
+fn agrb(v: gvec4b) = v.wyxz;
+fn agbr(v: gvec4b) = v.wyzx;
+fn abrg(v: gvec4b) = v.wzxy;
+fn abgr(v: gvec4b) = v.wzyx;
 
 // TODO: Improve GBuffer to support other buffer types
-export fn get(gb: GBuffer, i: gu32) {
+fn get(gb: GBuffer, i: gu32) {
   let statement = gb.id.concat('[').concat(i.varName).concat(']');
   let buffers = i.buffers.union(Set(gb));
   return gi32(statement, i.statements, buffers);
 }
 
-export fn store(a: gi32, b: gi32) {
+fn store(a: gi32, b: gi32) {
     let statement = a.varName.concat(" = ").concat(b.varName);
     let statements = a.statements.concat(b.statements).concat(Dict(statement, statement));
     let buffers = a.buffers.union(b.buffers);
@@ -3615,40 +3650,40 @@ fn gneg{I}(v: I) {
   let varName = '(-'.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn neg(v: gi32) = gneg{gi32}(v);
-export fn neg(v: gf32) = gneg{gf32}(v);
-export fn neg(v: gvec2i) = gneg{gvec2i}(v);
-export fn neg(v: gvec2f) = gneg{gvec2f}(v);
-export fn neg(v: gvec3i) = gneg{gvec3i}(v);
-export fn neg(v: gvec3f) = gneg{gvec3f}(v);
-export fn neg(v: gvec4i) = gneg{gvec4i}(v);
-export fn neg(v: gvec4f) = gneg{gvec4f}(v);
+fn neg(v: gi32) = gneg{gi32}(v);
+fn neg(v: gf32) = gneg{gf32}(v);
+fn neg(v: gvec2i) = gneg{gvec2i}(v);
+fn neg(v: gvec2f) = gneg{gvec2f}(v);
+fn neg(v: gvec3i) = gneg{gvec3i}(v);
+fn neg(v: gvec3f) = gneg{gvec3f}(v);
+fn neg(v: gvec4i) = gneg{gvec4i}(v);
+fn neg(v: gvec4f) = gneg{gvec4f}(v);
 
 fn gabs{I}(v: I) {
   let varName = 'abs('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn abs(v: gi32) = gabs{gi32}(v);
-export fn abs(v: gf32) = gabs{gf32}(v);
-export fn abs(v: gvec2i) = gabs{gvec2i}(v);
-export fn abs(v: gvec2f) = gabs{gvec2f}(v);
-export fn abs(v: gvec3i) = gabs{gvec3i}(v);
-export fn abs(v: gvec3f) = gabs{gvec3f}(v);
-export fn abs(v: gvec4i) = gabs{gvec4i}(v);
-export fn abs(v: gvec4f) = gabs{gvec4f}(v);
+fn abs(v: gi32) = gabs{gi32}(v);
+fn abs(v: gf32) = gabs{gf32}(v);
+fn abs(v: gvec2i) = gabs{gvec2i}(v);
+fn abs(v: gvec2f) = gabs{gvec2f}(v);
+fn abs(v: gvec3i) = gabs{gvec3i}(v);
+fn abs(v: gvec3f) = gabs{gvec3f}(v);
+fn abs(v: gvec4i) = gabs{gvec4i}(v);
+fn abs(v: gvec4f) = gabs{gvec4f}(v);
 
 fn gclz{I}(v: I) {
   let varName = 'countLeadingZeros('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn clz(v: gi32) = gclz{gi32}(v);
-export fn clz(v: gu32) = gclz{gu32}(v);
-export fn clz(v: gvec2i) = gclz{gvec2i}(v);
-export fn clz(v: gvec2u) = gclz{gvec2u}(v);
-export fn clz(v: gvec3i) = gclz{gvec3i}(v);
-export fn clz(v: gvec3u) = gclz{gvec3u}(v);
-export fn clz(v: gvec4i) = gclz{gvec4i}(v);
-export fn clz(v: gvec4u) = gclz{gvec4u}(v);
+fn clz(v: gi32) = gclz{gi32}(v);
+fn clz(v: gu32) = gclz{gu32}(v);
+fn clz(v: gvec2i) = gclz{gvec2i}(v);
+fn clz(v: gvec2u) = gclz{gvec2u}(v);
+fn clz(v: gvec3i) = gclz{gvec3i}(v);
+fn clz(v: gvec3u) = gclz{gvec3u}(v);
+fn clz(v: gvec4i) = gclz{gvec4i}(v);
+fn clz(v: gvec4u) = gclz{gvec4u}(v);
 
 fn gadd{A, B}(a: A, b: B) {
   let varName = '('.concat(a.varName).concat(' + ').concat(b.varName).concat(')');
@@ -3656,64 +3691,64 @@ fn gadd{A, B}(a: A, b: B) {
   let buffers = a.buffers.union(b.buffers);
   return {A}(varName, statements, buffers);
 }
-export fn add(a: gu32, b: gu32) = gadd(a, b);
-export fn add{T}(a: gu32, b: T) = add(a, b.gu32);
-export fn add{T}(a: T, b: gu32) = add(a.gu32, b);
+fn add(a: gu32, b: gu32) = gadd(a, b);
+fn add{T}(a: gu32, b: T) = add(a, b.gu32);
+fn add{T}(a: T, b: gu32) = add(a.gu32, b);
 
-export fn add(a: gi32, b: gi32) = gadd(a, b);
-export fn add{T}(a: gi32, b: T) = add(a, b.gi32);
-export fn add{T}(a: T, b: gi32) = add(a.gi32, b);
+fn add(a: gi32, b: gi32) = gadd(a, b);
+fn add{T}(a: gi32, b: T) = add(a, b.gi32);
+fn add{T}(a: T, b: gi32) = add(a.gi32, b);
 
-export fn add(a: gf32, b: gf32) = gadd(a, b);
-export fn add{T}(a: gf32, b: T) = add(a, b.gf32);
-export fn add{T}(a: T, b: gf32) = add(a.gf32, b);
+fn add(a: gf32, b: gf32) = gadd(a, b);
+fn add{T}(a: gf32, b: T) = add(a, b.gf32);
+fn add{T}(a: T, b: gf32) = add(a.gf32, b);
 
-export fn add(a: gvec2u, b: gvec2u) = gadd(a, b);
-export fn add(a: gvec2u, b: gu32) = gadd(a, b);
+fn add(a: gvec2u, b: gvec2u) = gadd(a, b);
+fn add(a: gvec2u, b: gu32) = gadd(a, b);
 // Because addition is commutative, I can do this
-export fn add(a: gu32, b: gvec2u) = gadd(b, a);
+fn add(a: gu32, b: gvec2u) = gadd(b, a);
 
-export fn add(a: gvec2i, b: gvec2i) = gadd(a, b);
-export fn add(a: gvec2i, b: gi32) = gadd(a, b);
-export fn add(a: gi32, b: gvec2i) = gadd(b, a);
+fn add(a: gvec2i, b: gvec2i) = gadd(a, b);
+fn add(a: gvec2i, b: gi32) = gadd(a, b);
+fn add(a: gi32, b: gvec2i) = gadd(b, a);
 
-export fn add(a: gvec2f, b: gvec2f) = gadd(a, b);
-export fn add(a: gvec2f, b: gf32) = gadd(a, b);
-export fn add(a: gf32, b: gvec2f) = gadd(b, a);
+fn add(a: gvec2f, b: gvec2f) = gadd(a, b);
+fn add(a: gvec2f, b: gf32) = gadd(a, b);
+fn add(a: gf32, b: gvec2f) = gadd(b, a);
 
-export fn add(a: gvec3u, b: gvec3u) = gadd(a, b);
-export fn add(a: gvec3u, b: gu32) = gadd(a, b);
-export fn add(a: gu32, b: gvec3u) = gadd(b, a);
+fn add(a: gvec3u, b: gvec3u) = gadd(a, b);
+fn add(a: gvec3u, b: gu32) = gadd(a, b);
+fn add(a: gu32, b: gvec3u) = gadd(b, a);
 
-export fn add(a: gvec3i, b: gvec3i) = gadd(a, b);
-export fn add(a: gvec3i, b: gi32) = gadd(a, b);
-export fn add(a: gi32, b: gvec3i) = gadd(b, a);
+fn add(a: gvec3i, b: gvec3i) = gadd(a, b);
+fn add(a: gvec3i, b: gi32) = gadd(a, b);
+fn add(a: gi32, b: gvec3i) = gadd(b, a);
 
-export fn add(a: gvec3f, b: gvec3f) = gadd(a, b);
-export fn add(a: gvec3f, b: gf32) = gadd(a, b);
-export fn add(a: gf32, b: gvec3f) = gadd(b, a);
+fn add(a: gvec3f, b: gvec3f) = gadd(a, b);
+fn add(a: gvec3f, b: gf32) = gadd(a, b);
+fn add(a: gf32, b: gvec3f) = gadd(b, a);
 
-export fn add(a: gvec4u, b: gvec4u) = gadd(a, b);
-export fn add(a: gvec4u, b: gu32) = gadd(a, b);
-export fn add(a: gu32, b: gvec4u) = gadd(b, a);
+fn add(a: gvec4u, b: gvec4u) = gadd(a, b);
+fn add(a: gvec4u, b: gu32) = gadd(a, b);
+fn add(a: gu32, b: gvec4u) = gadd(b, a);
 
-export fn add(a: gvec4i, b: gvec4i) = gadd(a, b);
-export fn add(a: gvec4i, b: gi32) = gadd(a, b);
-export fn add(a: gi32, b: gvec4i) = gadd(b, a);
+fn add(a: gvec4i, b: gvec4i) = gadd(a, b);
+fn add(a: gvec4i, b: gi32) = gadd(a, b);
+fn add(a: gi32, b: gvec4i) = gadd(b, a);
 
-export fn add(a: gvec4f, b: gvec4f) = gadd(a, b);
-export fn add(a: gvec4f, b: gf32) = gadd(a, b);
-export fn add(a: gf32, b: gvec4f) = gadd(b, a);
+fn add(a: gvec4f, b: gvec4f) = gadd(a, b);
+fn add(a: gvec4f, b: gf32) = gadd(a, b);
+fn add(a: gf32, b: gvec4f) = gadd(b, a);
 
-export fn add(a: gmat2x2f, b: gmat2x2f) = gadd(a, b);
-export fn add(a: gmat2x3f, b: gmat2x3f) = gadd(a, b);
-export fn add(a: gmat2x4f, b: gmat2x4f) = gadd(a, b);
-export fn add(a: gmat3x2f, b: gmat3x2f) = gadd(a, b);
-export fn add(a: gmat3x3f, b: gmat3x3f) = gadd(a, b);
-export fn add(a: gmat3x4f, b: gmat3x4f) = gadd(a, b);
-export fn add(a: gmat4x2f, b: gmat4x2f) = gadd(a, b);
-export fn add(a: gmat4x3f, b: gmat4x3f) = gadd(a, b);
-export fn add(a: gmat4x4f, b: gmat4x4f) = gadd(a, b);
+fn add(a: gmat2x2f, b: gmat2x2f) = gadd(a, b);
+fn add(a: gmat2x3f, b: gmat2x3f) = gadd(a, b);
+fn add(a: gmat2x4f, b: gmat2x4f) = gadd(a, b);
+fn add(a: gmat3x2f, b: gmat3x2f) = gadd(a, b);
+fn add(a: gmat3x3f, b: gmat3x3f) = gadd(a, b);
+fn add(a: gmat3x4f, b: gmat3x4f) = gadd(a, b);
+fn add(a: gmat4x2f, b: gmat4x2f) = gadd(a, b);
+fn add(a: gmat4x3f, b: gmat4x3f) = gadd(a, b);
+fn add(a: gmat4x4f, b: gmat4x4f) = gadd(a, b);
 
 fn gsub{A, B}(a: A, b: B) {
   let varName = '('.concat(a.varName).concat(' - ').concat(b.varName).concat(')');
@@ -3727,63 +3762,63 @@ fn gsubRev{A, B}(a: A, b: B) {
   let buffers = a.buffers.union(b.buffers);
   return {B}(varName, statements, buffers);
 }
-export fn sub(a: gu32, b: gu32) = gsub(a, b);
-export fn sub{T}(a: gu32, b: T) = sub(a, b.gu32);
-export fn sub{T}(a: T, b: gu32) = sub(a.gu32, b);
+fn sub(a: gu32, b: gu32) = gsub(a, b);
+fn sub{T}(a: gu32, b: T) = sub(a, b.gu32);
+fn sub{T}(a: T, b: gu32) = sub(a.gu32, b);
 
-export fn sub(a: gi32, b: gi32) = gsub(a, b);
-export fn sub{T}(a: gi32, b: T) = sub(a, b.gi32);
-export fn sub{T}(a: T, b: gi32) = sub(a.gi32, b);
+fn sub(a: gi32, b: gi32) = gsub(a, b);
+fn sub{T}(a: gi32, b: T) = sub(a, b.gi32);
+fn sub{T}(a: T, b: gi32) = sub(a.gi32, b);
 
-export fn sub(a: gf32, b: gf32) = gsub(a, b);
-export fn sub{T}(a: gf32, b: T) = sub(a, b.gf32);
-export fn sub{T}(a: T, b: gf32) = sub(a.gf32, b);
+fn sub(a: gf32, b: gf32) = gsub(a, b);
+fn sub{T}(a: gf32, b: T) = sub(a, b.gf32);
+fn sub{T}(a: T, b: gf32) = sub(a.gf32, b);
 
-export fn sub(a: gvec2u, b: gvec2u) = gsub(a, b);
-export fn sub(a: gvec2u, b: gu32) = gsub(a, b);
-export fn sub(a: gu32, b: gvec2u) = gsubRev(a, b);
+fn sub(a: gvec2u, b: gvec2u) = gsub(a, b);
+fn sub(a: gvec2u, b: gu32) = gsub(a, b);
+fn sub(a: gu32, b: gvec2u) = gsubRev(a, b);
 
-export fn sub(a: gvec2i, b: gvec2i) = gsub(a, b);
-export fn sub(a: gvec2i, b: gi32) = gsub(a, b);
-export fn sub(a: gi32, b: gvec2i) = gsubRev(a, b);
+fn sub(a: gvec2i, b: gvec2i) = gsub(a, b);
+fn sub(a: gvec2i, b: gi32) = gsub(a, b);
+fn sub(a: gi32, b: gvec2i) = gsubRev(a, b);
 
-export fn sub(a: gvec2f, b: gvec2f) = gsub(a, b);
-export fn sub(a: gvec2f, b: gf32) = gsub(a, b);
-export fn sub(a: gf32, b: gvec2f) = gsubRev(a, b);
+fn sub(a: gvec2f, b: gvec2f) = gsub(a, b);
+fn sub(a: gvec2f, b: gf32) = gsub(a, b);
+fn sub(a: gf32, b: gvec2f) = gsubRev(a, b);
 
-export fn sub(a: gvec3u, b: gvec3u) = gsub(a, b);
-export fn sub(a: gvec3u, b: gu32) = gsub(a, b);
-export fn sub(a: gu32, b: gvec3u) = gsubRev(a, b);
+fn sub(a: gvec3u, b: gvec3u) = gsub(a, b);
+fn sub(a: gvec3u, b: gu32) = gsub(a, b);
+fn sub(a: gu32, b: gvec3u) = gsubRev(a, b);
 
-export fn sub(a: gvec3i, b: gvec3i) = gsub(a, b);
-export fn sub(a: gvec3i, b: gi32) = gsub(a, b);
-export fn sub(a: gi32, b: gvec3i) = gsubRev(a, b);
+fn sub(a: gvec3i, b: gvec3i) = gsub(a, b);
+fn sub(a: gvec3i, b: gi32) = gsub(a, b);
+fn sub(a: gi32, b: gvec3i) = gsubRev(a, b);
 
-export fn sub(a: gvec3f, b: gvec3f) = gsub(a, b);
-export fn sub(a: gvec3f, b: gf32) = gsub(a, b);
-export fn sub(a: gf32, b: gvec3f) = gsubRev(a, b);
+fn sub(a: gvec3f, b: gvec3f) = gsub(a, b);
+fn sub(a: gvec3f, b: gf32) = gsub(a, b);
+fn sub(a: gf32, b: gvec3f) = gsubRev(a, b);
 
-export fn sub(a: gvec4u, b: gvec4u) = gsub(a, b);
-export fn sub(a: gvec4u, b: gu32) = gsub(a, b);
-export fn sub(a: gu32, b: gvec4u) = gsubRev(a, b);
+fn sub(a: gvec4u, b: gvec4u) = gsub(a, b);
+fn sub(a: gvec4u, b: gu32) = gsub(a, b);
+fn sub(a: gu32, b: gvec4u) = gsubRev(a, b);
 
-export fn sub(a: gvec4i, b: gvec4i) = gsub(a, b);
-export fn sub(a: gvec4i, b: gi32) = gsub(a, b);
-export fn sub(a: gi32, b: gvec4i) = gsubRev(a, b);
+fn sub(a: gvec4i, b: gvec4i) = gsub(a, b);
+fn sub(a: gvec4i, b: gi32) = gsub(a, b);
+fn sub(a: gi32, b: gvec4i) = gsubRev(a, b);
 
-export fn sub(a: gvec4f, b: gvec4f) = gsub(a, b);
-export fn sub(a: gvec4f, b: gf32) = gsub(a, b);
-export fn sub(a: gf32, b: gvec4f) = gsubRev(a, b);
+fn sub(a: gvec4f, b: gvec4f) = gsub(a, b);
+fn sub(a: gvec4f, b: gf32) = gsub(a, b);
+fn sub(a: gf32, b: gvec4f) = gsubRev(a, b);
 
-export fn sub(a: gmat2x2f, b: gmat2x2f) = gsub(a, b);
-export fn sub(a: gmat2x3f, b: gmat2x3f) = gsub(a, b);
-export fn sub(a: gmat2x4f, b: gmat2x4f) = gsub(a, b);
-export fn sub(a: gmat3x2f, b: gmat3x2f) = gsub(a, b);
-export fn sub(a: gmat3x3f, b: gmat3x3f) = gsub(a, b);
-export fn sub(a: gmat3x4f, b: gmat3x4f) = gsub(a, b);
-export fn sub(a: gmat4x2f, b: gmat4x2f) = gsub(a, b);
-export fn sub(a: gmat4x3f, b: gmat4x3f) = gsub(a, b);
-export fn sub(a: gmat4x4f, b: gmat4x4f) = gsub(a, b);
+fn sub(a: gmat2x2f, b: gmat2x2f) = gsub(a, b);
+fn sub(a: gmat2x3f, b: gmat2x3f) = gsub(a, b);
+fn sub(a: gmat2x4f, b: gmat2x4f) = gsub(a, b);
+fn sub(a: gmat3x2f, b: gmat3x2f) = gsub(a, b);
+fn sub(a: gmat3x3f, b: gmat3x3f) = gsub(a, b);
+fn sub(a: gmat3x4f, b: gmat3x4f) = gsub(a, b);
+fn sub(a: gmat4x2f, b: gmat4x2f) = gsub(a, b);
+fn sub(a: gmat4x3f, b: gmat4x3f) = gsub(a, b);
+fn sub(a: gmat4x4f, b: gmat4x4f) = gsub(a, b);
 
 fn gmul{A, B, C}(a: A, b: B) {
   let varName = '('.concat(a.varName).concat(' * ').concat(b.varName).concat(')');
@@ -3792,127 +3827,127 @@ fn gmul{A, B, C}(a: A, b: B) {
   return {C}(varName, statements, buffers);
 }
 fn gmul{A, B}(a: A, b: B) = gmul{A, B, A}(a, b);
-export fn mul(a: gu32, b: gu32) = gmul(a, b);
-export fn mul{T}(a: gu32, b: T) = mul(a, b.gu32);
-export fn mul{T}(a: T, b: gu32) = mul(a.gu32, b);
+fn mul(a: gu32, b: gu32) = gmul(a, b);
+fn mul{T}(a: gu32, b: T) = mul(a, b.gu32);
+fn mul{T}(a: T, b: gu32) = mul(a.gu32, b);
 
-export fn mul(a: gi32, b: gi32) = gmul(a, b);
-export fn mul{T}(a: gi32, b: T) = mul(a, b.gi32);
-export fn mul{T}(a: T, b: gi32) = mul(a.gi32, b);
+fn mul(a: gi32, b: gi32) = gmul(a, b);
+fn mul{T}(a: gi32, b: T) = mul(a, b.gi32);
+fn mul{T}(a: T, b: gi32) = mul(a.gi32, b);
 
-export fn mul(a: gf32, b: gf32) = gmul(a, b);
-export fn mul{T}(a: gf32, b: T) = mul(a, b.gf32);
-export fn mul{T}(a: T, b: gf32) = mul(a.gf32, b);
+fn mul(a: gf32, b: gf32) = gmul(a, b);
+fn mul{T}(a: gf32, b: T) = mul(a, b.gf32);
+fn mul{T}(a: T, b: gf32) = mul(a.gf32, b);
 
-export fn mul(a: gvec2u, b: gvec2u) = gmul(a, b);
-export fn mul(a: gvec2u, b: gu32) = gmul(a, b);
+fn mul(a: gvec2u, b: gvec2u) = gmul(a, b);
+fn mul(a: gvec2u, b: gu32) = gmul(a, b);
 // Same thing here, using the commutative property
-export fn mul(a: gu32, b: gvec2u) = gmul(b, a);
+fn mul(a: gu32, b: gvec2u) = gmul(b, a);
 
-export fn mul(a: gvec2i, b: gvec2i) = gmul(a, b);
-export fn mul(a: gvec2i, b: gi32) = gmul(a, b);
-export fn mul(a: gi32, b: gvec2i) = gmul(b, a);
+fn mul(a: gvec2i, b: gvec2i) = gmul(a, b);
+fn mul(a: gvec2i, b: gi32) = gmul(a, b);
+fn mul(a: gi32, b: gvec2i) = gmul(b, a);
 
-export fn mul(a: gvec2f, b: gvec2f) = gmul(a, b);
-export fn mul(a: gvec2f, b: gf32) = gmul(a, b);
-export fn mul(a: gf32, b: gvec2f) = gmul(b, a);
+fn mul(a: gvec2f, b: gvec2f) = gmul(a, b);
+fn mul(a: gvec2f, b: gf32) = gmul(a, b);
+fn mul(a: gf32, b: gvec2f) = gmul(b, a);
 
-export fn mul(a: gvec3u, b: gvec3u) = gmul(a, b);
-export fn mul(a: gvec3u, b: gu32) = gmul(a, b);
-export fn mul(a: gu32, b: gvec3u) = gmul(b, a);
+fn mul(a: gvec3u, b: gvec3u) = gmul(a, b);
+fn mul(a: gvec3u, b: gu32) = gmul(a, b);
+fn mul(a: gu32, b: gvec3u) = gmul(b, a);
 
-export fn mul(a: gvec3i, b: gvec3i) = gmul(a, b);
-export fn mul(a: gvec3i, b: gi32) = gmul(a, b);
-export fn mul(a: gi32, b: gvec3i) = gmul(b, a);
+fn mul(a: gvec3i, b: gvec3i) = gmul(a, b);
+fn mul(a: gvec3i, b: gi32) = gmul(a, b);
+fn mul(a: gi32, b: gvec3i) = gmul(b, a);
 
-export fn mul(a: gvec3f, b: gvec3f) = gmul(a, b);
-export fn mul(a: gvec3f, b: gf32) = gmul(a, b);
-export fn mul(a: gf32, b: gvec3f) = gmul(b, a);
+fn mul(a: gvec3f, b: gvec3f) = gmul(a, b);
+fn mul(a: gvec3f, b: gf32) = gmul(a, b);
+fn mul(a: gf32, b: gvec3f) = gmul(b, a);
 
-export fn mul(a: gvec4u, b: gvec4u) = gmul(a, b);
-export fn mul(a: gvec4u, b: gu32) = gmul(a, b);
-export fn mul(a: gu32, b: gvec4u) = gmul(b, a);
+fn mul(a: gvec4u, b: gvec4u) = gmul(a, b);
+fn mul(a: gvec4u, b: gu32) = gmul(a, b);
+fn mul(a: gu32, b: gvec4u) = gmul(b, a);
 
-export fn mul(a: gvec4i, b: gvec4i) = gmul(a, b);
-export fn mul(a: gvec4i, b: gi32) = gmul(a, b);
-export fn mul(a: gi32, b: gvec4i) = gmul(b, a);
+fn mul(a: gvec4i, b: gvec4i) = gmul(a, b);
+fn mul(a: gvec4i, b: gi32) = gmul(a, b);
+fn mul(a: gi32, b: gvec4i) = gmul(b, a);
 
-export fn mul(a: gvec4f, b: gvec4f) = gmul(a, b);
-export fn mul(a: gvec4f, b: gf32) = gmul(a, b);
-export fn mul(a: gf32, b: gvec4f) = gmul(b, a);
+fn mul(a: gvec4f, b: gvec4f) = gmul(a, b);
+fn mul(a: gvec4f, b: gf32) = gmul(a, b);
+fn mul(a: gf32, b: gvec4f) = gmul(b, a);
 
 // Matrix multiplication, though, needs some special consideration, most of the time
-export fn mul(a: gmat2x2f, b: gf32) = gmul(a, b);
-export fn mul(a: gf32, b: gmat2x2f) = gmul(b, a);
-export fn mul(a: gmat2x2f, b: gvec2f) = gmul{gmat2x2f, gvec2f, gvec2f}(a, b);
-export fn mul(a: gvec2f, b: gmat2x2f) = gmul{gvec2f, gmat2x2f, gvec2f}(a, b);
-export fn mul(a: gmat2x2f, b: gmat2x2f) = gmul(a, b);
-export fn mul(a: gmat2x2f, b: gmat3x2f) = gmul{gmat2x2f, gmat3x2f, gmat3x2f}(a, b);
-export fn mul(a: gmat2x2f, b: gmat4x2f) = gmul{gmat2x2f, gmat4x2f, gmat4x2f}(a, b);
+fn mul(a: gmat2x2f, b: gf32) = gmul(a, b);
+fn mul(a: gf32, b: gmat2x2f) = gmul(b, a);
+fn mul(a: gmat2x2f, b: gvec2f) = gmul{gmat2x2f, gvec2f, gvec2f}(a, b);
+fn mul(a: gvec2f, b: gmat2x2f) = gmul{gvec2f, gmat2x2f, gvec2f}(a, b);
+fn mul(a: gmat2x2f, b: gmat2x2f) = gmul(a, b);
+fn mul(a: gmat2x2f, b: gmat3x2f) = gmul{gmat2x2f, gmat3x2f, gmat3x2f}(a, b);
+fn mul(a: gmat2x2f, b: gmat4x2f) = gmul{gmat2x2f, gmat4x2f, gmat4x2f}(a, b);
 
-export fn mul(a: gmat2x3f, b: gf32) = gmul(a, b);
-export fn mul(a: gf32, b: gmat2x3f) = gmul(b, a);
-export fn mul(a: gmat2x3f, b: gvec2f) = gmul{gmat2x3f, gvec2f, gvec3f}(a, b);
-export fn mul(a: gvec3f, b: gmat2x3f) = gmul{gvec3f, gmat2x3f, gvec2f}(a, b);
-export fn mul(a: gmat2x3f, b: gmat2x2f) = gmul(a, b);
-export fn mul(a: gmat2x3f, b: gmat3x2f) = gmul{gmat2x3f, gmat3x2f, gmat3x3f}(a, b);
-export fn mul(a: gmat2x3f, b: gmat4x2f) = gmul{gmat2x3f, gmat4x2f, gmat4x3f}(a, b);
+fn mul(a: gmat2x3f, b: gf32) = gmul(a, b);
+fn mul(a: gf32, b: gmat2x3f) = gmul(b, a);
+fn mul(a: gmat2x3f, b: gvec2f) = gmul{gmat2x3f, gvec2f, gvec3f}(a, b);
+fn mul(a: gvec3f, b: gmat2x3f) = gmul{gvec3f, gmat2x3f, gvec2f}(a, b);
+fn mul(a: gmat2x3f, b: gmat2x2f) = gmul(a, b);
+fn mul(a: gmat2x3f, b: gmat3x2f) = gmul{gmat2x3f, gmat3x2f, gmat3x3f}(a, b);
+fn mul(a: gmat2x3f, b: gmat4x2f) = gmul{gmat2x3f, gmat4x2f, gmat4x3f}(a, b);
 
-export fn mul(a: gmat2x4f, b: gf32) = gmul(a, b);
-export fn mul(a: gf32, b: gmat2x4f) = gmul(b, a);
-export fn mul(a: gmat2x4f, b: gvec2f) = gmul{gmat2x4f, gvec2f, gvec4f}(a, b);
-export fn mul(a: gvec4f, b: gmat2x4f) = gmul{gvec4f, gmat2x4f, gvec2f}(a, b);
-export fn mul(a: gmat2x4f, b: gmat2x2f) = gmul(a, b);
-export fn mul(a: gmat2x4f, b: gmat3x2f) = gmul{gmat2x4f, gmat3x2f, gmat3x4f}(a, b);
-export fn mul(a: gmat2x4f, b: gmat4x2f) = gmul{gmat2x4f, gmat4x2f, gmat4x4f}(a, b);
+fn mul(a: gmat2x4f, b: gf32) = gmul(a, b);
+fn mul(a: gf32, b: gmat2x4f) = gmul(b, a);
+fn mul(a: gmat2x4f, b: gvec2f) = gmul{gmat2x4f, gvec2f, gvec4f}(a, b);
+fn mul(a: gvec4f, b: gmat2x4f) = gmul{gvec4f, gmat2x4f, gvec2f}(a, b);
+fn mul(a: gmat2x4f, b: gmat2x2f) = gmul(a, b);
+fn mul(a: gmat2x4f, b: gmat3x2f) = gmul{gmat2x4f, gmat3x2f, gmat3x4f}(a, b);
+fn mul(a: gmat2x4f, b: gmat4x2f) = gmul{gmat2x4f, gmat4x2f, gmat4x4f}(a, b);
 
-export fn mul(a: gmat3x2f, b: gf32) = gmul(a, b);
-export fn mul(a: gf32, b: gmat3x2f) = gmul(b, a);
-export fn mul(a: gmat3x2f, b: gvec3f) = gmul{gmat3x2f, gvec3f, gvec2f}(a, b);
-export fn mul(a: gvec2f, b: gmat3x2f) = gmul{gvec2f, gmat3x2f, gvec3f}(a, b);
-export fn mul(a: gmat3x2f, b: gmat2x3f) = gmul{gmat3x2f, gmat2x3f, gmat2x2f}(a, b);
-export fn mul(a: gmat3x2f, b: gmat3x3f) = gmul(a, b);
-export fn mul(a: gmat3x2f, b: gmat4x3f) = gmul{gmat3x2f, gmat4x3f, gmat4x2f}(a, b);
+fn mul(a: gmat3x2f, b: gf32) = gmul(a, b);
+fn mul(a: gf32, b: gmat3x2f) = gmul(b, a);
+fn mul(a: gmat3x2f, b: gvec3f) = gmul{gmat3x2f, gvec3f, gvec2f}(a, b);
+fn mul(a: gvec2f, b: gmat3x2f) = gmul{gvec2f, gmat3x2f, gvec3f}(a, b);
+fn mul(a: gmat3x2f, b: gmat2x3f) = gmul{gmat3x2f, gmat2x3f, gmat2x2f}(a, b);
+fn mul(a: gmat3x2f, b: gmat3x3f) = gmul(a, b);
+fn mul(a: gmat3x2f, b: gmat4x3f) = gmul{gmat3x2f, gmat4x3f, gmat4x2f}(a, b);
 
-export fn mul(a: gmat3x3f, b: gf32) = gmul(a, b);
-export fn mul(a: gf32, b: gmat3x3f) = gmul(b, a);
-export fn mul(a: gmat3x3f, b: gvec3f) = gmul{gmat3x3f, gvec3f, gvec3f}(a, b);
-export fn mul(a: gvec3f, b: gmat3x3f) = gmul(a, b);
-export fn mul(a: gmat3x3f, b: gmat2x3f) = gmul{gmat3x3f, gmat2x3f, gmat2x3f}(a, b);
-export fn mul(a: gmat3x3f, b: gmat3x3f) = gmul(a, b);
-export fn mul(a: gmat3x3f, b: gmat4x3f) = gmul{gmat3x3f, gmat4x3f, gmat4x3f}(a, b);
+fn mul(a: gmat3x3f, b: gf32) = gmul(a, b);
+fn mul(a: gf32, b: gmat3x3f) = gmul(b, a);
+fn mul(a: gmat3x3f, b: gvec3f) = gmul{gmat3x3f, gvec3f, gvec3f}(a, b);
+fn mul(a: gvec3f, b: gmat3x3f) = gmul(a, b);
+fn mul(a: gmat3x3f, b: gmat2x3f) = gmul{gmat3x3f, gmat2x3f, gmat2x3f}(a, b);
+fn mul(a: gmat3x3f, b: gmat3x3f) = gmul(a, b);
+fn mul(a: gmat3x3f, b: gmat4x3f) = gmul{gmat3x3f, gmat4x3f, gmat4x3f}(a, b);
 
-export fn mul(a: gmat3x4f, b: gf32) = gmul(a, b);
-export fn mul(a: gf32, b: gmat3x4f) = gmul(b, a);
-export fn mul(a: gmat3x4f, b: gvec3f) = gmul{gmat3x4f, gvec3f, gvec4f}(a, b);
-export fn mul(a: gvec4f, b: gmat3x4f) = gmul{gvec4f, gmat3x4f, gvec3f}(a, b);
-export fn mul(a: gmat3x4f, b: gmat2x3f) = gmul{gmat3x4f, gmat2x3f, gmat2x4f}(a, b);
-export fn mul(a: gmat3x4f, b: gmat3x3f) = gmul(a, b);
-export fn mul(a: gmat3x4f, b: gmat4x3f) = gmul{gmat3x4f, gmat4x3f, gmat4x4f}(a, b);
+fn mul(a: gmat3x4f, b: gf32) = gmul(a, b);
+fn mul(a: gf32, b: gmat3x4f) = gmul(b, a);
+fn mul(a: gmat3x4f, b: gvec3f) = gmul{gmat3x4f, gvec3f, gvec4f}(a, b);
+fn mul(a: gvec4f, b: gmat3x4f) = gmul{gvec4f, gmat3x4f, gvec3f}(a, b);
+fn mul(a: gmat3x4f, b: gmat2x3f) = gmul{gmat3x4f, gmat2x3f, gmat2x4f}(a, b);
+fn mul(a: gmat3x4f, b: gmat3x3f) = gmul(a, b);
+fn mul(a: gmat3x4f, b: gmat4x3f) = gmul{gmat3x4f, gmat4x3f, gmat4x4f}(a, b);
 
-export fn mul(a: gmat4x2f, b: gf32) = gmul(a, b);
-export fn mul(a: gf32, b: gmat4x2f) = gmul(b, a);
-export fn mul(a: gmat4x2f, b: gvec4f) = gmul{gmat4x2f, gvec4f, gvec2f}(a, b);
-export fn mul(a: gvec2f, b: gmat4x2f) = gmul{gvec2f, gmat4x2f, gvec4f}(a, b);
-export fn mul(a: gmat4x2f, b: gmat2x4f) = gmul{gmat4x2f, gmat2x4f, gmat2x2f}(a, b);
-export fn mul(a: gmat4x2f, b: gmat3x4f) = gmul{gmat4x2f, gmat3x4f, gmat3x2f}(a, b);
-export fn mul(a: gmat4x2f, b: gmat4x4f) = gmul(a, b);
+fn mul(a: gmat4x2f, b: gf32) = gmul(a, b);
+fn mul(a: gf32, b: gmat4x2f) = gmul(b, a);
+fn mul(a: gmat4x2f, b: gvec4f) = gmul{gmat4x2f, gvec4f, gvec2f}(a, b);
+fn mul(a: gvec2f, b: gmat4x2f) = gmul{gvec2f, gmat4x2f, gvec4f}(a, b);
+fn mul(a: gmat4x2f, b: gmat2x4f) = gmul{gmat4x2f, gmat2x4f, gmat2x2f}(a, b);
+fn mul(a: gmat4x2f, b: gmat3x4f) = gmul{gmat4x2f, gmat3x4f, gmat3x2f}(a, b);
+fn mul(a: gmat4x2f, b: gmat4x4f) = gmul(a, b);
 
-export fn mul(a: gmat4x3f, b: gf32) = gmul(a, b);
-export fn mul(a: gf32, b: gmat4x3f) = gmul(b, a);
-export fn mul(a: gmat4x3f, b: gvec4f) = gmul{gmat4x3f, gvec4f, gvec3f}(a, b);
-export fn mul(a: gvec3f, b: gmat4x3f) = gmul{gvec3f, gmat4x3f, gvec4f}(a, b);
-export fn mul(a: gmat4x3f, b: gmat2x4f) = gmul{gmat4x3f, gmat2x4f, gmat2x3f}(a, b);
-export fn mul(a: gmat4x3f, b: gmat3x4f) = gmul{gmat4x3f, gmat3x4f, gmat3x3f}(a, b);
-export fn mul(a: gmat4x3f, b: gmat4x4f) = gmul(a, b);
+fn mul(a: gmat4x3f, b: gf32) = gmul(a, b);
+fn mul(a: gf32, b: gmat4x3f) = gmul(b, a);
+fn mul(a: gmat4x3f, b: gvec4f) = gmul{gmat4x3f, gvec4f, gvec3f}(a, b);
+fn mul(a: gvec3f, b: gmat4x3f) = gmul{gvec3f, gmat4x3f, gvec4f}(a, b);
+fn mul(a: gmat4x3f, b: gmat2x4f) = gmul{gmat4x3f, gmat2x4f, gmat2x3f}(a, b);
+fn mul(a: gmat4x3f, b: gmat3x4f) = gmul{gmat4x3f, gmat3x4f, gmat3x3f}(a, b);
+fn mul(a: gmat4x3f, b: gmat4x4f) = gmul(a, b);
 
-export fn mul(a: gmat4x4f, b: gf32) = gmul(a, b);
-export fn mul(a: gf32, b: gmat4x4f) = gmul(b, a);
-export fn mul(a: gmat4x4f, b: gvec4f) = gmul{gmat4x4f, gvec4f, gvec4f}(a, b);
-export fn mul(a: gvec4f, b: gmat4x4f) = gmul(a, b);
-export fn mul(a: gmat4x4f, b: gmat2x4f) = gmul{gmat4x4f, gmat2x4f, gmat2x4f}(a, b);
-export fn mul(a: gmat4x4f, b: gmat3x4f) = gmul{gmat4x4f, gmat3x4f, gmat3x4f}(a, b);
-export fn mul(a: gmat4x4f, b: gmat4x4f) = gmul(a, b);
+fn mul(a: gmat4x4f, b: gf32) = gmul(a, b);
+fn mul(a: gf32, b: gmat4x4f) = gmul(b, a);
+fn mul(a: gmat4x4f, b: gvec4f) = gmul{gmat4x4f, gvec4f, gvec4f}(a, b);
+fn mul(a: gvec4f, b: gmat4x4f) = gmul(a, b);
+fn mul(a: gmat4x4f, b: gmat2x4f) = gmul{gmat4x4f, gmat2x4f, gmat2x4f}(a, b);
+fn mul(a: gmat4x4f, b: gmat3x4f) = gmul{gmat4x4f, gmat3x4f, gmat3x4f}(a, b);
+fn mul(a: gmat4x4f, b: gmat4x4f) = gmul(a, b);
 
 fn gdiv{A, B}(a: A, b: B) {
   let varName = '('.concat(a.varName).concat(' / ').concat(b.varName).concat(')');
@@ -3926,53 +3961,53 @@ fn gdivRev{A, B}(a: A, b: B) {
   let buffers = a.buffers.union(b.buffers);
   return {B}(varName, statements, buffers);
 }
-export fn div(a: gu32, b: gu32) = gdiv(a, b);
-export fn div{T}(a: gu32, b: T) = div(a, b.gu32);
-export fn div{T}(a: T, b: gu32) = div(a.gu32, b);
+fn div(a: gu32, b: gu32) = gdiv(a, b);
+fn div{T}(a: gu32, b: T) = div(a, b.gu32);
+fn div{T}(a: T, b: gu32) = div(a.gu32, b);
 
-export fn div(a: gi32, b: gi32) = gdiv(a, b);
-export fn div{T}(a: gi32, b: T) = div(a, b.gi32);
-export fn div{T}(a: T, b: gi32) = div(a.gi32, b);
+fn div(a: gi32, b: gi32) = gdiv(a, b);
+fn div{T}(a: gi32, b: T) = div(a, b.gi32);
+fn div{T}(a: T, b: gi32) = div(a.gi32, b);
 
-export fn div(a: gf32, b: gf32) = gdiv(a, b);
-export fn div{T}(a: gf32, b: T) = div(a, b.gf32);
-export fn div{T}(a: T, b: gf32) = div(a.gf32, b);
+fn div(a: gf32, b: gf32) = gdiv(a, b);
+fn div{T}(a: gf32, b: T) = div(a, b.gf32);
+fn div{T}(a: T, b: gf32) = div(a.gf32, b);
 
-export fn div(a: gvec2u, b: gvec2u) = gdiv(a, b);
-export fn div(a: gvec2u, b: gu32) = gdiv(a, b);
-export fn div(a: gu32, b: gvec2u) = gdivRev(a, b);
+fn div(a: gvec2u, b: gvec2u) = gdiv(a, b);
+fn div(a: gvec2u, b: gu32) = gdiv(a, b);
+fn div(a: gu32, b: gvec2u) = gdivRev(a, b);
 
-export fn div(a: gvec2i, b: gvec2i) = gdiv(a, b);
-export fn div(a: gvec2i, b: gi32) = gdiv(a, b);
-export fn div(a: gi32, b: gvec2i) = gdivRev(a, b);
+fn div(a: gvec2i, b: gvec2i) = gdiv(a, b);
+fn div(a: gvec2i, b: gi32) = gdiv(a, b);
+fn div(a: gi32, b: gvec2i) = gdivRev(a, b);
 
-export fn div(a: gvec2f, b: gvec2f) = gdiv(a, b);
-export fn div(a: gvec2f, b: gf32) = gdiv(a, b);
-export fn div(a: gf32, b: gvec2f) = gdivRev(a, b);
+fn div(a: gvec2f, b: gvec2f) = gdiv(a, b);
+fn div(a: gvec2f, b: gf32) = gdiv(a, b);
+fn div(a: gf32, b: gvec2f) = gdivRev(a, b);
 
-export fn div(a: gvec3u, b: gvec3u) = gdiv(a, b);
-export fn div(a: gvec3u, b: gu32) = gdiv(a, b);
-export fn div(a: gu32, b: gvec3u) = gdivRev(a, b);
+fn div(a: gvec3u, b: gvec3u) = gdiv(a, b);
+fn div(a: gvec3u, b: gu32) = gdiv(a, b);
+fn div(a: gu32, b: gvec3u) = gdivRev(a, b);
 
-export fn div(a: gvec3i, b: gvec3i) = gdiv(a, b);
-export fn div(a: gvec3i, b: gi32) = gdiv(a, b);
-export fn div(a: gi32, b: gvec3i) = gdivRev(a, b);
+fn div(a: gvec3i, b: gvec3i) = gdiv(a, b);
+fn div(a: gvec3i, b: gi32) = gdiv(a, b);
+fn div(a: gi32, b: gvec3i) = gdivRev(a, b);
 
-export fn div(a: gvec3f, b: gvec3f) = gdiv(a, b);
-export fn div(a: gvec3f, b: gf32) = gdiv(a, b);
-export fn div(a: gf32, b: gvec3f) = gdivRev(a, b);
+fn div(a: gvec3f, b: gvec3f) = gdiv(a, b);
+fn div(a: gvec3f, b: gf32) = gdiv(a, b);
+fn div(a: gf32, b: gvec3f) = gdivRev(a, b);
 
-export fn div(a: gvec4u, b: gvec4u) = gdiv(a, b);
-export fn div(a: gvec4u, b: gu32) = gdiv(a, b);
-export fn div(a: gu32, b: gvec4u) = gdivRev(a, b);
+fn div(a: gvec4u, b: gvec4u) = gdiv(a, b);
+fn div(a: gvec4u, b: gu32) = gdiv(a, b);
+fn div(a: gu32, b: gvec4u) = gdivRev(a, b);
 
-export fn div(a: gvec4i, b: gvec4i) = gdiv(a, b);
-export fn div(a: gvec4i, b: gi32) = gdiv(a, b);
-export fn div(a: gi32, b: gvec4i) = gdivRev(a, b);
+fn div(a: gvec4i, b: gvec4i) = gdiv(a, b);
+fn div(a: gvec4i, b: gi32) = gdiv(a, b);
+fn div(a: gi32, b: gvec4i) = gdivRev(a, b);
 
-export fn div(a: gvec4f, b: gvec4f) = gdiv(a, b);
-export fn div(a: gvec4f, b: gf32) = gdiv(a, b);
-export fn div(a: gf32, b: gvec4f) = gdivRev(a, b);
+fn div(a: gvec4f, b: gvec4f) = gdiv(a, b);
+fn div(a: gvec4f, b: gf32) = gdiv(a, b);
+fn div(a: gf32, b: gvec4f) = gdivRev(a, b);
 
 fn gmod{A, B}(a: A, b: B) {
   let varName = '('.concat(a.varName).concat(' % ').concat(b.varName).concat(')');
@@ -3986,53 +4021,53 @@ fn gmodRev{A, B}(a: A, b: B) {
   let buffers = a.buffers.union(b.buffers);
   return {B}(varName, statements, buffers);
 }
-export fn mod(a: gu32, b: gu32) = gmod(a, b);
-export fn mod{T}(a: gu32, b: T) = mod(a, b.gu32);
-export fn mod{T}(a: T, b: gu32) = mod(a.gu32, b);
+fn mod(a: gu32, b: gu32) = gmod(a, b);
+fn mod{T}(a: gu32, b: T) = mod(a, b.gu32);
+fn mod{T}(a: T, b: gu32) = mod(a.gu32, b);
 
-export fn mod(a: gi32, b: gi32) = gmod(a, b);
-export fn mod{T}(a: gi32, b: T) = mod(a, b.gi32);
-export fn mod{T}(a: T, b: gi32) = mod(a.gi32, b);
+fn mod(a: gi32, b: gi32) = gmod(a, b);
+fn mod{T}(a: gi32, b: T) = mod(a, b.gi32);
+fn mod{T}(a: T, b: gi32) = mod(a.gi32, b);
 
-export fn mod(a: gf32, b: gf32) = gmod(a, b);
-export fn mod{T}(a: gf32, b: T) = mod(a, b.gf32);
-export fn mod{T}(a: T, b: gf32) = mod(a.gf32, b);
+fn mod(a: gf32, b: gf32) = gmod(a, b);
+fn mod{T}(a: gf32, b: T) = mod(a, b.gf32);
+fn mod{T}(a: T, b: gf32) = mod(a.gf32, b);
 
-export fn mod(a: gvec2u, b: gvec2u) = gmod(a, b);
-export fn mod(a: gvec2u, b: gu32) = gmod(a, b);
-export fn mod(a: gu32, b: gvec2u) = gmodRev(a, b);
+fn mod(a: gvec2u, b: gvec2u) = gmod(a, b);
+fn mod(a: gvec2u, b: gu32) = gmod(a, b);
+fn mod(a: gu32, b: gvec2u) = gmodRev(a, b);
 
-export fn mod(a: gvec2i, b: gvec2i) = gmod(a, b);
-export fn mod(a: gvec2i, b: gi32) = gmod(a, b);
-export fn mod(a: gi32, b: gvec2i) = gmodRev(a, b);
+fn mod(a: gvec2i, b: gvec2i) = gmod(a, b);
+fn mod(a: gvec2i, b: gi32) = gmod(a, b);
+fn mod(a: gi32, b: gvec2i) = gmodRev(a, b);
 
-export fn mod(a: gvec2f, b: gvec2f) = gmod(a, b);
-export fn mod(a: gvec2f, b: gf32) = gmod(a, b);
-export fn mod(a: gf32, b: gvec2f) = gmodRev(a, b);
+fn mod(a: gvec2f, b: gvec2f) = gmod(a, b);
+fn mod(a: gvec2f, b: gf32) = gmod(a, b);
+fn mod(a: gf32, b: gvec2f) = gmodRev(a, b);
 
-export fn mod(a: gvec3u, b: gvec3u) = gmod(a, b);
-export fn mod(a: gvec3u, b: gu32) = gmod(a, b);
-export fn mod(a: gu32, b: gvec3u) = gmodRev(a, b);
+fn mod(a: gvec3u, b: gvec3u) = gmod(a, b);
+fn mod(a: gvec3u, b: gu32) = gmod(a, b);
+fn mod(a: gu32, b: gvec3u) = gmodRev(a, b);
 
-export fn mod(a: gvec3i, b: gvec3i) = gmod(a, b);
-export fn mod(a: gvec3i, b: gi32) = gmod(a, b);
-export fn mod(a: gi32, b: gvec3i) = gmodRev(a, b);
+fn mod(a: gvec3i, b: gvec3i) = gmod(a, b);
+fn mod(a: gvec3i, b: gi32) = gmod(a, b);
+fn mod(a: gi32, b: gvec3i) = gmodRev(a, b);
 
-export fn mod(a: gvec3f, b: gvec3f) = gmod(a, b);
-export fn mod(a: gvec3f, b: gf32) = gmod(a, b);
-export fn mod(a: gf32, b: gvec3f) = gmodRev(a, b);
+fn mod(a: gvec3f, b: gvec3f) = gmod(a, b);
+fn mod(a: gvec3f, b: gf32) = gmod(a, b);
+fn mod(a: gf32, b: gvec3f) = gmodRev(a, b);
 
-export fn mod(a: gvec4u, b: gvec4u) = gmod(a, b);
-export fn mod(a: gvec4u, b: gu32) = gmod(a, b);
-export fn mod(a: gu32, b: gvec4u) = gmodRev(a, b);
+fn mod(a: gvec4u, b: gvec4u) = gmod(a, b);
+fn mod(a: gvec4u, b: gu32) = gmod(a, b);
+fn mod(a: gu32, b: gvec4u) = gmodRev(a, b);
 
-export fn mod(a: gvec4i, b: gvec4i) = gmod(a, b);
-export fn mod(a: gvec4i, b: gi32) = gmod(a, b);
-export fn mod(a: gi32, b: gvec4i) = gmodRev(a, b);
+fn mod(a: gvec4i, b: gvec4i) = gmod(a, b);
+fn mod(a: gvec4i, b: gi32) = gmod(a, b);
+fn mod(a: gi32, b: gvec4i) = gmodRev(a, b);
 
-export fn mod(a: gvec4f, b: gvec4f) = gmod(a, b);
-export fn mod(a: gvec4f, b: gf32) = gmod(a, b);
-export fn mod(a: gf32, b: gvec4f) = gmodRev(a, b);
+fn mod(a: gvec4f, b: gvec4f) = gmod(a, b);
+fn mod(a: gvec4f, b: gf32) = gmod(a, b);
+fn mod(a: gf32, b: gvec4f) = gmodRev(a, b);
 
 fn gpow{A, B}(a: A, b: B) {
   let varName = 'pow('.concat(a.varName).concat(', ').concat(b.varName).concat(')');
@@ -4040,81 +4075,81 @@ fn gpow{A, B}(a: A, b: B) {
   let buffers = a.buffers.union(b.buffers);
   return {A}(varName, statements, buffers);
 }
-export fn pow(a: gf32, b: gf32) = gpow(a, b);
-export fn pow{T}(a: gf32, b: T) = pow(a, b.gf32);
-export fn pow{T}(a: T, b: gf32) = pow(a.gf32, b);
-export fn pow(a: gvec2f, b: gvec2f) = gpow(a, b);
-export fn pow{T}(a: gvec2f, b: T) = pow(a, b.gvec2f);
-export fn pow{T}(a: T, b: gvec2f) = pow(a.gvec2f, b);
-export fn pow(a: gvec3f, b: gvec3f) = gpow(a, b);
-export fn pow{T}(a: gvec3f, b: T) = pow(a, b.gvec3f);
-export fn pow{T}(a: T, b: gvec3f) = pow(a.gvec3f, b);
-export fn pow(a: gvec4f, b: gvec4f) = gpow(a, b);
-export fn pow{T}(a: gvec4f, b: T) = pow(a, b.gvec4f);
-export fn pow{T}(a: T, b: gvec4f) = pow(a.gvec4f, b);
+fn pow(a: gf32, b: gf32) = gpow(a, b);
+fn pow{T}(a: gf32, b: T) = pow(a, b.gf32);
+fn pow{T}(a: T, b: gf32) = pow(a.gf32, b);
+fn pow(a: gvec2f, b: gvec2f) = gpow(a, b);
+fn pow{T}(a: gvec2f, b: T) = pow(a, b.gvec2f);
+fn pow{T}(a: T, b: gvec2f) = pow(a.gvec2f, b);
+fn pow(a: gvec3f, b: gvec3f) = gpow(a, b);
+fn pow{T}(a: gvec3f, b: T) = pow(a, b.gvec3f);
+fn pow{T}(a: T, b: gvec3f) = pow(a.gvec3f, b);
+fn pow(a: gvec4f, b: gvec4f) = gpow(a, b);
+fn pow{T}(a: gvec4f, b: T) = pow(a, b.gvec4f);
+fn pow{T}(a: T, b: gvec4f) = pow(a.gvec4f, b);
 
 fn gsqrt{I}(v: I) {
   let varName = 'sqrt('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn sqrt(v: gf32) = gsqrt{gf32}(v);
-export fn sqrt(v: gvec2f) = gsqrt{gvec2f}(v);
-export fn sqrt(v: gvec3f) = gsqrt{gvec3f}(v);
-export fn sqrt(v: gvec4f) = gsqrt{gvec4f}(v);
+fn sqrt(v: gf32) = gsqrt{gf32}(v);
+fn sqrt(v: gvec2f) = gsqrt{gvec2f}(v);
+fn sqrt(v: gvec3f) = gsqrt{gvec3f}(v);
+fn sqrt(v: gvec4f) = gsqrt{gvec4f}(v);
 
 fn gacos{I}(v: I) {
   let varName = 'acos('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn acos(v: gf32) = gacos{gf32}(v);
-export fn acos(v: gvec2f) = gacos{gvec2f}(v);
-export fn acos(v: gvec3f) = gacos{gvec3f}(v);
-export fn acos(v: gvec4f) = gacos{gvec4f}(v);
+fn acos(v: gf32) = gacos{gf32}(v);
+fn acos(v: gvec2f) = gacos{gvec2f}(v);
+fn acos(v: gvec3f) = gacos{gvec3f}(v);
+fn acos(v: gvec4f) = gacos{gvec4f}(v);
 
 fn gacosh{I}(v: I) {
   let varName = 'acosh('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn acosh(v: gf32) = gacosh{gf32}(v);
-export fn acosh(v: gvec2f) = gacosh{gvec2f}(v);
-export fn acosh(v: gvec3f) = gacosh{gvec3f}(v);
-export fn acosh(v: gvec4f) = gacosh{gvec4f}(v);
+fn acosh(v: gf32) = gacosh{gf32}(v);
+fn acosh(v: gvec2f) = gacosh{gvec2f}(v);
+fn acosh(v: gvec3f) = gacosh{gvec3f}(v);
+fn acosh(v: gvec4f) = gacosh{gvec4f}(v);
 
 fn gasin{I}(v: I) {
   let varName = 'asin('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn asin(v: gf32) = gasin{gf32}(v);
-export fn asin(v: gvec2f) = gasin{gvec2f}(v);
-export fn asin(v: gvec3f) = gasin{gvec3f}(v);
-export fn asin(v: gvec4f) = gasin{gvec4f}(v);
+fn asin(v: gf32) = gasin{gf32}(v);
+fn asin(v: gvec2f) = gasin{gvec2f}(v);
+fn asin(v: gvec3f) = gasin{gvec3f}(v);
+fn asin(v: gvec4f) = gasin{gvec4f}(v);
 
 fn gasinh{I}(v: I) {
   let varName = 'asinh('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn asinh(v: gf32) = gasinh{gf32}(v);
-export fn asinh(v: gvec2f) = gasinh{gvec2f}(v);
-export fn asinh(v: gvec3f) = gasinh{gvec3f}(v);
-export fn asinh(v: gvec4f) = gasinh{gvec4f}(v);
+fn asinh(v: gf32) = gasinh{gf32}(v);
+fn asinh(v: gvec2f) = gasinh{gvec2f}(v);
+fn asinh(v: gvec3f) = gasinh{gvec3f}(v);
+fn asinh(v: gvec4f) = gasinh{gvec4f}(v);
 
 fn gatan{I}(v: I) {
   let varName = 'atan('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn atan(v: gf32) = gatan{gf32}(v);
-export fn atan(v: gvec2f) = gatan{gvec2f}(v);
-export fn atan(v: gvec3f) = gatan{gvec3f}(v);
-export fn atan(v: gvec4f) = gatan{gvec4f}(v);
+fn atan(v: gf32) = gatan{gf32}(v);
+fn atan(v: gvec2f) = gatan{gvec2f}(v);
+fn atan(v: gvec3f) = gatan{gvec3f}(v);
+fn atan(v: gvec4f) = gatan{gvec4f}(v);
 
 fn gatanh{I}(v: I) {
   let varName = 'atanh('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn atanh(v: gf32) = gatanh{gf32}(v);
-export fn atanh(v: gvec2f) = gatanh{gvec2f}(v);
-export fn atanh(v: gvec3f) = gatanh{gvec3f}(v);
-export fn atanh(v: gvec4f) = gatanh{gvec4f}(v);
+fn atanh(v: gf32) = gatanh{gf32}(v);
+fn atanh(v: gvec2f) = gatanh{gvec2f}(v);
+fn atanh(v: gvec3f) = gatanh{gvec3f}(v);
+fn atanh(v: gvec4f) = gatanh{gvec4f}(v);
 
 fn gatan2{I}(a: I, b: I) {
   let varName = 'atan2('.concat(a.varName).concat(', ').concat(b.varName).concat(')');
@@ -4122,36 +4157,36 @@ fn gatan2{I}(a: I, b: I) {
   let buffers = a.buffers.union(b.buffers);
   return {I}(varName, statements, buffers);
 }
-export fn atan2(a: gf32, b: gf32) = gatan2{gf32}(a, b);
-export fn atan2{T}(a: gf32, b: T) = gatan2{gf32}(a, b.gf32);
-export fn atan2{T}(a: T, b: gf32) = gatan2{gf32}(a.gf32, b);
-export fn atan2(a: gvec2f, b: gvec2f) = gatan2{gvec2f}(a, b);
-export fn atan2{T}(a: gvec2f, b: T) = gatan2{gvec2f}(a, b.gvec2f);
-export fn atan2{T}(a: T, b: gvec2f) = gatan2{gvec2f}(a.gvec2f, b);
-export fn atan2(a: gvec3f, b: gvec3f) = gatan2{gvec3f}(a, b);
-export fn atan2{T}(a: gvec3f, b: T) = gatan2{gvec3f}(a, b.gvec3f);
-export fn atan2{T}(a: T, b: gvec3f) = gatan2{gvec3f}(a.gvec3f, b);
-export fn atan2(a: gvec4f, b: gvec4f) = gatan2{gvec4f}(a, b);
-export fn atan2{T}(a: gvec4f, b: T) = gatan2{gvec4f}(a, b.gvec4f);
-export fn atan2{T}(a: T, b: gvec4f) = gatan2{gvec4f}(a.gvec4f, b);
+fn atan2(a: gf32, b: gf32) = gatan2{gf32}(a, b);
+fn atan2{T}(a: gf32, b: T) = gatan2{gf32}(a, b.gf32);
+fn atan2{T}(a: T, b: gf32) = gatan2{gf32}(a.gf32, b);
+fn atan2(a: gvec2f, b: gvec2f) = gatan2{gvec2f}(a, b);
+fn atan2{T}(a: gvec2f, b: T) = gatan2{gvec2f}(a, b.gvec2f);
+fn atan2{T}(a: T, b: gvec2f) = gatan2{gvec2f}(a.gvec2f, b);
+fn atan2(a: gvec3f, b: gvec3f) = gatan2{gvec3f}(a, b);
+fn atan2{T}(a: gvec3f, b: T) = gatan2{gvec3f}(a, b.gvec3f);
+fn atan2{T}(a: T, b: gvec3f) = gatan2{gvec3f}(a.gvec3f, b);
+fn atan2(a: gvec4f, b: gvec4f) = gatan2{gvec4f}(a, b);
+fn atan2{T}(a: gvec4f, b: T) = gatan2{gvec4f}(a, b.gvec4f);
+fn atan2{T}(a: T, b: gvec4f) = gatan2{gvec4f}(a.gvec4f, b);
 
 fn gfloor{I}(v: I) {
   let varName = 'floor('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn floor(v: gf32) = gfloor{gf32}(v);
-export fn floor(v: gvec2f) = gfloor{gvec2f}(v);
-export fn floor(v: gvec3f) = gfloor{gvec3f}(v);
-export fn floor(v: gvec4f) = gfloor{gvec4f}(v);
+fn floor(v: gf32) = gfloor{gf32}(v);
+fn floor(v: gvec2f) = gfloor{gvec2f}(v);
+fn floor(v: gvec3f) = gfloor{gvec3f}(v);
+fn floor(v: gvec4f) = gfloor{gvec4f}(v);
 
 fn gceil{I}(v: I) {
   let varName = 'ceil('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn ceil(v: gf32) = gceil{gf32}(v);
-export fn ceil(v: gvec2f) = gceil{gvec2f}(v);
-export fn ceil(v: gvec3f) = gceil{gvec3f}(v);
-export fn ceil(v: gvec4f) = gceil{gvec4f}(v);
+fn ceil(v: gf32) = gceil{gf32}(v);
+fn ceil(v: gvec2f) = gceil{gvec2f}(v);
+fn ceil(v: gvec3f) = gceil{gvec3f}(v);
+fn ceil(v: gvec4f) = gceil{gvec4f}(v);
 
 fn gclamp{I}(v: I, l: I, h: I) {
   let varName = 'clamp('.concat(v.varName).concat(', ').concat(l.varName).concat(', ').concat(h.varName).concat(')');
@@ -4159,172 +4194,172 @@ fn gclamp{I}(v: I, l: I, h: I) {
   let buffers = v.buffers.union(l.buffers).union(h.buffers);
   return {I}(varName, statements, buffers);
 }
-export fn clamp(v: gf32, l: gf32, h: gf32) = gclamp{gf32}(v, l, h);
-export fn clamp{T}(v: gf32, l: T, h: T) = gclamp{gf32}(v, l.gf32, h.gf32);
-export fn clamp{T}(v: gf32, l: gf32, h: T) = gclamp{gf32}(v, l, h.gf32);
-export fn clamp{T}(v: gf32, l: T, h: gf32) = gclamp{gf32}(v, l.gf32, h);
-export fn clamp(v: gvec2f, l: gvec2f, h: gvec2f) = gclamp{gvec2f}(v, l, h);
-export fn clamp{T}(v: gvec2f, l: T, h: T) = gclamp{gvec2f}(v, l.gvec2f, h.gvec2f);
-export fn clamp{T}(v: gvec2f, l: gvec2f, h: T) = gclamp{gvec2f}(v, l, h.gvec2f);
-export fn clamp{T}(v: gvec2f, l: T, h: gvec2f) = gclamp{gvec2f}(v, l.gvec2f, h);
-export fn clamp(v: gvec3f, l: gvec3f, h: gvec3f) = gclamp{gvec3f}(v, l, h);
-export fn clamp{T}(v: gvec3f, l: T, h: T) = gclamp{gvec3f}(v, l.gvec3f, h.gvec3f);
-export fn clamp{T}(v: gvec3f, l: gvec3f, h: T) = gclamp{gvec3f}(v, l, h.gvec3f);
-export fn clamp{T}(v: gvec3f, l: T, h: gvec3f) = gclamp{gvec3f}(v, l.gvec3f, h);
-export fn clamp(v: gvec4f, l: gvec4f, h: gvec4f) = gclamp{gvec4f}(v, l, h);
-export fn clamp{T}(v: gvec4f, l: T, h: T) = gclamp{gvec4f}(v, l.gvec4f, h.gvec4f);
-export fn clamp{T}(v: gvec4f, l: gvec4f, h: T) = gclamp{gvec4f}(v, l, h.gvec4f);
-export fn clamp{T}(v: gvec4f, l: T, h: gvec4f) = gclamp{gvec4f}(v, l.gvec4f, h);
+fn clamp(v: gf32, l: gf32, h: gf32) = gclamp{gf32}(v, l, h);
+fn clamp{T}(v: gf32, l: T, h: T) = gclamp{gf32}(v, l.gf32, h.gf32);
+fn clamp{T}(v: gf32, l: gf32, h: T) = gclamp{gf32}(v, l, h.gf32);
+fn clamp{T}(v: gf32, l: T, h: gf32) = gclamp{gf32}(v, l.gf32, h);
+fn clamp(v: gvec2f, l: gvec2f, h: gvec2f) = gclamp{gvec2f}(v, l, h);
+fn clamp{T}(v: gvec2f, l: T, h: T) = gclamp{gvec2f}(v, l.gvec2f, h.gvec2f);
+fn clamp{T}(v: gvec2f, l: gvec2f, h: T) = gclamp{gvec2f}(v, l, h.gvec2f);
+fn clamp{T}(v: gvec2f, l: T, h: gvec2f) = gclamp{gvec2f}(v, l.gvec2f, h);
+fn clamp(v: gvec3f, l: gvec3f, h: gvec3f) = gclamp{gvec3f}(v, l, h);
+fn clamp{T}(v: gvec3f, l: T, h: T) = gclamp{gvec3f}(v, l.gvec3f, h.gvec3f);
+fn clamp{T}(v: gvec3f, l: gvec3f, h: T) = gclamp{gvec3f}(v, l, h.gvec3f);
+fn clamp{T}(v: gvec3f, l: T, h: gvec3f) = gclamp{gvec3f}(v, l.gvec3f, h);
+fn clamp(v: gvec4f, l: gvec4f, h: gvec4f) = gclamp{gvec4f}(v, l, h);
+fn clamp{T}(v: gvec4f, l: T, h: T) = gclamp{gvec4f}(v, l.gvec4f, h.gvec4f);
+fn clamp{T}(v: gvec4f, l: gvec4f, h: T) = gclamp{gvec4f}(v, l, h.gvec4f);
+fn clamp{T}(v: gvec4f, l: T, h: gvec4f) = gclamp{gvec4f}(v, l.gvec4f, h);
 
 fn gexp{I}(v: I) {
   let varName = 'exp('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn exp(v: gf32) = gexp{gf32}(v);
-export fn exp(v: gvec2f) = gexp{gvec2f}(v);
-export fn exp(v: gvec3f) = gexp{gvec3f}(v);
-export fn exp(v: gvec4f) = gexp{gvec4f}(v);
+fn exp(v: gf32) = gexp{gf32}(v);
+fn exp(v: gvec2f) = gexp{gvec2f}(v);
+fn exp(v: gvec3f) = gexp{gvec3f}(v);
+fn exp(v: gvec4f) = gexp{gvec4f}(v);
 
 fn gln{I}(v: I) {
   let varName = 'log('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn ln(v: gf32) = gln{gf32}(v);
-export fn ln(v: gvec2f) = gln{gvec2f}(v);
-export fn ln(v: gvec3f) = gln{gvec3f}(v);
-export fn ln(v: gvec4f) = gln{gvec4f}(v);
+fn ln(v: gf32) = gln{gf32}(v);
+fn ln(v: gvec2f) = gln{gvec2f}(v);
+fn ln(v: gvec3f) = gln{gvec3f}(v);
+fn ln(v: gvec4f) = gln{gvec4f}(v);
 
 fn glog2{I}(v: I) {
   let varName = 'log2('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn log2(v: gf32) = glog2{gf32}(v);
-export fn log2(v: gvec2f) = glog2{gvec2f}(v);
-export fn log2(v: gvec3f) = glog2{gvec3f}(v);
-export fn log2(v: gvec4f) = glog2{gvec4f}(v);
+fn log2(v: gf32) = glog2{gf32}(v);
+fn log2(v: gvec2f) = glog2{gvec2f}(v);
+fn log2(v: gvec3f) = glog2{gvec3f}(v);
+fn log2(v: gvec4f) = glog2{gvec4f}(v);
 
 fn glog10{I}(v: I) {
   let varName = '(log('.concat(v.varName).concat(') / log(10.0))');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn log10(v: gf32) = glog10{gf32}(v);
-export fn log10(v: gvec2f) = glog10{gvec2f}(v);
-export fn log10(v: gvec3f) = glog10{gvec3f}(v);
-export fn log10(v: gvec4f) = glog10{gvec4f}(v);
+fn log10(v: gf32) = glog10{gf32}(v);
+fn log10(v: gvec2f) = glog10{gvec2f}(v);
+fn log10(v: gvec3f) = glog10{gvec3f}(v);
+fn log10(v: gvec4f) = glog10{gvec4f}(v);
 
 fn gcos{I}(v: I) {
   let varName = 'cos('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn cos(v: gf32) = gcos{gf32}(v);
-export fn cos(v: gvec2f) = gcos{gvec2f}(v);
-export fn cos(v: gvec3f) = gcos{gvec3f}(v);
-export fn cos(v: gvec4f) = gcos{gvec4f}(v);
+fn cos(v: gf32) = gcos{gf32}(v);
+fn cos(v: gvec2f) = gcos{gvec2f}(v);
+fn cos(v: gvec3f) = gcos{gvec3f}(v);
+fn cos(v: gvec4f) = gcos{gvec4f}(v);
 
 fn gcosh{I}(v: I) {
   let varName = 'cosh('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn cosh(v: gf32) = gcosh{gf32}(v);
-export fn cosh(v: gvec2f) = gcosh{gvec2f}(v);
-export fn cosh(v: gvec3f) = gcosh{gvec3f}(v);
-export fn cosh(v: gvec4f) = gcosh{gvec4f}(v);
+fn cosh(v: gf32) = gcosh{gf32}(v);
+fn cosh(v: gvec2f) = gcosh{gvec2f}(v);
+fn cosh(v: gvec3f) = gcosh{gvec3f}(v);
+fn cosh(v: gvec4f) = gcosh{gvec4f}(v);
 
 fn gsin{I}(v: I) {
   let varName = 'sin('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn sin(v: gf32) = gsin{gf32}(v);
-export fn sin(v: gvec2f) = gsin{gvec2f}(v);
-export fn sin(v: gvec3f) = gsin{gvec3f}(v);
-export fn sin(v: gvec4f) = gsin{gvec4f}(v);
+fn sin(v: gf32) = gsin{gf32}(v);
+fn sin(v: gvec2f) = gsin{gvec2f}(v);
+fn sin(v: gvec3f) = gsin{gvec3f}(v);
+fn sin(v: gvec4f) = gsin{gvec4f}(v);
 
 fn gsinh{I}(v: I) {
   let varName = 'sinh('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn sinh(v: gf32) = gsinh{gf32}(v);
-export fn sinh(v: gvec2f) = gsinh{gvec2f}(v);
-export fn sinh(v: gvec3f) = gsinh{gvec3f}(v);
-export fn sinh(v: gvec4f) = gsinh{gvec4f}(v);
+fn sinh(v: gf32) = gsinh{gf32}(v);
+fn sinh(v: gvec2f) = gsinh{gvec2f}(v);
+fn sinh(v: gvec3f) = gsinh{gvec3f}(v);
+fn sinh(v: gvec4f) = gsinh{gvec4f}(v);
 
 fn gtan{I}(v: I) {
   let varName = 'tan('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn tan(v: gf32) = gtan{gf32}(v);
-export fn tan(v: gvec2f) = gtan{gvec2f}(v);
-export fn tan(v: gvec3f) = gtan{gvec3f}(v);
-export fn tan(v: gvec4f) = gtan{gvec4f}(v);
+fn tan(v: gf32) = gtan{gf32}(v);
+fn tan(v: gvec2f) = gtan{gvec2f}(v);
+fn tan(v: gvec3f) = gtan{gvec3f}(v);
+fn tan(v: gvec4f) = gtan{gvec4f}(v);
 
 fn gtanh{I}(v: I) {
   let varName = 'tanh('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
 }
-export fn tanh(v: gf32) = gtanh{gf32}(v);
-export fn tanh(v: gvec2f) = gtanh{gvec2f}(v);
-export fn tanh(v: gvec3f) = gtanh{gvec3f}(v);
-export fn tanh(v: gvec4f) = gtanh{gvec4f}(v);
+fn tanh(v: gf32) = gtanh{gf32}(v);
+fn tanh(v: gvec2f) = gtanh{gvec2f}(v);
+fn tanh(v: gvec3f) = gtanh{gvec3f}(v);
+fn tanh(v: gvec4f) = gtanh{gvec4f}(v);
 
-export fn sec(v: gf32) = 1.0.div(cos(v));
-export fn sec(v: gvec2f) = gvec2f(1.0).div(cos(v));
-export fn sec(v: gvec3f) = gvec3f(1.0).div(cos(v));
-export fn sec(v: gvec4f) = gvec4f(1.0).div(cos(v));
+fn sec(v: gf32) = 1.0.div(cos(v));
+fn sec(v: gvec2f) = gvec2f(1.0).div(cos(v));
+fn sec(v: gvec3f) = gvec3f(1.0).div(cos(v));
+fn sec(v: gvec4f) = gvec4f(1.0).div(cos(v));
 
-export fn csc(v: gf32) = 1.0.div(sin(v));
-export fn csc(v: gvec2f) = gvec2f(1.0).div(sin(v));
-export fn csc(v: gvec3f) = gvec3f(1.0).div(sin(v));
-export fn csc(v: gvec4f) = gvec4f(1.0).div(sin(v));
+fn csc(v: gf32) = 1.0.div(sin(v));
+fn csc(v: gvec2f) = gvec2f(1.0).div(sin(v));
+fn csc(v: gvec3f) = gvec3f(1.0).div(sin(v));
+fn csc(v: gvec4f) = gvec4f(1.0).div(sin(v));
 
-export fn cot(v: gf32) = 1.0.div(tan(v));
-export fn cot(v: gvec2f) = gvec2f(1.0).div(tan(v));
-export fn cot(v: gvec3f) = gvec3f(1.0).div(tan(v));
-export fn cot(v: gvec4f) = gvec4f(1.0).div(tan(v));
+fn cot(v: gf32) = 1.0.div(tan(v));
+fn cot(v: gvec2f) = gvec2f(1.0).div(tan(v));
+fn cot(v: gvec3f) = gvec3f(1.0).div(tan(v));
+fn cot(v: gvec4f) = gvec4f(1.0).div(tan(v));
 
-export fn asec(v: gf32) = acos(1.0.div(v));
-export fn asec(v: gvec2f) = acos(gvec2f(1.0).div(v));
-export fn asec(v: gvec3f) = acos(gvec3f(1.0).div(v));
-export fn asec(v: gvec4f) = acos(gvec4f(1.0).div(v));
+fn asec(v: gf32) = acos(1.0.div(v));
+fn asec(v: gvec2f) = acos(gvec2f(1.0).div(v));
+fn asec(v: gvec3f) = acos(gvec3f(1.0).div(v));
+fn asec(v: gvec4f) = acos(gvec4f(1.0).div(v));
 
-export fn acsc(v: gf32) = asin(1.0.div(v));
-export fn acsc(v: gvec2f) = asin(gvec2f(1.0).div(v));
-export fn acsc(v: gvec3f) = asin(gvec3f(1.0).div(v));
-export fn acsc(v: gvec4f) = asin(gvec4f(1.0).div(v));
+fn acsc(v: gf32) = asin(1.0.div(v));
+fn acsc(v: gvec2f) = asin(gvec2f(1.0).div(v));
+fn acsc(v: gvec3f) = asin(gvec3f(1.0).div(v));
+fn acsc(v: gvec4f) = asin(gvec4f(1.0).div(v));
 
-export fn acot(v: gf32) = pi.div(2.0).sub(atan(v));
-export fn acot(v: gvec2f) = gvec2f(pi.div(2.0), pi.div(2.0)).sub(atan(v));
-export fn acot(v: gvec3f) = gvec3f(pi.div(2.0), pi.div(2.0), pi.div(2.0)).sub(atan(v));
-export fn acot(v: gvec4f) = gvec4f(pi.div(2.0), pi.div(2.0), pi.div(2.0), pi.div(2.0)).sub(atan(v));
+fn acot(v: gf32) = pi.div(2.0).sub(atan(v));
+fn acot(v: gvec2f) = gvec2f(pi.div(2.0), pi.div(2.0)).sub(atan(v));
+fn acot(v: gvec3f) = gvec3f(pi.div(2.0), pi.div(2.0), pi.div(2.0)).sub(atan(v));
+fn acot(v: gvec4f) = gvec4f(pi.div(2.0), pi.div(2.0), pi.div(2.0), pi.div(2.0)).sub(atan(v));
 
-export fn sech(v: gf32) = 1.0.div(cosh(v));
-export fn sech(v: gvec2f) = gvec2f(1.0).div(cosh(v));
-export fn sech(v: gvec3f) = gvec3f(1.0).div(cosh(v));
-export fn sech(v: gvec4f) = gvec4f(1.0).div(cosh(v));
+fn sech(v: gf32) = 1.0.div(cosh(v));
+fn sech(v: gvec2f) = gvec2f(1.0).div(cosh(v));
+fn sech(v: gvec3f) = gvec3f(1.0).div(cosh(v));
+fn sech(v: gvec4f) = gvec4f(1.0).div(cosh(v));
 
-export fn csch(v: gf32) = 1.0.div(sinh(v));
-export fn csch(v: gvec2f) = gvec2f(1.0).div(sinh(v));
-export fn csch(v: gvec3f) = gvec3f(1.0).div(sinh(v));
-export fn csch(v: gvec4f) = gvec4f(1.0).div(sinh(v));
+fn csch(v: gf32) = 1.0.div(sinh(v));
+fn csch(v: gvec2f) = gvec2f(1.0).div(sinh(v));
+fn csch(v: gvec3f) = gvec3f(1.0).div(sinh(v));
+fn csch(v: gvec4f) = gvec4f(1.0).div(sinh(v));
 
-export fn coth(v: gf32) = 1.0.div(tanh(v));
-export fn coth(v: gvec2f) = gvec2f(1.0).div(tanh(v));
-export fn coth(v: gvec3f) = gvec3f(1.0).div(tanh(v));
-export fn coth(v: gvec4f) = gvec4f(1.0).div(tanh(v));
+fn coth(v: gf32) = 1.0.div(tanh(v));
+fn coth(v: gvec2f) = gvec2f(1.0).div(tanh(v));
+fn coth(v: gvec3f) = gvec3f(1.0).div(tanh(v));
+fn coth(v: gvec4f) = gvec4f(1.0).div(tanh(v));
 
-export fn asech(v: gf32) = ln(1.0.add(sqrt(1.0.sub(v.pow(2.0)))).div(v));
-export fn asech(v: gvec2f) = ln(gvec2f(1.0).add(sqrt(gvec2f(1.0).sub(v.pow(gvec2f(2.0))))).div(v));
-export fn asech(v: gvec3f) = ln(gvec3f(1.0).add(sqrt(gvec3f(1.0).sub(v.pow(gvec3f(2.0))))).div(v));
-export fn asech(v: gvec4f) = ln(gvec4f(1.0).add(sqrt(gvec4f(1.0).sub(v.pow(gvec4f(2.0))))).div(v));
+fn asech(v: gf32) = ln(1.0.add(sqrt(1.0.sub(v.pow(2.0)))).div(v));
+fn asech(v: gvec2f) = ln(gvec2f(1.0).add(sqrt(gvec2f(1.0).sub(v.pow(gvec2f(2.0))))).div(v));
+fn asech(v: gvec3f) = ln(gvec3f(1.0).add(sqrt(gvec3f(1.0).sub(v.pow(gvec3f(2.0))))).div(v));
+fn asech(v: gvec4f) = ln(gvec4f(1.0).add(sqrt(gvec4f(1.0).sub(v.pow(gvec4f(2.0))))).div(v));
 
-export fn acsch(x: gf32) = ln(1.0.div(x).add(sqrt(1.0.div(x.pow(2.0)).add(1.0))));
-export fn acsch(x: gvec2f) = ln(gvec2f(1.0).div(x).add(sqrt(gvec2f(1.0).div(x.pow(gvec2f(2.0))).add(gvec2f(1.0)))));
-export fn acsch(x: gvec3f) = ln(gvec3f(1.0).div(x).add(sqrt(gvec3f(1.0).div(x.pow(gvec3f(2.0))).add(gvec3f(1.0)))));
-export fn acsch(x: gvec4f) = ln(gvec4f(1.0).div(x).add(sqrt(gvec4f(1.0).div(x.pow(gvec4f(2.0))).add(gvec4f(1.0)))));
+fn acsch(x: gf32) = ln(1.0.div(x).add(sqrt(1.0.div(x.pow(2.0)).add(1.0))));
+fn acsch(x: gvec2f) = ln(gvec2f(1.0).div(x).add(sqrt(gvec2f(1.0).div(x.pow(gvec2f(2.0))).add(gvec2f(1.0)))));
+fn acsch(x: gvec3f) = ln(gvec3f(1.0).div(x).add(sqrt(gvec3f(1.0).div(x.pow(gvec3f(2.0))).add(gvec3f(1.0)))));
+fn acsch(x: gvec4f) = ln(gvec4f(1.0).div(x).add(sqrt(gvec4f(1.0).div(x.pow(gvec4f(2.0))).add(gvec4f(1.0)))));
 
-export fn acoth(x: gf32) = ln(x.add(1.0).div(x.sub(1.0))).div(2.0);
-export fn acoth(x: gvec2f) = ln(x.add(gvec2f(1.0)).div(x.sub(gvec2f(1.0)))).div(gvec2f(2.0));
-export fn acoth(x: gvec3f) = ln(x.add(gvec3f(1.0)).div(x.sub(gvec3f(1.0)))).div(gvec3f(2.0));
-export fn acoth(x: gvec4f) = ln(x.add(gvec4f(1.0)).div(x.sub(gvec4f(1.0)))).div(gvec4f(2.0));
+fn acoth(x: gf32) = ln(x.add(1.0).div(x.sub(1.0))).div(2.0);
+fn acoth(x: gvec2f) = ln(x.add(gvec2f(1.0)).div(x.sub(gvec2f(1.0)))).div(gvec2f(2.0));
+fn acoth(x: gvec3f) = ln(x.add(gvec3f(1.0)).div(x.sub(gvec3f(1.0)))).div(gvec3f(2.0));
+fn acoth(x: gvec4f) = ln(x.add(gvec4f(1.0)).div(x.sub(gvec4f(1.0)))).div(gvec4f(2.0));
 
 // GPU Comparison methods
 
@@ -4334,30 +4369,30 @@ fn geq{I, O}(a: I, b: I) {
   let buffers = a.buffers.union(b.buffers);
   return {O}(varName, statements, buffers);
 }
-export fn eq(a: gu32, b: gu32) = geq{gu32, gbool}(a, b);
-export fn eq{T}(a: gu32, b: T) = geq{gu32, gbool}(a, b.gu32);
-export fn eq{T}(a: T, b: gu32) = geq{gu32, gbool}(a.gu32, b);
-export fn eq(a: gi32, b: gi32) = geq{gi32, gbool}(a, b);
-export fn eq{T}(a: gi32, b: T) = geq{gi32, gbool}(a, b.gi32);
-export fn eq{T}(a: T, b: gi32) = geq{gi32, gbool}(a.gi32, b);
-export fn eq(a: gf32, b: gf32) = geq{gf32, gbool}(a, b);
-export fn eq{T}(a: gf32, b: T) = geq{gf32, gbool}(a, b.gf32);
-export fn eq{T}(a: T, b: gf32) = geq{gf32, gbool}(a.gf32, b);
-export fn eq(a: gbool, b: gbool) = geq{gbool, gbool}(a, b);
-export fn eq{T}(a: gbool, b: T) = geq{gbool, gbool}(a, b.gbool);
-export fn eq{T}(a: T, b: gbool) = geq{gbool, gbool}(a.gbool, b);
-export fn eq(a: gvec2u, b: gvec2u) = geq{gvec2u, gvec2b}(a, b);
-export fn eq(a: gvec2i, b: gvec2i) = geq{gvec2i, gvec2b}(a, b);
-export fn eq(a: gvec2f, b: gvec2f) = geq{gvec2f, gvec2b}(a, b);
-export fn eq(a: gvec2b, b: gvec2b) = geq{gvec2b, gvec2b}(a, b);
-export fn eq(a: gvec3u, b: gvec3u) = geq{gvec3u, gvec3b}(a, b);
-export fn eq(a: gvec3i, b: gvec3i) = geq{gvec3i, gvec3b}(a, b);
-export fn eq(a: gvec3f, b: gvec3f) = geq{gvec3f, gvec3b}(a, b);
-export fn eq(a: gvec3b, b: gvec3b) = geq{gvec3b, gvec3b}(a, b);
-export fn eq(a: gvec4u, b: gvec4u) = geq{gvec4u, gvec4b}(a, b);
-export fn eq(a: gvec4i, b: gvec4i) = geq{gvec4i, gvec4b}(a, b);
-export fn eq(a: gvec4f, b: gvec4f) = geq{gvec4f, gvec4b}(a, b);
-export fn eq(a: gvec4b, b: gvec4b) = geq{gvec4b, gvec4b}(a, b);
+fn eq(a: gu32, b: gu32) = geq{gu32, gbool}(a, b);
+fn eq{T}(a: gu32, b: T) = geq{gu32, gbool}(a, b.gu32);
+fn eq{T}(a: T, b: gu32) = geq{gu32, gbool}(a.gu32, b);
+fn eq(a: gi32, b: gi32) = geq{gi32, gbool}(a, b);
+fn eq{T}(a: gi32, b: T) = geq{gi32, gbool}(a, b.gi32);
+fn eq{T}(a: T, b: gi32) = geq{gi32, gbool}(a.gi32, b);
+fn eq(a: gf32, b: gf32) = geq{gf32, gbool}(a, b);
+fn eq{T}(a: gf32, b: T) = geq{gf32, gbool}(a, b.gf32);
+fn eq{T}(a: T, b: gf32) = geq{gf32, gbool}(a.gf32, b);
+fn eq(a: gbool, b: gbool) = geq{gbool, gbool}(a, b);
+fn eq{T}(a: gbool, b: T) = geq{gbool, gbool}(a, b.gbool);
+fn eq{T}(a: T, b: gbool) = geq{gbool, gbool}(a.gbool, b);
+fn eq(a: gvec2u, b: gvec2u) = geq{gvec2u, gvec2b}(a, b);
+fn eq(a: gvec2i, b: gvec2i) = geq{gvec2i, gvec2b}(a, b);
+fn eq(a: gvec2f, b: gvec2f) = geq{gvec2f, gvec2b}(a, b);
+fn eq(a: gvec2b, b: gvec2b) = geq{gvec2b, gvec2b}(a, b);
+fn eq(a: gvec3u, b: gvec3u) = geq{gvec3u, gvec3b}(a, b);
+fn eq(a: gvec3i, b: gvec3i) = geq{gvec3i, gvec3b}(a, b);
+fn eq(a: gvec3f, b: gvec3f) = geq{gvec3f, gvec3b}(a, b);
+fn eq(a: gvec3b, b: gvec3b) = geq{gvec3b, gvec3b}(a, b);
+fn eq(a: gvec4u, b: gvec4u) = geq{gvec4u, gvec4b}(a, b);
+fn eq(a: gvec4i, b: gvec4i) = geq{gvec4i, gvec4b}(a, b);
+fn eq(a: gvec4f, b: gvec4f) = geq{gvec4f, gvec4b}(a, b);
+fn eq(a: gvec4b, b: gvec4b) = geq{gvec4b, gvec4b}(a, b);
 
 fn gneq{I, O}(a: I, b: I) {
   let varName = '('.concat(a.varName).concat(' != ').concat(b.varName).concat(')');
@@ -4365,30 +4400,30 @@ fn gneq{I, O}(a: I, b: I) {
   let buffers = a.buffers.union(b.buffers);
   return {O}(varName, statements, buffers);
 }
-export fn neq(a: gu32, b: gu32) = gneq{gu32, gbool}(a, b);
-export fn neq{T}(a: gu32, b: T) = gneq{gu32, gbool}(a, b.gu32);
-export fn neq{T}(a: T, b: gu32) = gneq{gu32, gbool}(a.gu32, b);
-export fn neq(a: gi32, b: gi32) = gneq{gi32, gbool}(a, b);
-export fn neq{T}(a: gi32, b: T) = gneq{gi32, gbool}(a, b.gi32);
-export fn neq{T}(a: T, b: gi32) = gneq{gi32, gbool}(a.gi32, b);
-export fn neq(a: gf32, b: gf32) = gneq{gf32, gbool}(a, b);
-export fn neq{T}(a: gf32, b: T) = gneq{gf32, gbool}(a, b.gf32);
-export fn neq{T}(a: T, b: gf32) = gneq{gf32, gbool}(a.gf32, b);
-export fn neq(a: gbool, b: gbool) = gneq{gbool, gbool}(a, b);
-export fn neq{T}(a: gbool, b: T) = gneq{gbool, gbool}(a, b.gbool);
-export fn neq{T}(a: T, b: gbool) = gneq{gbool, gbool}(a.gbool, b);
-export fn neq(a: gvec2u, b: gvec2u) = gneq{gvec2u, gvec2b}(a, b);
-export fn neq(a: gvec2i, b: gvec2i) = gneq{gvec2i, gvec2b}(a, b);
-export fn neq(a: gvec2f, b: gvec2f) = gneq{gvec2f, gvec2b}(a, b);
-export fn neq(a: gvec2b, b: gvec2b) = gneq{gvec2b, gvec2b}(a, b);
-export fn neq(a: gvec3u, b: gvec3u) = gneq{gvec3u, gvec3b}(a, b);
-export fn neq(a: gvec3i, b: gvec3i) = gneq{gvec3i, gvec3b}(a, b);
-export fn neq(a: gvec3f, b: gvec3f) = gneq{gvec3f, gvec3b}(a, b);
-export fn neq(a: gvec3b, b: gvec3b) = gneq{gvec3b, gvec3b}(a, b);
-export fn neq(a: gvec4u, b: gvec4u) = gneq{gvec4u, gvec4b}(a, b);
-export fn neq(a: gvec4i, b: gvec4i) = gneq{gvec4i, gvec4b}(a, b);
-export fn neq(a: gvec4f, b: gvec4f) = gneq{gvec4f, gvec4b}(a, b);
-export fn neq(a: gvec4b, b: gvec4b) = gneq{gvec4b, gvec4b}(a, b);
+fn neq(a: gu32, b: gu32) = gneq{gu32, gbool}(a, b);
+fn neq{T}(a: gu32, b: T) = gneq{gu32, gbool}(a, b.gu32);
+fn neq{T}(a: T, b: gu32) = gneq{gu32, gbool}(a.gu32, b);
+fn neq(a: gi32, b: gi32) = gneq{gi32, gbool}(a, b);
+fn neq{T}(a: gi32, b: T) = gneq{gi32, gbool}(a, b.gi32);
+fn neq{T}(a: T, b: gi32) = gneq{gi32, gbool}(a.gi32, b);
+fn neq(a: gf32, b: gf32) = gneq{gf32, gbool}(a, b);
+fn neq{T}(a: gf32, b: T) = gneq{gf32, gbool}(a, b.gf32);
+fn neq{T}(a: T, b: gf32) = gneq{gf32, gbool}(a.gf32, b);
+fn neq(a: gbool, b: gbool) = gneq{gbool, gbool}(a, b);
+fn neq{T}(a: gbool, b: T) = gneq{gbool, gbool}(a, b.gbool);
+fn neq{T}(a: T, b: gbool) = gneq{gbool, gbool}(a.gbool, b);
+fn neq(a: gvec2u, b: gvec2u) = gneq{gvec2u, gvec2b}(a, b);
+fn neq(a: gvec2i, b: gvec2i) = gneq{gvec2i, gvec2b}(a, b);
+fn neq(a: gvec2f, b: gvec2f) = gneq{gvec2f, gvec2b}(a, b);
+fn neq(a: gvec2b, b: gvec2b) = gneq{gvec2b, gvec2b}(a, b);
+fn neq(a: gvec3u, b: gvec3u) = gneq{gvec3u, gvec3b}(a, b);
+fn neq(a: gvec3i, b: gvec3i) = gneq{gvec3i, gvec3b}(a, b);
+fn neq(a: gvec3f, b: gvec3f) = gneq{gvec3f, gvec3b}(a, b);
+fn neq(a: gvec3b, b: gvec3b) = gneq{gvec3b, gvec3b}(a, b);
+fn neq(a: gvec4u, b: gvec4u) = gneq{gvec4u, gvec4b}(a, b);
+fn neq(a: gvec4i, b: gvec4i) = gneq{gvec4i, gvec4b}(a, b);
+fn neq(a: gvec4f, b: gvec4f) = gneq{gvec4f, gvec4b}(a, b);
+fn neq(a: gvec4b, b: gvec4b) = gneq{gvec4b, gvec4b}(a, b);
 
 fn glt{I, O}(a: I, b: I) {
   let varName = '('.concat(a.varName).concat(' < ').concat(b.varName).concat(')');
@@ -4396,24 +4431,24 @@ fn glt{I, O}(a: I, b: I) {
   let buffers = a.buffers.union(b.buffers);
   return {O}(varName, statements, buffers);
 }
-export fn lt(a: gu32, b: gu32) = glt{gu32, gbool}(a, b);
-export fn lt{T}(a: gu32, b: T) = glt{gu32, gbool}(a, b.gu32);
-export fn lt{T}(a: T, b: gu32) = glt{gu32, gbool}(a.gu32, b);
-export fn lt(a: gi32, b: gi32) = glt{gi32, gbool}(a, b);
-export fn lt{T}(a: gi32, b: T) = glt{gi32, gbool}(a, b.gi32);
-export fn lt{T}(a: T, b: gi32) = glt{gi32, gbool}(a.gi32, b);
-export fn lt(a: gf32, b: gf32) = glt{gf32, gbool}(a, b);
-export fn lt{T}(a: gf32, b: T) = glt{gf32, gbool}(a, b.gf32);
-export fn lt{T}(a: T, b: gf32) = glt{gf32, gbool}(a.gf32, b);
-export fn lt(a: gvec2u, b: gvec2u) = glt{gvec2u, gvec2b}(a, b);
-export fn lt(a: gvec2i, b: gvec2i) = glt{gvec2i, gvec2b}(a, b);
-export fn lt(a: gvec2f, b: gvec2f) = glt{gvec2f, gvec2b}(a, b);
-export fn lt(a: gvec3u, b: gvec3u) = glt{gvec3u, gvec3b}(a, b);
-export fn lt(a: gvec3i, b: gvec3i) = glt{gvec3i, gvec3b}(a, b);
-export fn lt(a: gvec3f, b: gvec3f) = glt{gvec3f, gvec3b}(a, b);
-export fn lt(a: gvec4u, b: gvec4u) = glt{gvec4u, gvec4b}(a, b);
-export fn lt(a: gvec4i, b: gvec4i) = glt{gvec4i, gvec4b}(a, b);
-export fn lt(a: gvec4f, b: gvec4f) = glt{gvec4f, gvec4b}(a, b);
+fn lt(a: gu32, b: gu32) = glt{gu32, gbool}(a, b);
+fn lt{T}(a: gu32, b: T) = glt{gu32, gbool}(a, b.gu32);
+fn lt{T}(a: T, b: gu32) = glt{gu32, gbool}(a.gu32, b);
+fn lt(a: gi32, b: gi32) = glt{gi32, gbool}(a, b);
+fn lt{T}(a: gi32, b: T) = glt{gi32, gbool}(a, b.gi32);
+fn lt{T}(a: T, b: gi32) = glt{gi32, gbool}(a.gi32, b);
+fn lt(a: gf32, b: gf32) = glt{gf32, gbool}(a, b);
+fn lt{T}(a: gf32, b: T) = glt{gf32, gbool}(a, b.gf32);
+fn lt{T}(a: T, b: gf32) = glt{gf32, gbool}(a.gf32, b);
+fn lt(a: gvec2u, b: gvec2u) = glt{gvec2u, gvec2b}(a, b);
+fn lt(a: gvec2i, b: gvec2i) = glt{gvec2i, gvec2b}(a, b);
+fn lt(a: gvec2f, b: gvec2f) = glt{gvec2f, gvec2b}(a, b);
+fn lt(a: gvec3u, b: gvec3u) = glt{gvec3u, gvec3b}(a, b);
+fn lt(a: gvec3i, b: gvec3i) = glt{gvec3i, gvec3b}(a, b);
+fn lt(a: gvec3f, b: gvec3f) = glt{gvec3f, gvec3b}(a, b);
+fn lt(a: gvec4u, b: gvec4u) = glt{gvec4u, gvec4b}(a, b);
+fn lt(a: gvec4i, b: gvec4i) = glt{gvec4i, gvec4b}(a, b);
+fn lt(a: gvec4f, b: gvec4f) = glt{gvec4f, gvec4b}(a, b);
 
 fn glte{I, O}(a: I, b: I) {
   let varName = '('.concat(a.varName).concat(' <= ').concat(b.varName).concat(')');
@@ -4421,24 +4456,24 @@ fn glte{I, O}(a: I, b: I) {
   let buffers = a.buffers.union(b.buffers);
   return {O}(varName, statements, buffers);
 }
-export fn lte(a: gu32, b: gu32) = glte{gu32, gbool}(a, b);
-export fn lte{T}(a: gu32, b: T) = glte{gu32, gbool}(a, b.gu32);
-export fn lte{T}(a: T, b: gu32) = glte{gu32, gbool}(a.gu32, b);
-export fn lte(a: gi32, b: gi32) = glte{gi32, gbool}(a, b);
-export fn lte{T}(a: gi32, b: T) = glte{gi32, gbool}(a, b.gi32);
-export fn lte{T}(a: T, b: gi32) = glte{gi32, gbool}(a.gi32, b);
-export fn lte(a: gf32, b: gf32) = glte{gf32, gbool}(a, b);
-export fn lte{T}(a: gf32, b: T) = glte{gf32, gbool}(a, b.gf32);
-export fn lte{T}(a: T, b: gf32) = glte{gf32, gbool}(a.gf32, b);
-export fn lte(a: gvec2u, b: gvec2u) = glte{gvec2u, gvec2b}(a, b);
-export fn lte(a: gvec2i, b: gvec2i) = glte{gvec2i, gvec2b}(a, b);
-export fn lte(a: gvec2f, b: gvec2f) = glte{gvec2f, gvec2b}(a, b);
-export fn lte(a: gvec3u, b: gvec3u) = glte{gvec3u, gvec3b}(a, b);
-export fn lte(a: gvec3i, b: gvec3i) = glte{gvec3i, gvec3b}(a, b);
-export fn lte(a: gvec3f, b: gvec3f) = glte{gvec3f, gvec3b}(a, b);
-export fn lte(a: gvec4u, b: gvec4u) = glte{gvec4u, gvec4b}(a, b);
-export fn lte(a: gvec4i, b: gvec4i) = glte{gvec4i, gvec4b}(a, b);
-export fn lte(a: gvec4f, b: gvec4f) = glte{gvec4f, gvec4b}(a, b);
+fn lte(a: gu32, b: gu32) = glte{gu32, gbool}(a, b);
+fn lte{T}(a: gu32, b: T) = glte{gu32, gbool}(a, b.gu32);
+fn lte{T}(a: T, b: gu32) = glte{gu32, gbool}(a.gu32, b);
+fn lte(a: gi32, b: gi32) = glte{gi32, gbool}(a, b);
+fn lte{T}(a: gi32, b: T) = glte{gi32, gbool}(a, b.gi32);
+fn lte{T}(a: T, b: gi32) = glte{gi32, gbool}(a.gi32, b);
+fn lte(a: gf32, b: gf32) = glte{gf32, gbool}(a, b);
+fn lte{T}(a: gf32, b: T) = glte{gf32, gbool}(a, b.gf32);
+fn lte{T}(a: T, b: gf32) = glte{gf32, gbool}(a.gf32, b);
+fn lte(a: gvec2u, b: gvec2u) = glte{gvec2u, gvec2b}(a, b);
+fn lte(a: gvec2i, b: gvec2i) = glte{gvec2i, gvec2b}(a, b);
+fn lte(a: gvec2f, b: gvec2f) = glte{gvec2f, gvec2b}(a, b);
+fn lte(a: gvec3u, b: gvec3u) = glte{gvec3u, gvec3b}(a, b);
+fn lte(a: gvec3i, b: gvec3i) = glte{gvec3i, gvec3b}(a, b);
+fn lte(a: gvec3f, b: gvec3f) = glte{gvec3f, gvec3b}(a, b);
+fn lte(a: gvec4u, b: gvec4u) = glte{gvec4u, gvec4b}(a, b);
+fn lte(a: gvec4i, b: gvec4i) = glte{gvec4i, gvec4b}(a, b);
+fn lte(a: gvec4f, b: gvec4f) = glte{gvec4f, gvec4b}(a, b);
 
 fn ggt{I, O}(a: I, b: I) {
   let varName = '('.concat(a.varName).concat(' < ').concat(b.varName).concat(')');
@@ -4446,24 +4481,24 @@ fn ggt{I, O}(a: I, b: I) {
   let buffers = a.buffers.union(b.buffers);
   return {O}(varName, statements, buffers);
 }
-export fn gt(a: gu32, b: gu32) = ggt{gu32, gbool}(a, b);
-export fn gt{T}(a: gu32, b: T) = ggt{gu32, gbool}(a, b.gu32);
-export fn gt{T}(a: T, b: gu32) = ggt{gu32, gbool}(a.gu32, b);
-export fn gt(a: gi32, b: gi32) = ggt{gi32, gbool}(a, b);
-export fn gt{T}(a: gi32, b: T) = ggt{gi32, gbool}(a, b.gi32);
-export fn gt{T}(a: T, b: gi32) = ggt{gi32, gbool}(a.gi32, b);
-export fn gt(a: gf32, b: gf32) = ggt{gf32, gbool}(a, b);
-export fn gt{T}(a: gf32, b: T) = ggt{gf32, gbool}(a, b.gf32);
-export fn gt{T}(a: T, b: gf32) = ggt{gf32, gbool}(a.gf32, b);
-export fn gt(a: gvec2u, b: gvec2u) = ggt{gvec2u, gvec2b}(a, b);
-export fn gt(a: gvec2i, b: gvec2i) = ggt{gvec2i, gvec2b}(a, b);
-export fn gt(a: gvec2f, b: gvec2f) = ggt{gvec2f, gvec2b}(a, b);
-export fn gt(a: gvec3u, b: gvec3u) = ggt{gvec3u, gvec3b}(a, b);
-export fn gt(a: gvec3i, b: gvec3i) = ggt{gvec3i, gvec3b}(a, b);
-export fn gt(a: gvec3f, b: gvec3f) = ggt{gvec3f, gvec3b}(a, b);
-export fn gt(a: gvec4u, b: gvec4u) = ggt{gvec4u, gvec4b}(a, b);
-export fn gt(a: gvec4i, b: gvec4i) = ggt{gvec4i, gvec4b}(a, b);
-export fn gt(a: gvec4f, b: gvec4f) = ggt{gvec4f, gvec4b}(a, b);
+fn gt(a: gu32, b: gu32) = ggt{gu32, gbool}(a, b);
+fn gt{T}(a: gu32, b: T) = ggt{gu32, gbool}(a, b.gu32);
+fn gt{T}(a: T, b: gu32) = ggt{gu32, gbool}(a.gu32, b);
+fn gt(a: gi32, b: gi32) = ggt{gi32, gbool}(a, b);
+fn gt{T}(a: gi32, b: T) = ggt{gi32, gbool}(a, b.gi32);
+fn gt{T}(a: T, b: gi32) = ggt{gi32, gbool}(a.gi32, b);
+fn gt(a: gf32, b: gf32) = ggt{gf32, gbool}(a, b);
+fn gt{T}(a: gf32, b: T) = ggt{gf32, gbool}(a, b.gf32);
+fn gt{T}(a: T, b: gf32) = ggt{gf32, gbool}(a.gf32, b);
+fn gt(a: gvec2u, b: gvec2u) = ggt{gvec2u, gvec2b}(a, b);
+fn gt(a: gvec2i, b: gvec2i) = ggt{gvec2i, gvec2b}(a, b);
+fn gt(a: gvec2f, b: gvec2f) = ggt{gvec2f, gvec2b}(a, b);
+fn gt(a: gvec3u, b: gvec3u) = ggt{gvec3u, gvec3b}(a, b);
+fn gt(a: gvec3i, b: gvec3i) = ggt{gvec3i, gvec3b}(a, b);
+fn gt(a: gvec3f, b: gvec3f) = ggt{gvec3f, gvec3b}(a, b);
+fn gt(a: gvec4u, b: gvec4u) = ggt{gvec4u, gvec4b}(a, b);
+fn gt(a: gvec4i, b: gvec4i) = ggt{gvec4i, gvec4b}(a, b);
+fn gt(a: gvec4f, b: gvec4f) = ggt{gvec4f, gvec4b}(a, b);
 
 fn ggte{I, O}(a: I, b: I) {
   let varName = '('.concat(a.varName).concat(' <= ').concat(b.varName).concat(')');
@@ -4471,34 +4506,34 @@ fn ggte{I, O}(a: I, b: I) {
   let buffers = a.buffers.union(b.buffers);
   return {O}(varName, statements, buffers);
 }
-export fn gte(a: gu32, b: gu32) = ggte{gu32, gbool}(a, b);
-export fn gte{T}(a: gu32, b: T) = ggte{gu32, gbool}(a, b.gu32);
-export fn gte{T}(a: T, b: gu32) = ggte{gu32, gbool}(a.gu32, b);
-export fn gte(a: gi32, b: gi32) = ggte{gi32, gbool}(a, b);
-export fn gte{T}(a: gi32, b: T) = ggte{gi32, gbool}(a, b.gi32);
-export fn gte{T}(a: T, b: gi32) = ggte{gi32, gbool}(a.gi32, b);
-export fn gte(a: gf32, b: gf32) = ggte{gf32, gbool}(a, b);
-export fn gte{T}(a: gf32, b: T) = ggte{gf32, gbool}(a, b.gf32);
-export fn gte{T}(a: T, b: gf32) = ggte{gf32, gbool}(a.gf32, b);
-export fn gte(a: gvec2u, b: gvec2u) = ggte{gvec2u, gvec2b}(a, b);
-export fn gte(a: gvec2i, b: gvec2i) = ggte{gvec2i, gvec2b}(a, b);
-export fn gte(a: gvec2f, b: gvec2f) = ggte{gvec2f, gvec2b}(a, b);
-export fn gte(a: gvec3u, b: gvec3u) = ggte{gvec3u, gvec3b}(a, b);
-export fn gte(a: gvec3i, b: gvec3i) = ggte{gvec3i, gvec3b}(a, b);
-export fn gte(a: gvec3f, b: gvec3f) = ggte{gvec3f, gvec3b}(a, b);
-export fn gte(a: gvec4u, b: gvec4u) = ggte{gvec4u, gvec4b}(a, b);
-export fn gte(a: gvec4i, b: gvec4i) = ggte{gvec4i, gvec4b}(a, b);
-export fn gte(a: gvec4f, b: gvec4f) = ggte{gvec4f, gvec4b}(a, b);
+fn gte(a: gu32, b: gu32) = ggte{gu32, gbool}(a, b);
+fn gte{T}(a: gu32, b: T) = ggte{gu32, gbool}(a, b.gu32);
+fn gte{T}(a: T, b: gu32) = ggte{gu32, gbool}(a.gu32, b);
+fn gte(a: gi32, b: gi32) = ggte{gi32, gbool}(a, b);
+fn gte{T}(a: gi32, b: T) = ggte{gi32, gbool}(a, b.gi32);
+fn gte{T}(a: T, b: gi32) = ggte{gi32, gbool}(a.gi32, b);
+fn gte(a: gf32, b: gf32) = ggte{gf32, gbool}(a, b);
+fn gte{T}(a: gf32, b: T) = ggte{gf32, gbool}(a, b.gf32);
+fn gte{T}(a: T, b: gf32) = ggte{gf32, gbool}(a.gf32, b);
+fn gte(a: gvec2u, b: gvec2u) = ggte{gvec2u, gvec2b}(a, b);
+fn gte(a: gvec2i, b: gvec2i) = ggte{gvec2i, gvec2b}(a, b);
+fn gte(a: gvec2f, b: gvec2f) = ggte{gvec2f, gvec2b}(a, b);
+fn gte(a: gvec3u, b: gvec3u) = ggte{gvec3u, gvec3b}(a, b);
+fn gte(a: gvec3i, b: gvec3i) = ggte{gvec3i, gvec3b}(a, b);
+fn gte(a: gvec3f, b: gvec3f) = ggte{gvec3f, gvec3b}(a, b);
+fn gte(a: gvec4u, b: gvec4u) = ggte{gvec4u, gvec4b}(a, b);
+fn gte(a: gvec4i, b: gvec4i) = ggte{gvec4i, gvec4b}(a, b);
+fn gte(a: gvec4f, b: gvec4f) = ggte{gvec4f, gvec4b}(a, b);
 
 fn if{T}(c: gbool, t: T, f: T) {
   let varName = "if_".concat(uuid().string.replace('-', '_'));
   let tBody = t.statements.Array.map(fn (kv: (string, string)) {
-    return if(kv.0.eq("@builtin(global_invocation_id) id: vec3u"), fn () = "", fn () {
+    return if(kv.0 == "@builtin(global_invocation_id) id: vec3u", fn () = "", fn () {
       return "  ".concat(kv.1).concat(";\n");
     });
   }).join("");
   let fBody = f.statements.Array.map(fn (kv: (string, string)) {
-    return if(kv.0.eq("@builtin(global_invocation_id) id: vec3u"), fn () = "", fn () {
+    return if(kv.0 == "@builtin(global_invocation_id) id: vec3u", fn () = "", fn () {
       return "  ".concat(kv.1).concat(";\n");
     });
   }).join("");
@@ -4547,18 +4582,18 @@ fn gnot{I}(a: I) {
   let buffers = a.buffers.clone();
   return {I}(varName, statements, buffers);
 }
-export fn not(a: gu32) = gnot(a);
-export fn not(a: gi32) = gnot(a);
-export fn not(a: gbool) = gnot(a);
-export fn not(a: gvec2u) = gnot(a);
-export fn not(a: gvec2i) = gnot(a);
-export fn not(a: gvec2b) = gnot(a);
-export fn not(a: gvec3u) = gnot(a);
-export fn not(a: gvec3i) = gnot(a);
-export fn not(a: gvec3b) = gnot(a);
-export fn not(a: gvec4u) = gnot(a);
-export fn not(a: gvec4i) = gnot(a);
-export fn not(a: gvec4b) = gnot(a);
+fn not(a: gu32) = gnot(a);
+fn not(a: gi32) = gnot(a);
+fn not(a: gbool) = gnot(a);
+fn not(a: gvec2u) = gnot(a);
+fn not(a: gvec2i) = gnot(a);
+fn not(a: gvec2b) = gnot(a);
+fn not(a: gvec3u) = gnot(a);
+fn not(a: gvec3i) = gnot(a);
+fn not(a: gvec3b) = gnot(a);
+fn not(a: gvec4u) = gnot(a);
+fn not(a: gvec4i) = gnot(a);
+fn not(a: gvec4b) = gnot(a);
 
 fn gor{I}(a: I, b: I) {
   let varName = '('.concat(a.varName).concat(' | ').concat(b.varName).concat(')');
@@ -4566,24 +4601,24 @@ fn gor{I}(a: I, b: I) {
   let buffers = a.buffers.union(b.buffers);
   return {I}(varName, statements, buffers);
 }
-export fn or(a: gu32, b: gu32) = gor(a, b);
-export fn or{T}(a: gu32, b: T) = gor(a, b.gu32);
-export fn or{T}(a: T, b: gu32) = gor(a.gu32, b);
-export fn or(a: gi32, b: gi32) = gor(a, b);
-export fn or{T}(a: gi32, b: T) = gor(a, b.gi32);
-export fn or{T}(a: T, b: gi32) = gor(a.gi32, b);
-export fn or(a: gbool, b: gbool) = gor(a, b);
-export fn or{T}(a: gbool, b: T) = gor(a, b.gbool);
-export fn or{T}(a: T, b: gbool) = gor(a.gbool, b);
-export fn or(a: gvec2u, b: gvec2u) = gor(a, b);
-export fn or(a: gvec2i, b: gvec2i) = gor(a, b);
-export fn or(a: gvec2b, b: gvec2b) = gor(a, b);
-export fn or(a: gvec3u, b: gvec3u) = gor(a, b);
-export fn or(a: gvec3i, b: gvec3i) = gor(a, b);
-export fn or(a: gvec3b, b: gvec3b) = gor(a, b);
-export fn or(a: gvec4u, b: gvec4u) = gor(a, b);
-export fn or(a: gvec4i, b: gvec4i) = gor(a, b);
-export fn or(a: gvec4b, b: gvec4b) = gor(a, b);
+fn or(a: gu32, b: gu32) = gor(a, b);
+fn or{T}(a: gu32, b: T) = gor(a, b.gu32);
+fn or{T}(a: T, b: gu32) = gor(a.gu32, b);
+fn or(a: gi32, b: gi32) = gor(a, b);
+fn or{T}(a: gi32, b: T) = gor(a, b.gi32);
+fn or{T}(a: T, b: gi32) = gor(a.gi32, b);
+fn or(a: gbool, b: gbool) = gor(a, b);
+fn or{T}(a: gbool, b: T) = gor(a, b.gbool);
+fn or{T}(a: T, b: gbool) = gor(a.gbool, b);
+fn or(a: gvec2u, b: gvec2u) = gor(a, b);
+fn or(a: gvec2i, b: gvec2i) = gor(a, b);
+fn or(a: gvec2b, b: gvec2b) = gor(a, b);
+fn or(a: gvec3u, b: gvec3u) = gor(a, b);
+fn or(a: gvec3i, b: gvec3i) = gor(a, b);
+fn or(a: gvec3b, b: gvec3b) = gor(a, b);
+fn or(a: gvec4u, b: gvec4u) = gor(a, b);
+fn or(a: gvec4i, b: gvec4i) = gor(a, b);
+fn or(a: gvec4b, b: gvec4b) = gor(a, b);
 
 fn gand{I}(a: I, b: I) {
   let varName = '('.concat(a.varName).concat(' & ').concat(b.varName).concat(')');
@@ -4591,24 +4626,24 @@ fn gand{I}(a: I, b: I) {
   let buffers = a.buffers.union(b.buffers);
   return {I}(varName, statements, buffers);
 }
-export fn and(a: gu32, b: gu32) = gand(a, b);
-export fn and{T}(a: gu32, b: T) = gand(a, b.gu32);
-export fn and{T}(a: T, b: gu32) = gand(a.gu32, b);
-export fn and(a: gi32, b: gi32) = gand(a, b);
-export fn and{T}(a: gi32, b: T) = gand(a, b.gi32);
-export fn and{T}(a: T, b: gi32) = gand(a.gi32, b);
-export fn and(a: gbool, b: gbool) = gand(a, b);
-export fn and{T}(a: gbool, b: T) = gand(a, b.gbool);
-export fn and{T}(a: T, b: gbool) = gand(a.gbool, b);
-export fn and(a: gvec2u, b: gvec2u) = gand(a, b);
-export fn and(a: gvec2i, b: gvec2i) = gand(a, b);
-export fn and(a: gvec2b, b: gvec2b) = gand(a, b);
-export fn and(a: gvec3u, b: gvec3u) = gand(a, b);
-export fn and(a: gvec3i, b: gvec3i) = gand(a, b);
-export fn and(a: gvec3b, b: gvec3b) = gand(a, b);
-export fn and(a: gvec4u, b: gvec4u) = gand(a, b);
-export fn and(a: gvec4i, b: gvec4i) = gand(a, b);
-export fn and(a: gvec4b, b: gvec4b) = gand(a, b);
+fn and(a: gu32, b: gu32) = gand(a, b);
+fn and{T}(a: gu32, b: T) = gand(a, b.gu32);
+fn and{T}(a: T, b: gu32) = gand(a.gu32, b);
+fn and(a: gi32, b: gi32) = gand(a, b);
+fn and{T}(a: gi32, b: T) = gand(a, b.gi32);
+fn and{T}(a: T, b: gi32) = gand(a.gi32, b);
+fn and(a: gbool, b: gbool) = gand(a, b);
+fn and{T}(a: gbool, b: T) = gand(a, b.gbool);
+fn and{T}(a: T, b: gbool) = gand(a.gbool, b);
+fn and(a: gvec2u, b: gvec2u) = gand(a, b);
+fn and(a: gvec2i, b: gvec2i) = gand(a, b);
+fn and(a: gvec2b, b: gvec2b) = gand(a, b);
+fn and(a: gvec3u, b: gvec3u) = gand(a, b);
+fn and(a: gvec3i, b: gvec3i) = gand(a, b);
+fn and(a: gvec3b, b: gvec3b) = gand(a, b);
+fn and(a: gvec4u, b: gvec4u) = gand(a, b);
+fn and(a: gvec4i, b: gvec4i) = gand(a, b);
+fn and(a: gvec4b, b: gvec4b) = gand(a, b);
 
 // There's no xor for bools in wgsl. Do I patch that over or leave it as an exercise to the reader?
 fn gxor{I}(a: I, b: I) {
@@ -4617,18 +4652,18 @@ fn gxor{I}(a: I, b: I) {
   let buffers = a.buffers.union(b.buffers);
   return {I}(varName, statements, buffers);
 }
-export fn xor(a: gu32, b: gu32) = gxor(a, b);
-export fn xor{T}(a: gu32, b: T) = gxor(a, b.gu32);
-export fn xor{T}(a: T, b: gu32) = gxor(a.gu32, b);
-export fn xor(a: gi32, b: gi32) = gxor(a, b);
-export fn xor{T}(a: gi32, b: T) = gxor(a, b.gi32);
-export fn xor{T}(a: T, b: gi32) = gxor(a.gi32, b);
-export fn xor(a: gvec2u, b: gvec2u) = gxor(a, b);
-export fn xor(a: gvec2i, b: gvec2i) = gxor(a, b);
-export fn xor(a: gvec3u, b: gvec3u) = gxor(a, b);
-export fn xor(a: gvec3i, b: gvec3i) = gxor(a, b);
-export fn xor(a: gvec4u, b: gvec4u) = gxor(a, b);
-export fn xor(a: gvec4i, b: gvec4i) = gxor(a, b);
+fn xor(a: gu32, b: gu32) = gxor(a, b);
+fn xor{T}(a: gu32, b: T) = gxor(a, b.gu32);
+fn xor{T}(a: T, b: gu32) = gxor(a.gu32, b);
+fn xor(a: gi32, b: gi32) = gxor(a, b);
+fn xor{T}(a: gi32, b: T) = gxor(a, b.gi32);
+fn xor{T}(a: T, b: gi32) = gxor(a.gi32, b);
+fn xor(a: gvec2u, b: gvec2u) = gxor(a, b);
+fn xor(a: gvec2i, b: gvec2i) = gxor(a, b);
+fn xor(a: gvec3u, b: gvec3u) = gxor(a, b);
+fn xor(a: gvec3i, b: gvec3i) = gxor(a, b);
+fn xor(a: gvec4u, b: gvec4u) = gxor(a, b);
+fn xor(a: gvec4i, b: gvec4i) = gxor(a, b);
 
 fn gshl{I}(a: I, b: I) {
   let varName = '('.concat(a.varName).concat(' << ').concat(b.varName).concat(')');
@@ -4636,18 +4671,18 @@ fn gshl{I}(a: I, b: I) {
   let buffers = a.buffers.union(b.buffers);
   return {I}(varName, statements, buffers);
 }
-export fn shl(a: gu32, b: gu32) = gshl(a, b);
-export fn shl{T}(a: gu32, b: T) = gshl(a, b.gu32);
-export fn shl{T}(a: T, b: gu32) = gshl(a.gu32, b);
-export fn shl(a: gi32, b: gi32) = gshl(a, b);
-export fn shl{T}(a: gi32, b: T) = gshl(a, b.gi32);
-export fn shl{T}(a: T, b: gi32) = gshl(a.gi32, b);
-export fn shl(a: gvec2u, b: gvec2u) = gshl(a, b);
-export fn shl(a: gvec2i, b: gvec2i) = gshl(a, b);
-export fn shl(a: gvec3u, b: gvec3u) = gshl(a, b);
-export fn shl(a: gvec3i, b: gvec3i) = gshl(a, b);
-export fn shl(a: gvec4u, b: gvec4u) = gshl(a, b);
-export fn shl(a: gvec4i, b: gvec4i) = gshl(a, b);
+fn shl(a: gu32, b: gu32) = gshl(a, b);
+fn shl{T}(a: gu32, b: T) = gshl(a, b.gu32);
+fn shl{T}(a: T, b: gu32) = gshl(a.gu32, b);
+fn shl(a: gi32, b: gi32) = gshl(a, b);
+fn shl{T}(a: gi32, b: T) = gshl(a, b.gi32);
+fn shl{T}(a: T, b: gi32) = gshl(a.gi32, b);
+fn shl(a: gvec2u, b: gvec2u) = gshl(a, b);
+fn shl(a: gvec2i, b: gvec2i) = gshl(a, b);
+fn shl(a: gvec3u, b: gvec3u) = gshl(a, b);
+fn shl(a: gvec3i, b: gvec3i) = gshl(a, b);
+fn shl(a: gvec4u, b: gvec4u) = gshl(a, b);
+fn shl(a: gvec4i, b: gvec4i) = gshl(a, b);
 
 fn gshr{I}(a: I, b: I) {
   let varName = '('.concat(a.varName).concat(' >> ').concat(b.varName).concat(')');
@@ -4655,18 +4690,18 @@ fn gshr{I}(a: I, b: I) {
   let buffers = a.buffers.union(b.buffers);
   return {I}(varName, statements, buffers);
 }
-export fn shr(a: gu32, b: gu32) = gshr(a, b);
-export fn shr{T}(a: gu32, b: T) = gshr(a, b.gu32);
-export fn shr{T}(a: T, b: gu32) = gshr(a.gu32, b);
-export fn shr(a: gi32, b: gi32) = gshr(a, b);
-export fn shr{T}(a: gi32, b: T) = gshr(a, b.gi32);
-export fn shr{T}(a: T, b: gi32) = gshr(a.gi32, b);
-export fn shr(a: gvec2u, b: gvec2u) = gshr(a, b);
-export fn shr(a: gvec2i, b: gvec2i) = gshr(a, b);
-export fn shr(a: gvec3u, b: gvec3u) = gshr(a, b);
-export fn shr(a: gvec3i, b: gvec3i) = gshr(a, b);
-export fn shr(a: gvec4u, b: gvec4u) = gshr(a, b);
-export fn shr(a: gvec4i, b: gvec4i) = gshr(a, b);
+fn shr(a: gu32, b: gu32) = gshr(a, b);
+fn shr{T}(a: gu32, b: T) = gshr(a, b.gu32);
+fn shr{T}(a: T, b: gu32) = gshr(a.gu32, b);
+fn shr(a: gi32, b: gi32) = gshr(a, b);
+fn shr{T}(a: gi32, b: T) = gshr(a, b.gi32);
+fn shr{T}(a: T, b: gi32) = gshr(a.gi32, b);
+fn shr(a: gvec2u, b: gvec2u) = gshr(a, b);
+fn shr(a: gvec2i, b: gvec2i) = gshr(a, b);
+fn shr(a: gvec3u, b: gvec3u) = gshr(a, b);
+fn shr(a: gvec3i, b: gvec3i) = gshr(a, b);
+fn shr(a: gvec4u, b: gvec4u) = gshr(a, b);
+fn shr(a: gvec4i, b: gvec4i) = gshr(a, b);
 
 // Bitcasting methods (TODO: Is there a better naming scheme possible?)
 
@@ -4676,42 +4711,42 @@ fn gbitcast{I, O}(v: I) {
   let buffers = v.buffers.clone;
   return {O}(varName, statements, buffers);
 }
-export fn asU32(v: gu32) = v;
-export fn asU32(v: gi32) = gbitcast{gi32, gu32}(v);
-export fn asU32(v: gf32) = gbitcast{gf32, gu32}(v);
-export fn asI32(v: gu32) = gbitcast{gu32, gi32}(v);
-export fn asI32(v: gi32) = v;
-export fn asI32(v: gf32) = gbitcast{gf32, gi32}(v);
-export fn asF32(v: gu32) = gbitcast{gu32, gf32}(v);
-export fn asF32(v: gi32) = gbitcast{gi32, gf32}(v);
-export fn asF32(v: gf32) = v;
-export fn asVec2u(v: gvec2u) = v;
-export fn asVec2u(v: gvec2i) = gbitcast{gvec2i, gvec2u}(v);
-export fn asVec2u(v: gvec2f) = gbitcast{gvec2f, gvec2u}(v);
-export fn asVec2i(v: gvec2u) = gbitcast{gvec2u, gvec2i}(v);
-export fn asVec2i(v: gvec2i) = v;
-export fn asVec2i(v: gvec2f) = gbitcast{gvec2f, gvec2i}(v);
-export fn asVec2f(v: gvec2u) = gbitcast{gvec2u, gvec2f}(v);
-export fn asVec2f(v: gvec2i) = gbitcast{gvec2i, gvec2f}(v);
-export fn asVec2f(v: gvec2f) = v;
-export fn asVec3u(v: gvec3u) = v;
-export fn asVec3u(v: gvec3i) = gbitcast{gvec3i, gvec3u}(v);
-export fn asVec3u(v: gvec3f) = gbitcast{gvec3f, gvec3u}(v);
-export fn asVec3i(v: gvec3u) = gbitcast{gvec3u, gvec3i}(v);
-export fn asVec3i(v: gvec3i) = v;
-export fn asVec3i(v: gvec3f) = gbitcast{gvec3f, gvec3i}(v);
-export fn asVec3f(v: gvec3u) = gbitcast{gvec3u, gvec3f}(v);
-export fn asVec3f(v: gvec3i) = gbitcast{gvec3i, gvec3f}(v);
-export fn asVec3f(v: gvec3f) = v;
-export fn asVec4u(v: gvec4u) = v;
-export fn asVec4u(v: gvec4i) = gbitcast{gvec4i, gvec4u}(v);
-export fn asVec4u(v: gvec4f) = gbitcast{gvec4f, gvec4u}(v);
-export fn asVec4i(v: gvec4u) = gbitcast{gvec4u, gvec4i}(v);
-export fn asVec4i(v: gvec4i) = v;
-export fn asVec4i(v: gvec4f) = gbitcast{gvec4f, gvec4i}(v);
-export fn asVec4f(v: gvec4u) = gbitcast{gvec4u, gvec4f}(v);
-export fn asVec4f(v: gvec4i) = gbitcast{gvec4i, gvec4f}(v);
-export fn asVec4f(v: gvec4f) = v;
+fn asU32(v: gu32) = v;
+fn asU32(v: gi32) = gbitcast{gi32, gu32}(v);
+fn asU32(v: gf32) = gbitcast{gf32, gu32}(v);
+fn asI32(v: gu32) = gbitcast{gu32, gi32}(v);
+fn asI32(v: gi32) = v;
+fn asI32(v: gf32) = gbitcast{gf32, gi32}(v);
+fn asF32(v: gu32) = gbitcast{gu32, gf32}(v);
+fn asF32(v: gi32) = gbitcast{gi32, gf32}(v);
+fn asF32(v: gf32) = v;
+fn asVec2u(v: gvec2u) = v;
+fn asVec2u(v: gvec2i) = gbitcast{gvec2i, gvec2u}(v);
+fn asVec2u(v: gvec2f) = gbitcast{gvec2f, gvec2u}(v);
+fn asVec2i(v: gvec2u) = gbitcast{gvec2u, gvec2i}(v);
+fn asVec2i(v: gvec2i) = v;
+fn asVec2i(v: gvec2f) = gbitcast{gvec2f, gvec2i}(v);
+fn asVec2f(v: gvec2u) = gbitcast{gvec2u, gvec2f}(v);
+fn asVec2f(v: gvec2i) = gbitcast{gvec2i, gvec2f}(v);
+fn asVec2f(v: gvec2f) = v;
+fn asVec3u(v: gvec3u) = v;
+fn asVec3u(v: gvec3i) = gbitcast{gvec3i, gvec3u}(v);
+fn asVec3u(v: gvec3f) = gbitcast{gvec3f, gvec3u}(v);
+fn asVec3i(v: gvec3u) = gbitcast{gvec3u, gvec3i}(v);
+fn asVec3i(v: gvec3i) = v;
+fn asVec3i(v: gvec3f) = gbitcast{gvec3f, gvec3i}(v);
+fn asVec3f(v: gvec3u) = gbitcast{gvec3u, gvec3f}(v);
+fn asVec3f(v: gvec3i) = gbitcast{gvec3i, gvec3f}(v);
+fn asVec3f(v: gvec3f) = v;
+fn asVec4u(v: gvec4u) = v;
+fn asVec4u(v: gvec4i) = gbitcast{gvec4i, gvec4u}(v);
+fn asVec4u(v: gvec4f) = gbitcast{gvec4f, gvec4u}(v);
+fn asVec4i(v: gvec4u) = gbitcast{gvec4u, gvec4i}(v);
+fn asVec4i(v: gvec4i) = v;
+fn asVec4i(v: gvec4f) = gbitcast{gvec4f, gvec4i}(v);
+fn asVec4f(v: gvec4u) = gbitcast{gvec4u, gvec4f}(v);
+fn asVec4f(v: gvec4i) = gbitcast{gvec4i, gvec4f}(v);
+fn asVec4f(v: gvec4f) = v;
 
 // GPU Vector functions
 
@@ -4721,9 +4756,9 @@ fn gevery{I}(v: I) {
   let buffers = v.buffers.clone;
   return gbool(varName, statements, buffers);
 }
-export fn every(v: gvec2b) = gevery(v);
-export fn every(v: gvec3b) = gevery(v);
-export fn every(v: gvec4b) = gevery(v);
+fn every(v: gvec2b) = gevery(v);
+fn every(v: gvec3b) = gevery(v);
+fn every(v: gvec4b) = gevery(v);
 
 fn gsome{I}(v: I) {
   let varName = 'any('.concat(v.varName).concat(')');
@@ -4731,9 +4766,9 @@ fn gsome{I}(v: I) {
   let buffers = v.buffers.clone;
   return gbool(varName, statements, buffers);
 }
-export fn some(v: gvec2b) = gsome(v);
-export fn some(v: gvec3b) = gsome(v);
-export fn some(v: gvec4b) = gsome(v);
+fn some(v: gvec2b) = gsome(v);
+fn some(v: gvec3b) = gsome(v);
+fn some(v: gvec4b) = gsome(v);
 
 fn piecewiseIf{C, T}(c: C, t: T, f: T) {
   let varName = "select("
@@ -4747,23 +4782,23 @@ fn piecewiseIf{C, T}(c: C, t: T, f: T) {
   let buffers = f.buffers.union(t.buffers).union(c.buffers);
   return {T}(varName, statements, buffers);
 }
-export fn if(c: gvec2b, t: gvec2u, f: gvec2u) = piecewiseIf{gvec2b, gvec2u}(c, t, f);
-export fn if(c: gvec2b, t: gvec2i, f: gvec2i) = piecewiseIf{gvec2b, gvec2i}(c, t, f);
-export fn if(c: gvec2b, t: gvec2f, f: gvec2f) = piecewiseIf{gvec2b, gvec2f}(c, t, f);
-export fn if(c: gvec2b, t: gvec2b, f: gvec2b) = piecewiseIf{gvec2b, gvec2b}(c, t, f);
-export fn if(c: gvec3b, t: gvec3u, f: gvec3u) = piecewiseIf{gvec3b, gvec3u}(c, t, f);
-export fn if(c: gvec3b, t: gvec3i, f: gvec3i) = piecewiseIf{gvec3b, gvec3i}(c, t, f);
-export fn if(c: gvec3b, t: gvec3f, f: gvec3f) = piecewiseIf{gvec3b, gvec3f}(c, t, f);
-export fn if(c: gvec3b, t: gvec3b, f: gvec3b) = piecewiseIf{gvec3b, gvec3b}(c, t, f);
-export fn if(c: gvec4b, t: gvec4u, f: gvec4u) = piecewiseIf{gvec4b, gvec4u}(c, t, f);
-export fn if(c: gvec4b, t: gvec4i, f: gvec4i) = piecewiseIf{gvec4b, gvec4i}(c, t, f);
-export fn if(c: gvec4b, t: gvec4f, f: gvec4f) = piecewiseIf{gvec4b, gvec4f}(c, t, f);
-export fn if(c: gvec4b, t: gvec4b, f: gvec4b) = piecewiseIf{gvec4b, gvec4b}(c, t, f);
+fn if(c: gvec2b, t: gvec2u, f: gvec2u) = piecewiseIf{gvec2b, gvec2u}(c, t, f);
+fn if(c: gvec2b, t: gvec2i, f: gvec2i) = piecewiseIf{gvec2b, gvec2i}(c, t, f);
+fn if(c: gvec2b, t: gvec2f, f: gvec2f) = piecewiseIf{gvec2b, gvec2f}(c, t, f);
+fn if(c: gvec2b, t: gvec2b, f: gvec2b) = piecewiseIf{gvec2b, gvec2b}(c, t, f);
+fn if(c: gvec3b, t: gvec3u, f: gvec3u) = piecewiseIf{gvec3b, gvec3u}(c, t, f);
+fn if(c: gvec3b, t: gvec3i, f: gvec3i) = piecewiseIf{gvec3b, gvec3i}(c, t, f);
+fn if(c: gvec3b, t: gvec3f, f: gvec3f) = piecewiseIf{gvec3b, gvec3f}(c, t, f);
+fn if(c: gvec3b, t: gvec3b, f: gvec3b) = piecewiseIf{gvec3b, gvec3b}(c, t, f);
+fn if(c: gvec4b, t: gvec4u, f: gvec4u) = piecewiseIf{gvec4b, gvec4u}(c, t, f);
+fn if(c: gvec4b, t: gvec4i, f: gvec4i) = piecewiseIf{gvec4b, gvec4i}(c, t, f);
+fn if(c: gvec4b, t: gvec4f, f: gvec4f) = piecewiseIf{gvec4b, gvec4f}(c, t, f);
+fn if(c: gvec4b, t: gvec4b, f: gvec4b) = piecewiseIf{gvec4b, gvec4b}(c, t, f);
 
 // GBuffer methods
 
 /* This one doesn't seem to work yet for some reason
-export fn map{G, G2}(gb: GBuffer, f: G -> G2) {
+fn map{G, G2}(gb: GBuffer, f: G -> G2) {
   let idx = gFor(gb.len);
   let val = gb[idx];
   let out = GBuffer{i32}(gb.len);
@@ -4771,7 +4806,7 @@ export fn map{G, G2}(gb: GBuffer, f: G -> G2) {
   compute.build.run;
   return out;
 }*/
-export fn map(gb: GBuffer, f: gu32 -> gu32) {
+fn map(gb: GBuffer, f: gu32 -> gu32) {
   let idx = gFor(gb.len);
   let val = gb[idx].asU32;
   let out = GBuffer{u32}(gb.len);
@@ -4779,7 +4814,7 @@ export fn map(gb: GBuffer, f: gu32 -> gu32) {
   compute.build.run;
   return out;
 }
-export fn map(gb: GBuffer, f: gi32 -> gi32) {
+fn map(gb: GBuffer, f: gi32 -> gi32) {
   let idx = gFor(gb.len);
   let val = gb[idx];
   let out = GBuffer{i32}(gb.len);
@@ -4787,7 +4822,7 @@ export fn map(gb: GBuffer, f: gi32 -> gi32) {
   compute.build.run;
   return out;
 }
-export fn map(gb: GBuffer, f: gf32 -> gf32) {
+fn map(gb: GBuffer, f: gf32 -> gf32) {
   let idx = gFor(gb.len);
   let val = gb[idx].asF32;
   let out = GBuffer{f32}(gb.len);
@@ -4795,7 +4830,7 @@ export fn map(gb: GBuffer, f: gf32 -> gf32) {
   compute.build.run;
   return out;
 }
-export fn{Js} map(gb: GBuffer, f: gf32 -> gf32) { // TODO: Get rid of this jank
+fn{Js} map(gb: GBuffer, f: gf32 -> gf32) { // TODO: Get rid of this jank
   let idx = gFor(gb.len);
   let val = gb[idx].asF32;
   let out = GBuffer{f32}(gb.len); // The JS binding currently ignores this
@@ -4806,7 +4841,7 @@ export fn{Js} map(gb: GBuffer, f: gf32 -> gf32) { // TODO: Get rid of this jank
 }
 // This one technically only works for i32/u32/f32 by chance. Once the issue above is fixed, this
 // one can be fixed, too.
-export fn map{G, G2}(gb: GBuffer, f: (G, gu32) -> G2) {
+fn map{G, G2}(gb: GBuffer, f: (G, gu32) -> G2) {
   let idx = gFor(gb.len);
   let val = gb[idx];
   let out = GBuffer{i32}(gb.len);
@@ -4816,114 +4851,83 @@ export fn map{G, G2}(gb: GBuffer, f: (G, gu32) -> G2) {
 }
 
 /// Process exit-related bindings
-export fn{Rs} ExitCode "std::process::ExitCode::from" :: Own{u8} -> ExitCode;
-export fn{Js} ExitCode "Number" :: u8 -> ExitCode;
-export fn ExitCode(e: u16) = ExitCode(e.u8);
-export fn ExitCode(e: u32) = ExitCode(e.u8);
-export fn ExitCode(e: u64) = ExitCode(e.u8);
-export fn ExitCode(e: i8) = ExitCode(e.u8);
-export fn ExitCode(e: i16) = ExitCode(e.u8);
-export fn ExitCode(e: i32) = ExitCode(e.u8);
-export fn ExitCode(e: i64) = ExitCode(e.u8);
+fn{Rs} ExitCode "std::process::ExitCode::from" :: Own{u8} -> ExitCode;
+fn{Js} ExitCode "Number" :: u8 -> ExitCode;
+fn ExitCode(e: u16) = ExitCode(e.u8);
+fn ExitCode(e: u32) = ExitCode(e.u8);
+fn ExitCode(e: u64) = ExitCode(e.u8);
+fn ExitCode(e: i8) = ExitCode(e.u8);
+fn ExitCode(e: i16) = ExitCode(e.u8);
+fn ExitCode(e: i32) = ExitCode(e.u8);
+fn ExitCode(e: i64) = ExitCode(e.u8);
 
 /// Stdout/stderr-related bindings
 // TODO: Rework this to just print anything that can be converted to `string` via interfaces
-export fn{Rs} print{T}(v: T) = {"println!" :: ("{}", string)}(v.string);
-export fn{Js} print{T}(v: T) = {"console.log" :: T}(v);
-export fn{Js} print{T}(v: T[]) = {"((vs) => console.log(vs.map((v) => v.valueOf())))" :: T[]}(v);
-export fn{Js} print "((s) => console.log(s.val))" :: string;
-export fn{Js} print (b: bool) = b.string.print;
-export fn{Js} print (i: i8) = i.string.print;
-export fn{Js} print (u: u8) = u.string.print;
-export fn{Js} print (i: i16) = i.string.print;
-export fn{Js} print (u: u16) = u.string.print;
-export fn{Js} print (i: i32) = i.string.print;
-export fn{Js} print (u: u32) = u.string.print;
-export fn{Js} print (i: i64) = i.string.print;
-export fn{Js} print (u: u64) = u.string.print;
-export fn{Js} print (f: f32) = f.string.print;
-export fn{Js} print (f: f64) = f.string.print;
-export fn{Js} print (i: i64[]) = "[".concat(i.map(string).join(", ")).concat("]").print;
-export fn{Js} print (u: u64[]) = "[".concat(u.map(string).join(", ")).concat("]").print;
-export fn{Js} print{S} (i: Buffer{i64, S}) = "[".concat(i.map(string).join(", ")).concat("]").print;
-export fn{Js} print{S} (u: Buffer{u64, S}) = "[".concat(u.map(string).join(", ")).concat("]").print;
-export fn{Js} print (e: Error) = "Error: ".concat(e.string).print;
-export fn{Rs} print (d: Duration) = {"println!" :: ("{}.{:0>9}", u64, u32)}(
+fn{Rs} print{T}(v: T) = {"println!" :: ("{}", string)}(v.string);
+fn{Js} print{T}(v: T) = {"console.log" :: T}(v);
+fn{Js} print{T}(v: T[]) = {"((vs) => console.log(vs.map((v) => v.valueOf())))" :: T[]}(v);
+fn{Js} print "((s) => console.log(s.val))" :: string;
+fn{Js} print (b: bool) = b.string.print;
+fn{Js} print (i: i8) = i.string.print;
+fn{Js} print (u: u8) = u.string.print;
+fn{Js} print (i: i16) = i.string.print;
+fn{Js} print (u: u16) = u.string.print;
+fn{Js} print (i: i32) = i.string.print;
+fn{Js} print (u: u32) = u.string.print;
+fn{Js} print (i: i64) = i.string.print;
+fn{Js} print (u: u64) = u.string.print;
+fn{Js} print (f: f32) = f.string.print;
+fn{Js} print (f: f64) = f.string.print;
+fn{Js} print (i: i64[]) = "[".concat(i.map(string).join(", ")).concat("]").print;
+fn{Js} print (u: u64[]) = "[".concat(u.map(string).join(", ")).concat("]").print;
+fn{Js} print{S} (i: Buffer{i64, S}) = "[".concat(i.map(string).join(", ")).concat("]").print;
+fn{Js} print{S} (u: Buffer{u64, S}) = "[".concat(u.map(string).join(", ")).concat("]").print;
+fn{Js} print (e: Error) = "Error: ".concat(e.string).print;
+fn{Rs} print (d: Duration) = {"println!" :: ("{}.{:0>9}", u64, u32)}(
   {Method{"as_secs"} :: Duration -> u64}(d),
   {Method{"subsec_nanos"} :: Duration -> u32}(d));
-export fn{Rs} print(v: void) = {"println!" :: "void"}();
-export fn{Js} print(v: void) = {"console.log" :: "void"}();
-export fn{Rs} print(s: string) = {"println!" :: ("{}", string)}(s);
-export fn{Rs} print{T, N}(a: T[N]) = "[".concat(a.map(string).join(", ")).concat("]").print;
-export fn{Rs} print{T}(a: T[]) = "[".concat(a.map(string).join(", ")).concat("]").print;
-export fn print{T}(v: T?) = if(v.exists,
-  fn = v.getOrExit.print,
+fn{Rs} print(v: void) = {"println!" :: "void"}();
+fn{Js} print(v: void) = {"console.log" :: "void"}();
+fn{Rs} print(s: string) = {"println!" :: ("{}", string)}(s);
+fn{Rs} print{T, N}(a: T[N]) = "[".concat(a.map(string).join(", ")).concat("]").print;
+fn{Rs} print{T}(a: T[]) = "[".concat(a.map(string).join(", ")).concat("]").print;
+fn print{T}(v: T?) = if(v.exists,
+  fn = print(v!!),
   fn = print("void"));
-export fn print{T}(v: T!) = if({T}(v).exists,
-  fn = v.getOrExit.print,
-  fn = v.Error.getOrExit.print);
-export fn{Js} print{T}(v: void!) = if({T}(v).exists,
+fn print{T}(v: T!) = if({T}(v).exists,
+  fn = print(v!!),
+  fn = print(v.Error!!));
+fn{Js} print{T}(v: void!) = if({T}(v).exists,
   fn = "void".print,
-  fn = v.Error.getOrExit.print);
-export fn{Rs} eprint{T}(v: T) = {"eprintln!" :: ("{}", string)}(v.string);
-export fn{Js} eprint{T}(v: T) = {"console.error" :: string}(v.string);
-export fn{Rs} eprint(v: void) = {"eprintln!" :: "void"}();
-export fn{Js} eprint(v: void) = {"console.error" :: "void"}();
-export fn{Rs} eprint(s: string) = {"eprintln!" :: ("{}", string)}(s);
-export fn{Js} eprint "((s) => console.error(s.val))" :: string;
-export fn{Js} eprint (b: bool) = b.string.print;
-export fn{Js} eprint (i: i8) = i.string.print;
-export fn{Js} eprint (u: u8) = u.string.print;
-export fn{Js} eprint (i: i16) = i.string.print;
-export fn{Js} eprint (u: u16) = u.string.print;
-export fn{Js} eprint (i: i32) = i.string.print;
-export fn{Js} eprint (u: u32) = u.string.print;
-export fn{Js} eprint (i: i64) = i.string.print;
-export fn{Js} eprint (u: u64) = u.string.print;
-export fn{Js} eprint (f: f32) = f.string.print;
-export fn{Js} eprint (f: f64) = f.string.print;
-export fn{Js} eprint (i: i64[]) = "[".concat(i.map(string).join(", ")).concat("]").print;
-export fn{Js} eprint (u: u64[]) = "[".concat(u.map(string).join(", ")).concat("]").print;
-export fn{Rs} eprint{T}(a: T[]) = "[".concat(a.map(string).join(", ")).concat("]").eprint;
-export fn{Rs} eprint{T}(v: T?) = if(v.exists,
-  fn = v.getOrExit.eprint,
+  fn = print(v.Error!!));
+fn{Rs} eprint{T}(v: T) = {"eprintln!" :: ("{}", string)}(v.string);
+fn{Js} eprint{T}(v: T) = {"console.error" :: string}(v.string);
+fn{Rs} eprint(v: void) = {"eprintln!" :: "void"}();
+fn{Js} eprint(v: void) = {"console.error" :: "void"}();
+fn{Rs} eprint(s: string) = {"eprintln!" :: ("{}", string)}(s);
+fn{Js} eprint "((s) => console.error(s.val))" :: string;
+fn{Js} eprint (b: bool) = b.string.print;
+fn{Js} eprint (i: i8) = i.string.print;
+fn{Js} eprint (u: u8) = u.string.print;
+fn{Js} eprint (i: i16) = i.string.print;
+fn{Js} eprint (u: u16) = u.string.print;
+fn{Js} eprint (i: i32) = i.string.print;
+fn{Js} eprint (u: u32) = u.string.print;
+fn{Js} eprint (i: i64) = i.string.print;
+fn{Js} eprint (u: u64) = u.string.print;
+fn{Js} eprint (f: f32) = f.string.print;
+fn{Js} eprint (f: f64) = f.string.print;
+fn{Js} eprint (i: i64[]) = "[".concat(i.map(string).join(", ")).concat("]").print;
+fn{Js} eprint (u: u64[]) = "[".concat(u.map(string).join(", ")).concat("]").print;
+fn{Rs} eprint{T}(a: T[]) = "[".concat(a.map(string).join(", ")).concat("]").eprint;
+fn{Rs} eprint{T}(v: T?) = if(v.exists,
+  fn = eprint(v!!),
   fn = eprint("void"));
-export fn{Rs} eprint{T}(v: T!) = if({T}(v).exists,
-  fn = v.getOrExit.eprint,
-  fn = v.Error.getOrExit.eprint);
+fn{Rs} eprint{T}(v: T!) = if({T}(v).exists,
+  fn = eprint(v!!),
+  fn = eprint(v.Error!!));
 
-export fn{Rs} stdout "print!" :: ("{}", string);
-export fn{Js} stdout "((s) => process.stdout.write(s.val))" :: string;
-export fn{Rs} stderr "eprint!" :: ("{}", string);
-export fn{Js} stderr "((s) => process.stderr.write(s.val))" :: string;
-
-/// Built-in operator definitions
-export infix add as + precedence 3;
-export infix sub as - precedence 3;
-export prefix neg as - precedence 6;
-export infix mul as * precedence 4;
-export infix div as / precedence 4;
-export infix mod as % precedence 4;
-// export infix template as % precedence 4;
-export infix pow as ** precedence 5;
-export infix and as & precedence 4;
-export infix and as && precedence 4;
-export infix or as | precedence 3;
-export infix or as || precedence 3;
-export infix xor as ^ precedence 3;
-export prefix not as ! precedence 5;
-export infix nand as !& precedence 4;
-export infix nor as !| precedence 3;
-export infix xnor as !^ precedence 3;
-export infix eq as == precedence 1;
-export infix neq as != precedence 1;
-export infix lt as < precedence 1;
-export infix lte as <= precedence 1;
-export infix gt as > precedence 1;
-export infix gte as >= precedence 1;
-export prefix len as # precedence 1; // TODO: Is this useful?
-export infix shl as << precedence 2;
-export infix shr as >> precedence 2;
-export infix wrl as <<< precedence 2;
-export infix wrr as >>> precedence 2;
-export infix store as = precedence 0;
+fn{Rs} stdout "print!" :: ("{}", string);
+fn{Js} stdout "((s) => process.stdout.write(s.val))" :: string;
+fn{Rs} stderr "eprint!" :: ("{}", string);
+fn{Js} stderr "((s) => process.stderr.write(s.val))" :: string;


### PR DESCRIPTION
I realized that the root scope doesn't need to export anything since it's always included in the scope hierarchy, so I dropped the essentially useless `export`s (after a minor tweak to how the `ctype` syntax is parsed). Then I realized that the type-operator and function-operator binding can be done before any types or functions are defined, which would then let me use the operators where it makes sense to use them, so I also refactored *everything* according to that. Then I re-ordered the floating point and integer types and functions according to the new "FUI" ordering I'm going to use for tiebreaker logic in the near future. Finally I added a few more operators where it made sense to me.
