### PR TITLE
Allow chaining of nullable `get` calls and fix a bug in JS codegen for optional arrays

### DIFF
--- a/alan/src/lntojs/function.rs
+++ b/alan/src/lntojs/function.rs
@@ -761,7 +761,8 @@ pub fn from_microstatement(
                                 let enum_name = match enum_type {
                                     CType::Field(n, _) => Ok(n.clone()),
                                     CType::Type(n, _) => Ok(n.clone()),
-                                    _ => Err(format!("Cannot generate an constructor function for {} type as the input type has no name?", ret_name)),
+                                    CType::Array(_) => Ok(enum_type.to_callable_string()),
+                                    otherwise => Err(format!("Cannot generate an constructor function for {} type as the input type has no name? {:?}", ret_name, otherwise)),
                                 }?;
                                 for t in &ts {
                                     let inner_type = t.degroup();
@@ -928,7 +929,8 @@ pub fn from_microstatement(
                                 let enum_name = match &enum_type {
                                     CType::Field(n, _) => Ok(n.clone()),
                                     CType::Type(n, _) => Ok(n.clone()),
-                                    _ => Err(format!("Cannot generate an constructor function for {} type as the input type has no name?", function.name)),
+                                    CType::Array(_) => Ok(enum_type.to_callable_string()),
+                                    otherwise => Err(format!("Cannot generate an constructor function for {} type as the input type has no name?, {:?}", function.name, otherwise)),
                                 }?;
                                 for t in &ts {
                                     let mut inner_type = t.degroup();
@@ -938,6 +940,9 @@ pub fn from_microstatement(
                                         }
                                     }
                                     match &inner_type {
+                                        CType::Array(_) => {
+                                            return Ok((argstrs[0].clone(), out, deps));
+                                        }
                                         CType::Field(n, _) if *n == enum_name => {
                                             // Special-casing for Option and Result mapping. TODO:
                                             // Make this more centralized

--- a/alan/src/lntojs/typen.rs
+++ b/alan/src/lntojs/typen.rs
@@ -37,6 +37,10 @@ pub fn ctype_to_jtype(
                                 deps = res.1;
                             }
                         }
+                        CType::Array(t) => {
+                            let res = ctype_to_jtype(t, deps)?;
+                            deps = res.1;
+                        }
                         otherwise => {
                             return Err(format!("TODO: What is this? {:?}", otherwise).into());
                         }

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -1208,6 +1208,7 @@ fn{Js} len{T} (a: T[]) = {Property{"length"} :: T[] -> i32}(a).i64;
 fn{Rs} get{T} "alan_std::getarray" <- RootBacking :: (T[], i64) -> T?;
 fn{Js} get{T} (a: T[], i: i64) = if((i >= 0) & (i < a.len),
   fn = {Method{"at"} :: (T[], i32) -> T}(a, i.i32));
+fn get{T} (a: Maybe{T[]}, i: i64) = if(a.exists, fn = (a!!).get(i), fn = {T?}());
 fn push{T} (a: Mut{T[]}, v: T) = {Method{"push"} :: (Mut{T[]}, Own{T})}(a, v);
 fn{Rs} pop{T} (a: Mut{T[]}) -> T? = {Method{"pop"} :: Mut{T[]} -> T?}(a);
 fn{Js} pop{T} (a: Mut{T[]}) -> T? = {"((a) => a || null)" :: T? -> T?}({Method{"pop"} :: Mut{T[]} -> T?}(a));


### PR DESCRIPTION
This PR has two separate fixes merged together.

1. Added a new `get{T}` function for the `Maybe{T[]}` type, allowing you to try and get a value out of an array that may or may not exist. This means instead of needing to write `(arrayOfArrays[i] ?? [])[j]` you can just write `arrayOfArrays[i][j]`, which is much nicer.
2. This worked fine in Rust, but I uncovered a missing case in the JS codegen path for this, so that is also updated (and I updated the error message to include more useful information if a failure like this happens again).
