### PR TITLE
Improved JS clone function that better handles nesting

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -727,6 +727,23 @@ test!(mutable_functions => r#"
     stdout "3\n5\n";
 );
 
+test!(complex_cloning => r#"
+    type struct = b: bool, d: Dict{string, Set{i64}};
+
+    export fn main {
+      let s = Set([1, 2, 3]);
+      s.len.print;
+      s.clone.len.print;
+      let d = Dict('foo', s);
+      d.len.print;
+      d.clone.len.print;
+      let b = struct(true, d);
+      b.d.len.print;
+      b.clone{struct}.d.len.print;
+    }"#;
+    stdout "3\n3\n1\n1\n1\n1\n";
+);
+
 // Conditionals
 
 test_ignore!(basic_conditionals => r#"

--- a/alan/src/program/ctype.rs
+++ b/alan/src/program/ctype.rs
@@ -102,7 +102,7 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
+                                    "https://github.com/alantech/alan.git#js-clone-fix".to_string(),
                                 )),
                             )))),
                         )),
@@ -135,7 +135,7 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
+                                    "https://github.com/alantech/alan.git#js-clone-fix".to_string(),
                                 )),
                             )))),
                         )),
@@ -168,7 +168,7 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
+                                    "https://github.com/alantech/alan.git#js-clone-fix".to_string(),
                                 )),
                             )))),
                         )),
@@ -201,7 +201,7 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
+                                    "https://github.com/alantech/alan.git#js-clone-fix".to_string(),
                                 )),
                             )))),
                         )),

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -117,7 +117,7 @@ type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
 type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
-type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git#js-clone-fix"};
 
 // Defining derived types
 type void = ();
@@ -221,8 +221,7 @@ infix store as = precedence 0;
 
 /// Functions for (potentially) every type
 fn{Rs} clone{T} (v: T) -> T = {Method{"clone"} :: T -> T}(v);
-// TODO: This needs to be turned into a JS function that's bound
-fn{Js} clone{T} (v: T) -> T = {"(function clone(t) { if (t instanceof Array) { return t.map(clone); } else if (t.build instanceof Function) { return t.build(t.val); } else if (t instanceof Set) { return t.union(new Set()); } else { return structuredClone(t); } })" :: T -> T}(v);
+fn{Js} clone{T} (v: T) -> T = {"alan_std.clone" <- RootBacking :: T -> T}(v);
 fn void{T}(v: T) -> void {}
 fn void() -> void {}
 fn{Rs} store{T} (a: Mut{T}, b: T) -> T = {"std::mem::replace" :: (Mut{T}, Own{T}) -> T}(a, b);

--- a/alan_std.js
+++ b/alan_std.js
@@ -26,10 +26,12 @@ export function ifbool(b, t, f) {
 export function clone(v) {
   if (v instanceof Array) {
     return v.map(clone);
-  } else if (v.build instanceof Function) {
-    return v.build(v.val);
   } else if (v instanceof Set) {
     return v.union(new Set());
+  } else if (v instanceof Map) {
+    return new Map(v.entries().map((kv) => [clone(kv[0]), clone(kv[1])]));
+  } else if (v.build instanceof Function) {
+    return v.build(v.val);
   } else if (v instanceof Object) {
     return Object.fromEntries(Object.entries(v).map((kv) => [kv[0], clone(kv[1])]));
   } else {

--- a/alan_std.js
+++ b/alan_std.js
@@ -23,6 +23,20 @@ export function ifbool(b, t, f) {
   }
 }
 
+export function clone(v) {
+  if (t instanceof Array) {
+    return t.map(clone);
+  } else if (t.build instanceof Function) {
+    return t.build(t.val);
+  } else if (t instanceof Set) {
+    return t.union(new Set());
+  } else if (t instanceof Object) {
+    return Object.entries().map((kv) => [kv[0], clone(kv[1])]).fromEntries();
+  } else {
+    return structuredClone(t);
+  }
+}
+
 // For those reading this binding support code, you might be wondering *why* all of the primitive
 // types are now boxed in their own classes. The reason is that in Alan (and Rust), you can mark
 // any input argument as mutable instead of the default being immutable, but in Javascript, all

--- a/alan_std.js
+++ b/alan_std.js
@@ -24,16 +24,16 @@ export function ifbool(b, t, f) {
 }
 
 export function clone(v) {
-  if (t instanceof Array) {
-    return t.map(clone);
-  } else if (t.build instanceof Function) {
-    return t.build(t.val);
-  } else if (t instanceof Set) {
-    return t.union(new Set());
-  } else if (t instanceof Object) {
-    return Object.entries().map((kv) => [kv[0], clone(kv[1])]).fromEntries();
+  if (v instanceof Array) {
+    return v.map(clone);
+  } else if (v.build instanceof Function) {
+    return v.build(v.val);
+  } else if (v instanceof Set) {
+    return v.union(new Set());
+  } else if (v instanceof Object) {
+    return Object.entries(v).map((kv) => [kv[0], clone(kv[1])]).fromEntries();
   } else {
-    return structuredClone(t);
+    return structuredClone(v);
   }
 }
 

--- a/alan_std.js
+++ b/alan_std.js
@@ -31,7 +31,7 @@ export function clone(v) {
   } else if (v instanceof Set) {
     return v.union(new Set());
   } else if (v instanceof Object) {
-    return Object.entries(v).map((kv) => [kv[0], clone(kv[1])]).fromEntries();
+    return Object.fromEntries(Object.entries(v).map((kv) => [kv[0], clone(kv[1])]));
   } else {
     return structuredClone(v);
   }


### PR DESCRIPTION
One of the bugs I noticed yesterday was `clone` failing on a custom structure but only for JS, not Rust. The issue wasn't in the compiler, but the clone function itself. It got too big to be inlined in the root scope so I added it to the JS stdlib support file instead.
