### PR TITLE
Implement the bare minimum for `@std/fs`: file reading support

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -1062,6 +1062,19 @@ test!(basic_fn_import "fn_foo" =>
     stdout "Bar\n";
 );
 
+test!(file_reading "file_reading" =>
+    "test_file.txt" => "Hello, World!",
+    "file_reading.ln" => r#"
+        type File <-- '@std/fs';
+        fn string <-- '@std/fs'; // TODO: Should this be auto-imported?
+
+        export fn main {
+            File('./test_file.txt').string.print;
+        }
+    "#;
+    stdout "Hello, World!\n";
+);
+
 // Maybe, Result, and Either
 
 test!(maybe => r#"

--- a/alan/src/program/program.rs
+++ b/alan/src/program/program.rs
@@ -55,7 +55,7 @@ impl<'a> Program<'a> {
         Program::return_program(program);
         let ln_src = if path.starts_with('@') {
             match path.as_str() {
-                //"@std/app" => include_str!("../std/app.ln").to_string(),
+                "@std/fs" => include_str!("../std/fs.ln").to_string(),
                 _ => {
                     return Err(format!("Unknown standard library named {}", &path).into());
                 }

--- a/alan/src/std/fs.ln
+++ b/alan/src/std/fs.ln
@@ -1,0 +1,5 @@
+// For now all file operations open and close the actual file handle, so we don't need anything more
+export type File = path: string;
+
+export fn{Rs} string(f: File) = {Method{"map_err(|s| alan_std::AlanError { message: alan_std::stringify(s) }).into"} :: Own{Binds{"Result<String, std::io::Error>"}} -> string!}({"std::fs::read_to_string" :: string -> Binds{"Result<String, std::io::Error>"}}(f.path));
+export fn{Js} string(f: File) = {"(async (p) => { try { return new alan_std.Str((await import('node:fs')).readFileSync(p.val, { encoding: 'utf8' })); } catch (e) { return new alan_std.AlanError(e.message); } })" :: string -> string!}(f.path);


### PR DESCRIPTION
This is the beginning of the first non-root standard library in Alan v0.2: `@std/fs`.

For now, only one feature is implemented: reading an entire text file into a string.

Other things will be implemented over time, but since filesystem access doesn't exist in the browser, I'm not sure if I'll devote much effort into it in the near term. This is for Advent of Code 2024.
