### PR TITLE
Implement the 'swap' method for arrays and buffers

### DIFF
--- a/alan/src/program/ctype.rs
+++ b/alan/src/program/ctype.rs
@@ -102,7 +102,8 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
+                                    "https://github.com/alantech/alan.git#array-and-buffer-swap"
+                                        .to_string(), // TODO: This *really* needs to be derived from the root scope
                                 )),
                             )))),
                         )),
@@ -135,7 +136,8 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
+                                    "https://github.com/alantech/alan.git#array-and-buffer-swap"
+                                        .to_string(), // TODO: This *really* needs to be derived from the root scope
                                 )),
                             )))),
                         )),
@@ -168,7 +170,8 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
+                                    "https://github.com/alantech/alan.git#array-and-buffer-swap"
+                                        .to_string(), // TODO: This *really* needs to be derived from the root scope
                                 )),
                             )))),
                         )),
@@ -201,7 +204,8 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
+                                    "https://github.com/alantech/alan.git#array-and-buffer-swap"
+                                        .to_string(), // TODO: This *really* needs to be derived from the root scope
                                 )),
                             )))),
                         )),

--- a/alan/src/program/ctype.rs
+++ b/alan/src/program/ctype.rs
@@ -102,8 +102,7 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git#array-and-buffer-swap"
-                                        .to_string(), // TODO: This *really* needs to be derived from the root scope
+                                    "https://github.com/alantech/alan.git".to_string(),
                                 )),
                             )))),
                         )),
@@ -136,8 +135,7 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git#array-and-buffer-swap"
-                                        .to_string(), // TODO: This *really* needs to be derived from the root scope
+                                    "https://github.com/alantech/alan.git".to_string(),
                                 )),
                             )))),
                         )),
@@ -170,8 +168,7 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git#array-and-buffer-swap"
-                                        .to_string(), // TODO: This *really* needs to be derived from the root scope
+                                    "https://github.com/alantech/alan.git".to_string(),
                                 )),
                             )))),
                         )),
@@ -204,8 +201,7 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git#array-and-buffer-swap"
-                                        .to_string(), // TODO: This *really* needs to be derived from the root scope
+                                    "https://github.com/alantech/alan.git".to_string(),
                                 )),
                             )))),
                         )),

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -116,8 +116,8 @@ type Rs = Env{"ALAN_OUTPUT_LANG"} == "rs";
 type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
-type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
-type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git#array-and-buffer-swap"};
+type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git#array-and-buffer-swap"};
 
 // Defining derived types
 type void = ();
@@ -1263,6 +1263,8 @@ fn{Rs} delete{T} "alan_std::deletearray" <- RootBacking :: (Mut{T[]}, i64) -> T!
 fn{Js} delete{T} (a: T[], i: i64) = {"((a, i) => { if (i < 0n || i >= BigInt(a.length)) { return new alan_std.AlanError(new alan_std.Str(`Provided array index ${i.toString()} is beyond the bounds of the array`)); } else { return a.splice(Number(i), 1)[0]; } })" :: (T[], i64) -> T!}(a, i);
 fn{Rs} last{T} (v: T[]) = {Method{"cloned"} :: T? -> T?}({Method{"last"} :: T[] -> T?}(v));
 fn{Js} last{T} (v: T[]) = {Method{"at"} :: (T[], -1) -> T?}(v);
+fn{Rs} swap{T} "alan_std::swaparray" <- RootBacking :: (Mut{T[]}, i64, i64) -> void!;
+fn{Js} swap{T} "alan_std.swap" <- RootBacking :: (T[], i64, i64) -> void!;
 
 /// Buffer related bindings
 fn{Rs} get{T, S} "alan_std::getbuffer" <- RootBacking :: (T[S], i64) -> T?;
@@ -1304,6 +1306,8 @@ fn{Rs} cross "alan_std::cross_f64" <- RootBacking :: (Buffer{f64, 3}, Buffer{f64
 fn{Js} cross{T} "alan_std.cross" <- RootBacking :: (Buffer{T, 3}, Buffer{T, 3}) -> Buffer{T, 3};
 fn{Js} cross(a: Buffer{f32, 3}, b: Buffer{f32, 3}) = cross{f32}(a, b);
 fn{Js} cross(a: Buffer{f64, 3}, b: Buffer{f64, 3}) = cross{f64}(a, b);
+fn{Rs} swap{T, S} "alan_std::swapbuffer" <- RootBacking :: (Mut{Buffer{T, S}}, i64, i64) -> void!;
+fn{Js} swap{T, S} "alan_std.swap" <- RootBacking :: (Buffer{T, S}, i64, i64) -> void!;
 
 /// Dictionary-related bindings
 fn{Rs} Dict{K, V} "alan_std::OrderedHashMap::new" <- RootBacking :: () -> Dict{K, V};

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -116,8 +116,8 @@ type Rs = Env{"ALAN_OUTPUT_LANG"} == "rs";
 type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
-type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git#array-and-buffer-swap"};
-type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git#array-and-buffer-swap"};
+type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
 
 // Defining derived types
 type void = ();

--- a/alan/test.ln
+++ b/alan/test.ln
@@ -811,6 +811,11 @@ export fn{Test} main {
       test.assert(eq, arr.map(string).join(', '), '1, 2, 3, 4, 5');
       test.assert(eq, arr.delete(4)!!, 5);
       test.assert(eq, arr.map(string).join(', '), '1, 2, 3, 4');
+    })
+    .it('swap', fn (test: Mut{Testing}) {
+      let arr = [1, 2, 5];
+      arr.swap(0, 2);
+      test.assert(eq, arr.map(string).join(', '), '5, 2, 1');
     });
 
   test.describe("Buffers")
@@ -865,6 +870,11 @@ export fn{Test} main {
         .assert(eq, b.map(string).join(', '), '1, 2, 3');
       b[2] = 4;
       test.assert(eq, b.map(string).join(', '), '1, 2, 4');
+    })
+    .it('swap', fn (test: Mut{Testing}) {
+      let b = {i64[3]}(1, 2, 5);
+      b.swap(0, 2);
+      test.assert(eq, b.map(string).join(', '), '5, 2, 1');
     });
 
   test.describe("Conditionals")

