### PR TITLE
Fix a Rust typegen bug

### DIFF
--- a/alan/src/lntors/typen.rs
+++ b/alan/src/lntors/typen.rs
@@ -154,7 +154,7 @@ pub fn ctype_to_rtype(
                     _ => CType::fail("Bound types must be strings or rust imports"),
                 }
             }
-            _ => Ok(("".to_string(), deps)), // TODO: Is this correct?
+            otherwise => ctype_to_rtype(otherwise, in_function_type, deps),
         }
         CType::Generic(name, args, _) => Ok((format!("{}<{}>", name, args.join(", ")), deps)),
         CType::Binds(n, args) => {


### PR DESCRIPTION
While working on other things, I noticed this typegen bug in the Rust type generation and fixed it (there's no equivalent in the JS codegen because the JS path doesn't emit types).
