### PR TITLE
Fix direct offset access for buffers and make Set work as expected in Javascript

### DIFF
--- a/alan/src/lntojs/function.rs
+++ b/alan/src/lntojs/function.rs
@@ -623,6 +623,20 @@ pub fn from_microstatement(
                                     return Ok((format!("{}.{}", argstrs[0], n), out, deps));
                                 }
                             }
+                            CType::Buffer(_, s) => {
+                                // Similarly short-circuit for direct `<N>` function calls
+                                if let Ok(i) = function.name.parse::<i64>() {
+                                    if let CType::Int(l) = **s {
+                                        if i128::from(i) < l {
+                                            return Ok((
+                                                format!("{}[{}]", argstrs[0], i),
+                                                out,
+                                                deps,
+                                            ));
+                                        }
+                                    }
+                                }
+                            }
                             CType::Field(..) => {
                                 return Ok((format!("{}.arg0", argstrs[0]), out, deps));
                             }

--- a/alan/src/lntors/function.rs
+++ b/alan/src/lntors/function.rs
@@ -709,6 +709,20 @@ pub fn from_microstatement(
                                     return Ok((format!("{}.{}", argstrs[0], i), out, deps));
                                 }
                             }
+                            CType::Buffer(_, s) => {
+                                // Similarly short-circuit for direct `<N>` function calls
+                                if let Ok(i) = function.name.parse::<i64>() {
+                                    if let CType::Int(l) = **s {
+                                        if i128::from(i) < l {
+                                            return Ok((
+                                                format!("{}[{}]", argstrs[0], i),
+                                                out,
+                                                deps,
+                                            ));
+                                        }
+                                    }
+                                }
+                            }
                             CType::Field(..) => {
                                 return Ok((format!("{}.0", argstrs[0]), out, deps));
                             }

--- a/alan/src/program/ctype.rs
+++ b/alan/src/program/ctype.rs
@@ -102,7 +102,7 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
+                                    "https://github.com/alantech/alan.git#buffer-direct-access-and-js-set-fixes".to_string(),
                                 )),
                             )))),
                         )),
@@ -135,7 +135,7 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
+                                    "https://github.com/alantech/alan.git#buffer-direct-access-and-js-set-fixes".to_string(),
                                 )),
                             )))),
                         )),
@@ -168,7 +168,7 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
+                                    "https://github.com/alantech/alan.git#buffer-direct-access-and-js-set-fixes".to_string(),
                                 )),
                             )))),
                         )),
@@ -201,7 +201,7 @@ impl CType {
                             Box::new(CType::Node(Box::new(CType::Dependency(
                                 Box::new(CType::TString("alan_std".to_string())),
                                 Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
+                                    "https://github.com/alantech/alan.git#buffer-direct-access-and-js-set-fixes".to_string(),
                                 )),
                             )))),
                         )),

--- a/alan/src/program/ctype.rs
+++ b/alan/src/program/ctype.rs
@@ -2646,6 +2646,16 @@ impl CType {
                         origin_scope_path: scope.path.clone(),
                     });
                 }