--- a/alan_std.js
+++ b/alan_std.js
@@ -420,6 +420,18 @@ export class Str {
   }
 }
 
+export function swap(a, i, j) {
+  if (i.val < 0 || i.val > a.length) {
+    return new AlanError(`Provided index ${i.val} is beyond the bounds of the array`);
+  }
+  if (j.val < 0 || j.val > a.length) {
+    return new AlanError(`Provided index ${j.val} is beyond the bounds of the array`);
+  }
+  let temp = a[i.val];
+  a[i.val] = a[j.val];
+  a[j.val] = temp;
+}
+
 export function cross(a, b) {
   // Assuming they're all the same type
   let type = a[0].constructor;

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -410,6 +410,53 @@ pub fn deletearray<T: std::clone::Clone>(a: &mut Vec<T>, i: &i64) -> Result<T, A
     }
 }
 
+/// `swaparray` swaps the values at the specified indicies (or fails if either index is out of
+/// bounds). It returns a Fallible void value.
+#[inline(always)]
+pub fn swaparray<T>(a: &mut Vec<T>, i: &i64, j: &i64) -> Result<(), AlanError> {
+    if *i < 0 {
+        return Err(format!(
+            "Provided array index {} is beyond the bounds of the array",
+            i
+        )
+        .into());
+    }
+    if *j < 0 {
+        return Err(format!(
+            "Provided array index {} is beyond the bounds of the array",
+            j
+        )
+        .into());
+    }
+    let i = *i as usize;
+    let j = *j as usize;
+    if i >= a.len() {
+        return Err(format!(
+            "Provided array index {} is beyond the bounds of the array",
+            i
+        )
+        .into());
+    }
+    if j >= a.len() {
+        return Err(format!(
+            "Provided array index {} is beyond the bounds of the array",
+            j
+        )
+        .into());
+    }
+    if i == j {
+        return Ok(());
+    }
+    if i < j {
+        let (i_section, j_section) = a.split_at_mut(j);
+        std::mem::swap(&mut i_section[i], &mut j_section[0]);
+    } else {
+        let (j_section, i_section) = a.split_at_mut(j);
+        std::mem::swap(&mut j_section[j], &mut i_section[0]);
+    }
+    Ok(())
+}
+
 /// Buffer-related functions
 
 /// `getbuffer` returns the value at the given index presuming it exists
@@ -563,6 +610,53 @@ pub fn storebuffer<T: std::clone::Clone, const S: usize>(
         .into()),
         true => Ok(std::mem::replace(a.each_mut()[*i as usize], v.clone())),
     }
+}
+
+/// `swapbuffer` swaps the values at the specified indicies (or fails if either index is out of
+/// bounds). It returns a Fallible void value.
+#[inline(always)]
+pub fn swapbuffer<T, const S: usize>(a: &mut [T; S], i: &i64, j: &i64) -> Result<(), AlanError> {
+    if *i < 0 {
+        return Err(format!(
+            "Provided buffer index {} is beyond the bounds of the buffer",
+            i
+        )
+        .into());
+    }
+    if *j < 0 {
+        return Err(format!(
+            "Provided buffer index {} is beyond the bounds of the buffer",
+            j
+        )
+        .into());
+    }
+    let i = *i as usize;
+    let j = *j as usize;
+    if i >= a.len() {
+        return Err(format!(
+            "Provided buffer index {} is beyond the bounds of the buffer",
+            i
+        )
+        .into());
+    }
+    if j >= a.len() {
+        return Err(format!(
+            "Provided buffer index {} is beyond the bounds of the buffer",
+            j
+        )
+        .into());
+    }
+    if i == j {
+        return Ok(());
+    }
+    if i < j {
+        let (i_section, j_section) = a.split_at_mut(j);
+        std::mem::swap(&mut i_section[i], &mut j_section[0]);
+    } else {
+        let (j_section, i_section) = a.split_at_mut(i);
+        std::mem::swap(&mut j_section[j], &mut i_section[0]);
+    }
+    Ok(())
 }
 
 /// Dictionary-related bindings


### PR DESCRIPTION
I've decided to just bind the native `sort` functions from Rust and Javascript for now, but since I already put the work into implementing `swap` and because it is still useful outside of the context of in-place sorting, I'm making this PR to include it.
