### PR TITLE
Remove the `hash` built-in function

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -934,22 +934,6 @@ test_full!(array_custom_types => r#"
     stdout "2, 4\n";
 );
 
-// Hashing
-test!(hash => r#"
-    export fn main {
-      print(hash(1));
-      print(hash(3.14159));
-      print(hash(true));
-      print(hash('false'));
-      print(hash([1, 2, 5, 3]));
-    }"#;
-    stdout r#"1742378985846435984
--3655443395552619065
-4952851536318644461
--3294960077868127759
--8231513229892369092
-"#;
-);
 test_full!(basic_dict => r#"
     export fn main {
       let test = Dict('foo', 1);

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -223,16 +223,6 @@ infix store as = precedence 0;
 fn{Rs} clone{T} (v: T) -> T = {Method{"clone"} :: T -> T}(v);
 // TODO: This needs to be turned into a JS function that's bound
 fn{Js} clone{T} (v: T) -> T = {"(function clone(t) { if (t instanceof Array) { return t.map(clone); } else if (t.build instanceof Function) { return t.build(t.val); } else if (t instanceof Set) { return t.union(new Set()); } else { return structuredClone(t); } })" :: T -> T}(v);
-// TODO: The "proper" way to hash this consistently for all types is to decompose the input type
-// into the various primitive types of Alan and then have hashing rules for each of them, which
-// may themselves decompose, etc. This might be doable in Alan code on top of specialized hashing
-// functions in Rust (as partially implemented here) or it might be better done as a special `hash`
-// function created by the compiler for the specific type *if* ever actually used, walking the
-// CType tree to determine the correct code to run. In either case, this is "good enough" for now.
-fn{Rs} hash{T} "alan_std::hash" <- RootBacking :: T -> i64;
-fn{Rs} hash{T} "alan_std::hasharray" <- RootBacking :: T[] -> i64;
-fn{Rs} hash "alan_std::hashstring" <- RootBacking :: string -> i64;
-// TODO: JS variant for `hash`
 fn void{T}(v: T) -> void {}
 fn void() -> void {}
 fn{Rs} store{T} (a: Mut{T}, b: T) -> T = {"std::mem::replace" :: (Mut{T}, Own{T}) -> T}(a, b);

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -43,39 +43,6 @@ impl From<String> for AlanError {
     }
 }
 
-/// Functions for (potentially) every type
-
-/// `hash` hashes the input type
-#[inline(always)]
-pub fn hash<T>(v: &T) -> i64 {
-    let mut hasher = std::hash::DefaultHasher::new();
-    let v_len = std::mem::size_of::<T>();
-    let v_raw = unsafe { std::slice::from_raw_parts(v as *const T as usize as *const u8, v_len) };
-    hasher.write(v_raw);
-    hasher.finish() as i64
-}
-
-/// `hasharray` hashes the input array one element at a time
-#[inline(always)]
-pub fn hasharray<T>(v: &Vec<T>) -> i64 {
-    let mut hasher = std::hash::DefaultHasher::new();
-    let v_len = std::mem::size_of::<T>();
-    for r in v {
-        let v_raw =
-            unsafe { std::slice::from_raw_parts(r as *const T as usize as *const u8, v_len) };
-        hasher.write(v_raw);
-    }
-    hasher.finish() as i64
-}
-
-/// `hashstring` hashes the input string
-#[inline(always)]
-pub fn hashstring(v: &String) -> i64 {
-    let mut hasher = std::hash::DefaultHasher::new();
-    hasher.write(v.as_str().as_bytes());
-    hasher.finish() as i64
-}
-
 /// String-related functions
 
 /// Converts anything that implements ToString into a string. Needed to convert all errors into


### PR DESCRIPTION
Another relic of Alan 0.1 that doesn't really do anything right now, is difficult to support (not implemented in JS, and the implementation is broken in certain scenarios on Rust), and a distraction from what Alan 0.2 is about.