+                // Also include accessor functions for each
+                for i in 0..size {
+                    fs.push(Function {
+                        name: format!("{}", i),
+                        typen: CType::Function(Box::new(t.clone()), b.clone()),
+                        microstatements: Vec::new(),
+                        kind: FnKind::Derived,
+                        origin_scope_path: scope.path.clone(),
+                    })
+                }
             }
             CType::Array(a) => {
                 // For Arrays we create only one kind of array, one that takes any

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -117,7 +117,7 @@ type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
 type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
-type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git#buffer-direct-access-and-js-set-fixes"};
 
 // Defining derived types
 type void = ();
@@ -176,7 +176,7 @@ type{Js} uuid = Binds{"alan_std.uuidv4" <- RootBacking};
 type{Rs} Dict{K, V} = Binds{"alan_std::OrderedHashMap" <- RootBacking, K, V};
 type{Js} Dict{K, V} = Binds{"Map", K, V};
 type{Rs} Set{V} = Binds{"std::collections::HashSet", V};
-type{Js} Set{V} = Binds{"Set", V};
+type{Js} Set{V} = Binds{"alan_std.FuzzySet" <- RootBacking, V};
 
 // Basic trig constants (this language is meant for GPGPU, this makes sense in the root scope)
 const e = 2.718281828459045;
@@ -1393,20 +1393,20 @@ fn Set{V}(a: Array{V}) = a.reduce(Set{V}(), fn (s: Set{V}, v: V) {
   return s;
 });
 fn{Rs} Set{V} "std::collections::HashSet::new" :: () -> Set{V};
-fn{Js} Set{V} "new Set" :: () -> Set{V};
+fn{Js} Set{V} "new alan_std.FuzzySet" <- RootBacking :: () -> Set{V};
 fn{Rs} store{V} (s: Mut{Set{V}}, v: V) {
   {Method{"insert"} :: (Mut{Set{V}}, Own{V}) -> bool}(s, v);
 }
 fn{Js} store{V} (s: Mut{Set{V}}, v: V) {
-  {"((s, v) => s.add(v.toString()))" :: (Set{V}, V) -> Set{V}}(s, v);
+  {Method{"store"} :: (Set{V}, V) -> Set{V}}(s, v);
 }
 fn{Rs} has{V} (s: Set{V}, v: V) = {Method{"contains"} :: (Set{V}, V) -> bool}(s, v);
-fn{Js} has{V} (s: Set{V}, v: V) = {"((s, v) => new alan_std.Bool(s.has(v.toString())))" <- RootBacking :: (Set{V}, V) -> bool}(s, v);
+fn{Js} has{V} (s: Set{V}, v: V) = {Method{"has"} :: (Set{V}, V) -> bool}(s, v);
 fn{Rs} len{V} (s: Set{V}) = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}(
   {Method{"len"} :: Set{V} -> Binds{"usize"}}(s));
-fn{Js} len{V} (s: Set{V}) = {Property{"size"} :: Set{V} -> i32}(s).i64;
+fn{Js} len{V} (s: Set{V}) = {Method{"len"} :: Set{V} -> i64}(s);
 fn{Rs} Array{V} "alan_std::arrayset" <- RootBacking :: Set{V} -> V[];
