### PR TITLE
Fix generic type resolution when cloning structs

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -739,7 +739,7 @@ test!(complex_cloning => r#"
       d.clone.len.print;
       let b = struct(true, d);
       b.d.len.print;
-      b.clone{struct}.d.len.print;
+      b.clone.d.len.print;
     }"#;
     stdout "3\n3\n1\n1\n1\n1\n";
 );

--- a/alan/src/program/microstatement.rs
+++ b/alan/src/program/microstatement.rs
@@ -757,31 +757,9 @@ pub fn baseassignablelist_to_microstatements<'a>(
                 for arg in &arg_microstatements {
                     arg_types.push(arg.get_type());
                 }
-                // We create a type on-the-fly from the contents the GnCall block. It's given a
-                // name based on the CType tree with all non-`a-zA-Z0-9_` chars replaced with `-`
-                // TODO: Eliminate the duplication of CType generation logic by abstracting out the
-                // automatic function creation into a reusable component
                 let ctype = withtypeoperatorslist_to_ctype(&g.typecalllist, &scope)?;
                 let name = ctype.to_callable_string();
-                let parse_type = parse::Types {
-                    typen: "type".to_string(),
-                    a: "".to_string(),
-                    opttypegenerics: None,
-                    b: "".to_string(),
-                    fulltypename: parse::FullTypename {
-                        typename: name.clone(),
-                        opttypegenerics: None,
-                    },
-                    c: "".to_string(),
-                    typedef: parse::TypeDef {
-                        a: Some("=".to_string()),
-                        b: "".to_string(),
-                        typeassignables: g.typecalllist.clone(),
-                    },
-                    optsemicolon: ";".to_string(),
-                };
-                let res = CType::from_ast(scope, &parse_type, false)?;
-                scope = res.0;
+                scope = CType::from_ctype(scope, name.clone(), ctype.clone());
                 let temp_scope = scope.child();
                 // Now we are sure the type and function exist, and we know the name for the
                 // function. It would be best if we could just pass it to ourselves and run the

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -220,8 +220,8 @@ infix wrr as >>> precedence 5;
 infix store as = precedence 0;
 
 /// Functions for (potentially) every type
-fn{Rs} clone{T} (v: T) -> T = {Method{"clone"} :: T -> T}(v);
-fn{Js} clone{T} (v: T) -> T = {"alan_std.clone" <- RootBacking :: T -> T}(v);
+fn{Rs} clone{T} (v: T) -> T = {Method{"clone"} :: (v: T) -> T}(v);
+fn{Js} clone{T} (v: T) -> T = {"alan_std.clone" <- RootBacking :: (v: T) -> T}(v);
 fn void{T}(v: T) -> void {}
 fn void() -> void {}
 fn{Rs} store{T} (a: Mut{T}, b: T) -> T = {"std::mem::replace" :: (Mut{T}, Own{T}) -> T}(a, b);

--- a/alan/test.ln
+++ b/alan/test.ln
@@ -934,7 +934,8 @@ export fn{Test} main {
       );
     })
     .it("keyval array to dictionary", fn (test: Mut{Testing}) {
-      const kva = [{(i64, string)}(1, 'foo'), {(i64, string)}(2, 'bar'), {(i64, string)}(3, 'baz')];
+      // This is an improvement, but figure out why `{(i64, string)}` doesn't work
+      const kva = [{i64, string}(1, 'foo'), {i64, string}(2, 'bar'), {i64, string}(3, 'baz')];
       // TODO: Improve this with anonymous tuples
       // const kva = [(1, 'foo'), (2, 'bar'), (3, 'baz')];
       const hm = Dict(kva);


### PR DESCRIPTION
This fix is working around an issue with how generic types interact with the function type. Defining a function type `T -> T` *looks* like it should work just fine, but if the type `T` is resolved to is a tuple type, eg `i64, string` that becomes `i64, string -> i64, string`, where the first half of that then gets interpretted as a function with two arguments. If you instead write this generic function type as `(v: T) -> T` it becomes `(v: (i64, string)) -> i64, string` when analyzed and remains a single argument.

I'm not happy with this workaround, but I'm also not sure if ripping up a ton of the generic type resolution code to "fix" it is a good idea. (Specifically because when I did try to do that yesterday, I got caught in a quagmire of other code in the root scope failing because it was no longer resolving correctly, and in those cases the code as written also felt "right".)

There are other places where I need to make this change, as well, but just focusing on `clone` right now. I'll tackle the others over time.
