### PR TITLE
Only convert the outer closures into block syntax for the three block hacks

### DIFF
--- a/alan/src/lntors/function.rs
+++ b/alan/src/lntors/function.rs
@@ -326,7 +326,7 @@ pub fn from_microstatement(
                     out = res.1;
                     deps = res.2;
                     let res = from_microstatement(&args[1], parent_fn, scope, out, deps)?;
-                    let successblock = res.0.replace("|| {", "{");
+                    let successblock = res.0.replacen("|| {", "{", 1);
                     out = res.1;
                     deps = res.2;
                     return Ok((
@@ -340,11 +340,11 @@ pub fn from_microstatement(
                     out = res.1;
                     deps = res.2;
                     let res = from_microstatement(&args[1], parent_fn, scope, out, deps)?;
-                    let successblock = res.0.replace("|| {", "{");
+                    let successblock = res.0.replacen("|| {", "{", 1);
                     out = res.1;
                     deps = res.2;
                     let res = from_microstatement(&args[2], parent_fn, scope, out, deps)?;
-                    let failblock = res.0.replace("|| {", "{");
+                    let failblock = res.0.replacen("|| {", "{", 1);
                     out = res.1;
                     deps = res.2;
                     return Ok((
@@ -358,11 +358,11 @@ pub fn from_microstatement(
                     let conditionalparts = res.0.split("return").collect::<Vec<&str>>();
                     let conditional = [conditionalparts[0], &conditionalparts[1].replace(";", "")]
                         .join("")
-                        .replace("|| {", "{");
+                        .replacen("|| {", "{", 1);
                     out = res.1;
                     deps = res.2;
                     let res = from_microstatement(&args[1], parent_fn, scope, out, deps)?;
-                    let loopblock = res.0.replace("|| {", "{");
+                    let loopblock = res.0.replacen("|| {", "{", 1);
                     out = res.1;
                     deps = res.2;
                     return Ok((


### PR DESCRIPTION
I realized that if you create a closure function inside of code that uses one of the hack block behavior, it accidentally turns the inner closures into blocks as well and then breaks the generated code. This prevents that by only allowing one replacement (the outer closure).