-fn{Js} Array{V} "Array.from" :: Set{V} -> V[];
+fn{Js} Array{V} (s: Set{V}) = {Method{"array"} :: Set{V} -> V[]}(s)
 fn{Rs} union{V} "alan_std::unionset" <- RootBacking :: (Set{V}, Set{V}) -> Set{V};
 fn{Js} union{V} (a: Set{V}, b: Set{V}) = {Method{"union"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
 fn or{V}(a: Set{V}, b: Set{V}) = union(a, b);
@@ -1420,7 +1420,7 @@ fn{Rs} symmetricDifference{V} "alan_std::symmetric_differenceset" <- RootBacking
 fn{Js} symmetricDifference{V} (a: Set{V}, b: Set{V}) = {Method{"symmetricDifference"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
 fn xor{V}(a: Set{V}, b: Set{V}) = symmetricDifference(a, b);
 fn{Rs} product{V} "alan_std::productset" <- RootBacking :: (Set{V}, Set{V}) -> Set{(V, V)};
-fn{Js} product{V} "((a, b) => { let out = new Set(); for (let arg0 of a) { for (let arg1 of b) { out.add({ arg0, arg1 }); } } return out; })" :: (Set{V}, Set{V}) -> Set{(V, V)};
+fn{Js} product{V} (a: Set{V}, b: Set{V}) = {Method{"product"} :: (Set{V}, Set{V}) -> Set{(V, V)}}(a, b);
 fn mul{V}(a: Set{V}, b: Set{V}) = product(a, b);
 
 /// Tree implementation

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -1398,10 +1398,10 @@ fn{Rs} store{V} (s: Mut{Set{V}}, v: V) {
   {Method{"insert"} :: (Mut{Set{V}}, Own{V}) -> bool}(s, v);
 }
 fn{Js} store{V} (s: Mut{Set{V}}, v: V) {
-  {"((s, v) => s.add(v?.val ?? v))" :: (Set{V}, V) -> Set{V}}(s, v);
+  {"((s, v) => s.add(v.toString()))" :: (Set{V}, V) -> Set{V}}(s, v);
 }
 fn{Rs} has{V} (s: Set{V}, v: V) = {Method{"contains"} :: (Set{V}, V) -> bool}(s, v);
-fn{Js} has{V} (s: Set{V}, v: V) = {"((s, v) => new alan_std.Bool(s.has(v?.val ?? v)))" <- RootBacking :: (Set{V}, V) -> bool}(s, v);
+fn{Js} has{V} (s: Set{V}, v: V) = {"((s, v) => new alan_std.Bool(s.has(v.toString())))" <- RootBacking :: (Set{V}, V) -> bool}(s, v);
 fn{Rs} len{V} (s: Set{V}) = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}(
   {Method{"len"} :: Set{V} -> Binds{"usize"}}(s));
 fn{Js} len{V} (s: Set{V}) = {Property{"size"} :: Set{V} -> i32}(s).i64;

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -1397,9 +1397,7 @@ fn{Js} Set{V} "new alan_std.FuzzySet" <- RootBacking :: () -> Set{V};
 fn{Rs} store{V} (s: Mut{Set{V}}, v: V) {
   {Method{"insert"} :: (Mut{Set{V}}, Own{V}) -> bool}(s, v);
 }
-fn{Js} store{V} (s: Mut{Set{V}}, v: V) {
-  {Method{"store"} :: (Set{V}, V) -> Set{V}}(s, v);
-}
+fn{Js} store{V} (s: Mut{Set{V}}, v: V) = {Method{"store"} :: (Set{V}, V) -> ()}(s, v);
 fn{Rs} has{V} (s: Set{V}, v: V) = {Method{"contains"} :: (Set{V}, V) -> bool}(s, v);
 fn{Js} has{V} (s: Set{V}, v: V) = {Method{"has"} :: (Set{V}, V) -> bool}(s, v);
 fn{Rs} len{V} (s: Set{V}) = {Cast{"i64"} :: Deref{Binds{"usize"}} -> i64}(
@@ -1411,7 +1409,7 @@ fn{Rs} union{V} "alan_std::unionset" <- RootBacking :: (Set{V}, Set{V}) -> Set{V
 fn{Js} union{V} (a: Set{V}, b: Set{V}) = {Method{"union"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
 fn or{V}(a: Set{V}, b: Set{V}) = union(a, b);
 fn{Rs} intersect{V} "alan_std::intersectset" <- RootBacking :: (Set{V}, Set{V}) -> Set{V};
-fn{Js} intersect{V} (a: Set{V}, b: Set{V}) = {Method{"intersection"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
+fn{Js} intersect{V} (a: Set{V}, b: Set{V}) = {Method{"intersect"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);
 fn and{V}(a: Set{V}, b: Set{V}) = intersect(a, b);
 fn{Rs} difference{V} "alan_std::differenceset" <- RootBacking :: (Set{V}, Set{V}) -> Set{V};
 fn{Js} difference{V} (a: Set{V}, b: Set{V}) = {Method{"difference"} :: (Set{V}, Set{V}) -> Set{V}}(a, b);

--- a/alan_std.js
+++ b/alan_std.js
@@ -68,7 +68,7 @@ export class FuzzySet {
   intersect(other) {
     let set = {};
     for (let a of Object.keys(this.map)) {
-      if (other.has(a)) {
+      if (other.has(a).val) {
         set[a] = true;
       }
     }
@@ -79,7 +79,7 @@ export class FuzzySet {
   difference(other) {
     let set = {};
     for (let a of Object.keys(this.map)) {
-      if (!other.has(a)) {
+      if (!other.has(a).val) {
         set[a] = true;
       }
     }
@@ -90,12 +90,12 @@ export class FuzzySet {
   symmetricDifference(other) {
     let set = {};
     for (let a of Object.keys(this.map)) {
-      if (!other.has(a)) {
+      if (!other.has(a).val) {
         set[a] = true;
       }
     }
     for (let b of Object.keys(other.map)) {
-      if (!this.has(b)) {
+      if (!this.has(b).val) {
         set[b] = true;
       }
     }

--- a/alan_std.js
+++ b/alan_std.js
@@ -31,13 +31,13 @@ export class FuzzySet {
   store(val) {
     // TODO: Create a 'universal' hash function for JS to make the key
     // TODO: Remove this GPUBuffer hack eventually
-    this.map[val instanceof globalThis.GPUBuffer ? val.label : val.toString()] = val;
+    this.map[globalThis.GPUBuffer && val instanceof globalThis.GPUBuffer ? val.label : val.toString()] = val;
   }
 
   has(val) {
     return new Bool(
       this.map.hasOwnProperty(
-        val instanceof globalThis.GPUBuffer ? val.label : val.toString()
+        globalThis.GPUBuffer && val instanceof globalThis.GPUBuffer ? val.label : val.toString()
       )
     );
   }

--- a/alan_std.js
+++ b/alan_std.js
@@ -53,7 +53,7 @@ export class FuzzySet {
   makeMapWith(keys, other) {
     let map = {};
     for (let key of keys) {
-      map[key] = this.has(key) ? this.map[key] : other.map[key];
+      map[key] = this.has(key).val ? this.map[key] : other.map[key];
     }
     return map;
   }

--- a/alan_std.js
+++ b/alan_std.js
@@ -31,13 +31,13 @@ export class FuzzySet {
   store(val) {
     // TODO: Create a 'universal' hash function for JS to make the key
     // TODO: Remove this GPUBuffer hack eventually
-    this.map[val instanceof (window ?? global).GPUBuffer ? val.label : val.toString()] = val;
+    this.map[val instanceof globalThis.GPUBuffer ? val.label : val.toString()] = val;
   }
 
   has(val) {
     return new Bool(
       this.map.hasOwnProperty(
-        val instanceof (window ?? global).GPUBuffer ? val.label : val.toString()
+        val instanceof globalThis.GPUBuffer ? val.label : val.toString()
       )
     );
   }

--- a/alan_std.js
+++ b/alan_std.js
@@ -30,11 +30,12 @@ export class FuzzySet {
 
   store(val) {
     // TODO: Create a 'universal' hash function for JS to make the key
-    this.map[val.toString()] = val;
+    // TODO: Remove this GPUBuffer hack eventually
+    this.map[val instanceof GPUBuffer ? val.label : val.toString()] = val;
   }
 
   has(val) {
-    return new Bool(this.map.hasOwnProperty(val.toString()));
+    return new Bool(this.map.hasOwnProperty(val instanceof GPUBuffer ? val.label : val.toString()));
   }
 
   len() {

--- a/alan_std.js
+++ b/alan_std.js
@@ -31,11 +31,15 @@ export class FuzzySet {
   store(val) {
     // TODO: Create a 'universal' hash function for JS to make the key
     // TODO: Remove this GPUBuffer hack eventually
-    this.map[val instanceof GPUBuffer ? val.label : val.toString()] = val;
+    this.map[val instanceof (window ?? global).GPUBuffer ? val.label : val.toString()] = val;
   }
 
   has(val) {
-    return new Bool(this.map.hasOwnProperty(val instanceof GPUBuffer ? val.label : val.toString()));
+    return new Bool(
+      this.map.hasOwnProperty(
+        val instanceof (window ?? global).GPUBuffer ? val.label : val.toString()
+      )
+    );
   }
 
   len() {

--- a/alan_std.js
+++ b/alan_std.js
@@ -34,7 +34,7 @@ export class FuzzySet {
   }
 
   has(val) {
-    return this.map.hasOwnProperty(val.toString());
+    return new Bool(this.map.hasOwnProperty(val.toString()));
   }
 
   len() {


### PR DESCRIPTION
I could have sworn I had `.0`, `.1`, etc working for buffers, but apparently not, so this implements it.

I also ran into a weird issue with sets of buffers in Javascript and realized that `Set` in Javascript only does exact object checking (eg, just comparing if the value pointer is equal) so recreating a buffer and testing it would fail because they are different buffer objects in memory. This change resolves that, as well.
