### PR TITLE
Add some hackery for conditionals where the functions are "block-like" side-effect-only functions for Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,10 +20,10 @@ jobs:
       run: cargo build --verbose
     - if: ${{ github.ref_name == 'main' }}
       name: Run tests
-      run: cargo test --verbose -- --include-ignored
+      run: cargo test --release --verbose -- --include-ignored
     - if: ${{ github.ref_name != 'main' }}
       name: Run tests
-      run: cargo test --verbose
+      run: cargo test --release --verbose
     - name: Run native tests
       run: cargo run --release -- test alan/test.ln
     - name: Run js tests
@@ -37,10 +37,10 @@ jobs:
       run: cargo build --verbose
     - if: ${{ github.ref_name == 'main' }}
       name: Run tests
-      run: cargo test --verbose -- --include-ignored
+      run: cargo test --release --verbose -- --include-ignored
     - if: ${{ github.ref_name != 'main' }}
       name: Run tests
-      run: cargo test --verbose
+      run: cargo test --release --verbose
     - name: Run native tests
       run: cargo run --release -- test alan/test.ln
     - name: Run js tests
@@ -58,10 +58,10 @@ jobs:
       run: cargo build --verbose
     - if: ${{ github.ref_name == 'main' }}
       name: Run tests
-      run: cargo test --verbose -- --include-ignored
+      run: cargo test --release --verbose -- --include-ignored
     - if: ${{ github.ref_name != 'main' }}
       name: Run tests
-      run: cargo test --verbose
+      run: cargo test --release --verbose
     - if: always()
       name: Stop web server
       run: yarn stop-server
@@ -78,10 +78,10 @@ jobs:
       run: cargo build --verbose
     - if: ${{ github.ref_name == 'main' }}
       name: Run tests
-      run: RUST_MIN_STACK=8388608 cargo test --verbose -- --include-ignored
+      run: RUST_MIN_STACK=8388608 cargo test --release --verbose -- --include-ignored
     - if: ${{ github.ref_name != 'main' }}
       name: Run tests
-      run: RUST_MIN_STACK=8388608 cargo test --verbose
+      run: RUST_MIN_STACK=8388608 cargo test --release --verbose
     - name: Run native tests
       run: cargo run --release -- test alan/test.ln
     - name: Run js tests
@@ -99,10 +99,10 @@ jobs:
       run: cargo build --verbose
     - if: ${{ github.ref_name == 'main' }}
       name: Run tests
-      run: RUST_MIN_STACK=8388608 cargo test --verbose -- --include-ignored
+      run: RUST_MIN_STACK=8388608 cargo test --release --verbose -- --include-ignored
     - if: ${{ github.ref_name != 'main' }}
       name: Run tests
-      run: RUST_MIN_STACK=8388608 cargo test --verbose
+      run: RUST_MIN_STACK=8388608 cargo test --release --verbose
     - if: always()
       name: Stop web server
       run: yarn stop-server

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -1101,13 +1101,13 @@ test!(maybe => r#"
     export fn main {
       const maybe5 = fiver(5.5);
       if(maybe5.exists,
-        fn = maybe5.getOr(0).print,
-        fn = 'what?'.print);
+        fn { maybe5.getOr(0).print; },
+        fn { 'what?'.print; });
 
       const maybeNot5 = fiver(4.4);
       if(!maybeNot5.exists,
-        fn = 'Correctly received nothing!'.print,
-        fn = 'uhhh'.print);
+        fn { 'Correctly received nothing!'.print; },
+        fn { 'uhhh'.print; });
 
       maybe5.print;
       maybeNot5.print;
@@ -1129,13 +1129,13 @@ test!(fallible => r#"
     export fn main {
       const oneFifth = reciprocal(5.0);
       if(oneFifth.f64.exists,
-        fn = print(oneFifth.getOr(0.0)),
-        fn = print('what?'));
+        fn { print(oneFifth.getOr(0.0)); },
+        fn { print('what?'); });
 
       const oneZeroth = reciprocal(0.0);
       if(oneZeroth.Error.exists,
-        fn = print(oneZeroth.Error.getOr(Error('No error'))),
-        fn = print('uhhh'));
+        fn { print(oneZeroth.Error.getOr(Error('No error'))); },
+        fn { print('uhhh'); });
 
       oneFifth.print;
       oneZeroth.print;

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -5129,8 +5129,8 @@ fn{Test} assert{T}(groupname: string[], comparator: (T, T) -> bool, actual: T, e
   "\u{1b}[0m".stdout;
   let res = comparator(actual, expected);
   if(res,
-    fn = "\u{0d}\u{1b}[32;1m✅".stdout,
-    fn = "\u{0d}\u{1b}[31;1m❎".stdout);
+    fn { "\u{0d}\u{1b}[32;1m✅".stdout; },
+    fn { "\u{0d}\u{1b}[31;1m❎".stdout; });
   line.stdout;
   "\u{1b}[0m".print;
   if(!res, fn {

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -520,6 +520,11 @@ fn if{T}(c: bool, t: T, f: T) = if(c, fn () = t, fn () = f);
 fn if{T}(c: bool, t: () -> T) = if(c, fn () = Maybe{T}(t()), fn () = Maybe{T}());
 fn{Rs} if{T} "alan_std::ifbool" <- RootBacking :: (bool, () -> T, () -> T) -> T;
 fn{Js} if{T} "alan_std.ifbool" <- RootBacking :: (bool, () -> T, () -> T) -> T;
+fn{Js} if(c: bool, t: () -> ()) {
+  if(c, t, fn { 0; });
+}
+fn{Rs} if "ifstatementhack" :: (bool, () -> ()) -> ();
+fn{Rs} if "ifelsestatementhack" :: (bool, () -> (), () -> ()) -> ();
 
 /// Float-related functions and function bindings
 fn{Rs} add Infix{"+"} :: (f32, f32) -> f32;


### PR DESCRIPTION
If you try to have two branches of an `if` function call that both try to mutate the same outer variable, that will not compile in Rust because it was implemented as closure functions that are then called, and that fails the borrow checker due to two mutable references taken "at the same time" (this is potentially true if they were passed to different threads, but not how we're using it).

So this hackery (that will eventually be formalized) rewrites back into a normal conditional statement to make this common style of code work.
