### PR TITLE
Cache the module and compute_pipeline objects after first run for potential reuse

### DIFF
--- a/alan_std.js
+++ b/alan_std.js
@@ -687,21 +687,29 @@ export class GPGPU {
     this.entrypoint = entrypoint ?? "main";
     this.buffers = buffers;
     this.workgroupSizes = workgroupSizes;
+    this.module = undefined;
+    this.computePipeline = undefined;
   }
 }
 
 export async function gpuRun(gg) {
   let g = await gpu();
-  let module = g.device.createShaderModule({
-    code: gg.source,
-  });
-  let computePipeline = g.device.createComputePipeline({
-    layout: "auto",
-    compute: {
-      entryPoint: gg.entrypoint,
-      module,
-    },
-  });
+  if (!this.module) {
+    this.module = g.device.createShaderModule({
+      code: gg.source,
+    });
+  }
+  let module = this.module;
+  if (!this.computePipeline) {
+    this.computePipeline = g.device.createComputePipeline({
+      layout: "auto",
+      compute: {
+        entryPoint: gg.entryPoint,
+        module,
+      },
+    });
+  }
+  let computePipeline = this.computePipeline;
   let encoder = g.device.createCommandEncoder();
   let cpass = encoder.beginComputePass();
   cpass.setPipeline(computePipeline);

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -986,6 +986,8 @@ pub struct GPGPU {
     pub entrypoint: String,
     pub buffers: Vec<Vec<GBuffer>>,
     pub workgroup_sizes: [i64; 3],
+    pub module: Option<wgpu::ShaderModule>,
+    pub compute_pipeline: Option<wgpu::ComputePipeline>,
 }
 
 impl GPGPU {
@@ -995,26 +997,34 @@ impl GPGPU {
             entrypoint: "main".to_string(),
             buffers,
             workgroup_sizes,
+            module: None,
+            compute_pipeline: None,
         }
     }
 }
 
-pub fn gpu_run(gg: &GPGPU) {
+pub fn gpu_run(gg: &mut GPGPU) {
     let g = gpu();
-    let module = g.device.create_shader_module(wgpu::ShaderModuleDescriptor {
-        label: None,
-        source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(&gg.source)),
-    });
-    let compute_pipeline = g
-        .device
-        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+    if let None = &gg.module {
+        gg.module = Some(g.device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: None,
-            layout: None,
-            module: &module,
-            entry_point: Some(&gg.entrypoint),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            cache: None, // TODO: Might be worthwhile
-        });
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(&gg.source)),
+        }));
+    }
+    let module = gg.module.as_ref().unwrap();
+    if let None = &gg.compute_pipeline {
+        gg.compute_pipeline = Some(g.device.create_compute_pipeline(
+            &wgpu::ComputePipelineDescriptor {
+                label: None,
+                layout: None,
+                module,
+                entry_point: Some(&gg.entrypoint),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                cache: None,
+            },
+        ));
+    }
+    let compute_pipeline = gg.compute_pipeline.as_ref().unwrap();
     let mut bind_groups = Vec::new();
     let mut encoder = g
         .device
@@ -1024,7 +1034,7 @@ pub fn gpu_run(gg: &GPGPU) {
             label: None,
             timestamp_writes: None,
         });
-        cpass.set_pipeline(&compute_pipeline);
+        cpass.set_pipeline(compute_pipeline);
         for i in 0..gg.buffers.len() {
             let bind_group_layout = compute_pipeline.get_bind_group_layout(i.try_into().unwrap());
             let bind_group_buffers = &gg.buffers[i];


### PR DESCRIPTION
This shouldn't cause any problems for single-use compute shader executions as at the end of the scope the GPGPU object would be dropped and the cached value with it, and it'll be cleaned up by the garbage collector in the same way it was in JS before. But this should reduce latency for compute shader execution that is re-run multiple times, and should be amenable to manually swapping out the buffer objects (even if using the GPU types and the `build` function, though that's much more "digging into the guts of the abstraction" but doable where it wasn't before) so you can quickly perform the same kind of operation on a large swath of values.
