### PR TITLE
Implement the cross product for CPU and GPU

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -619,8 +619,14 @@ test_gpgpu!(gpu_ctz => r#"
 
 test_gpgpu!(gpu_cross => r#"
     // TODO: A nicer test involving `map`
+
+    // TODO: This is horrible
+    fn{Rs} fixJsGBuffer(b: GBuffer) = b;
+    fn{Js} fixJsGBuffer "((b) => { b.ValKind = alan_std.F32; })" :: GBuffer;
+
     export fn main {
       let b = GBuffer(filled(0.f32, 2));
+      fixJsGBuffer(b);
       let idx = gFor(2);
       let compute = b[idx].store(if(
         idx == 0,

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -617,6 +617,22 @@ test_gpgpu!(gpu_ctz => r#"
     stdout "[32, 0, 1, 31]\n";
 );
 
+test_gpgpu!(gpu_cross => r#"
+    // TODO: A nicer test involving `map`
+    export fn main {
+      let b = GBuffer(filled(0.f32, 2));
+      let idx = gFor(2);
+      let compute = b[idx].store(if(
+        idx == 0,
+        gvec3f(1.0, 0.0, 0.0) >< gvec3f(0.0, 1.0, 0.0),
+        gvec3f(0.0, 1.0, 0.0) >< gvec3f(1.0, 0.0, 0.0)
+      ).z.asI32); // TODO: This isn't right and shouldn't be necessary
+      compute.build.run;
+      b.read{f32}.print;
+    }"#;
+    stdout "[1, -1]\n";
+);
+
 // TODO: Fix u64 numeric constants to get u64 bitwise tests in the new test suite
 test!(u64_bitwise => r#"
     prefix u64 as ~ precedence 10

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -189,6 +189,7 @@ infix add as + precedence 3;
 infix sub as - precedence 3;
 prefix neg as - precedence 6;
 infix mul as * precedence 4;
+infix cross as >< precedence 4;
 infix div as / precedence 4;
 infix mod as % precedence 4;
 // export infix template as % precedence 4;
@@ -1298,6 +1299,11 @@ fn{Rs} repeat{T, S} "alan_std::repeatbuffertoarray" <- RootBacking :: (T[S], i64
 fn{Js} repeat{T, S} (a: T[S], c: i64) = {"((a, c) => { let out = []; for (let i = 0n; i < c; i++) { out.push(...a); } return out; })" :: (T[S], i64) -> T[]}(a, c);
 fn{Rs} store{T, S} "alan_std::storebuffer" <- RootBacking :: (Mut{T[S]}, i64, T) -> T!;
 fn{Js} store{T, S} (a: T[S], i: i64, v: T) = {"((a, i, v) => { if (i < 0n || i > BigInt(a.length)) { return new alan_std.AlanError(new alan_std.Str(`Provided array index ${i.toString()} is greater than the length of the array`)); } else { let out = a[Number(i)]; a[Number(i)] = v; return out; } })" :: (T[S], i64, T) -> T!}(a, i, v);
+fn{Rs} cross "alan_std::cross_f32" <- RootBacking :: (Buffer{f32, 3}, Buffer{f32, 3}) -> Buffer{f32, 3};
+fn{Rs} cross "alan_std::cross_f64" <- RootBacking :: (Buffer{f64, 3}, Buffer{f64, 3}) -> Buffer{f64, 3};
+fn{Js} cross{T} "alan_std.cross" <- RootBacking :: (Buffer{T, 3}, Buffer{T, 3}) -> Buffer{T, 3};
+fn{Js} cross(a: Buffer{f32, 3}, b: Buffer{f32, 3}) = cross{f32}(a, b);
+fn{Js} cross(a: Buffer{f64, 3}, b: Buffer{f64, 3}) = cross{f64}(a, b);
 
 /// Dictionary-related bindings
 fn{Rs} Dict{K, V} "alan_std::OrderedHashMap::new" <- RootBacking :: () -> Dict{K, V};
@@ -3734,6 +3740,14 @@ fn ctz(v: gvec3u) = gctz{gvec3u}(v);
 fn ctz(v: gvec4i) = gctz{gvec4i}(v);
 fn ctz(v: gvec4u) = gctz{gvec4u}(v);
 
+fn cross(a: gvec3f, b: gvec3f) {
+  // Yes, this legitimately only works for this exact type in wgsl
+  let varName = 'cross('.concat(a.varName).concat(', ').concat(b.varName).concat(')');
+  let statements = a.statements.concat(b.statements);
+  let buffers = a.buffers.union(b.buffers);
+  return gvec3f(varName, statements, buffers);
+}
+
 fn gadd{A, B}(a: A, b: B) {
   let varName = '('.concat(a.varName).concat(' + ').concat(b.varName).concat(')');
   let statements = a.statements.concat(b.statements);
@@ -4938,8 +4952,8 @@ fn{Rs} print (d: Duration) = {"println!" :: ("{}.{:0>9}", u64, u32)}(
 fn{Rs} print(v: void) = {"println!" :: "void"}();
 fn{Js} print(v: void) = {"console.log" :: "void"}();
 fn{Rs} print(s: string) = {"println!" :: ("{}", string)}(s);
-fn{Rs} print{T, N}(a: T[N]) = "[".concat(a.map(string).join(", ")).concat("]").print;
-fn{Rs} print{T}(a: T[]) = "[".concat(a.map(string).join(", ")).concat("]").print;
+fn{Rs} print{T, N}(a: T[N]) = "[".concat(a.map(fn (v: T) = string(v)).join(", ")).concat("]").print;
+fn{Rs} print{T}(a: T[]) = "[".concat(a.map(fn (v: T) = string(v)).join(", ")).concat("]").print;
 fn print{T}(v: T?) = if(v.exists,
   fn = print(v!!),
   fn = print("void"));

--- a/alan/test.ln
+++ b/alan/test.ln
@@ -436,6 +436,9 @@ export fn{Test} main {
       .assert(eq, 5.u32 !^ 3.u32, 4_294_967_289.u32);
     // TODO: Fix u64 numeric constants to get u64 bitwise tests in here
 
+  test.describe("Cross Product").it("")
+    .assert(eq, ({f64[3]}(1.0, 0.0, 0.0) >< {f64[3]}(0.0, 1.0, 0.0)).map(fn (v: f64) = string(v)).join(', '), {f64[3]}(0.0, 0.0, 1.0).map(fn (v: f64) = string(v)).join(', '));
+
   test.describe("Boolean logic").it("")
     .assert(eq, true, true)
     .assert(eq, false, false)


### PR DESCRIPTION
There are several compromises here that I want to eventually tackle.

1. The CPU side uses `f32[3]` or `f64[3]` as the type, rather than a more specialized one. Right now there's no reason to use a specialized one because CPU vector intrinsics are locked to Rust nightly, but perhaps it makes sense to create CPU-side `vec[2/3/4][f/u/i]` to match the GPU side and in preparation for when they actually do get proper acceleration?
2. I can't create a buffer of an array of `f32[3]`s and then read that back out. Much of the `GBuffer` behavior dates to before I had generics at all, and I should probably spend some time reworking it from the ground up. This means that I had to do the cross product on the GPU side and then just extract the `z` value out for checking, instead of checking against the whole thing -- I also had to pretend cast it to an integer to assign it, which is also gross.
3. I have several places where in the new test suite I am mapping arrays and buffers to strings in order to do the equality checking. I should come up with a way to do deep equal in a generalized way and reduce the noise in the test suite.
