### PR TITLE
Add `run` method for an array of `GPGPU` values

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -542,6 +542,20 @@ test_gpgpu!(hello_gpu_new => r#"
     }"#;
     stdout "[0, 2, 4, 6]\n";
 );
+test_gpgpu!(list_of_gpu_tasks => r#"
+    export fn main {
+      let b1 = GBuffer(filled(2.i32, 8));
+      let b2 = GBuffer(filled(5.i32, 4));
+      let i1 = gFor(8);
+      let i2 = gFor(4);
+      let c1 = b1[i1].store(b1[i1] * i1.gi32);
+      let c2 = b2[i2].store(b1[i2] + i2.gi32);
+      [c1.build, c2.build].run; // Execution order determined here
+      b1.read{i32}.print;
+      b2.read{i32}.print;
+    }"#;
+    stdout "[0, 2, 4, 6, 8, 10, 12, 14]\n[0, 3, 6, 9]\n";
+);
 
 test_gpgpu!(hello_gpu_odd => r#"
     export fn main {

--- a/alan/src/program/ctype.rs
+++ b/alan/src/program/ctype.rs
@@ -79,139 +79,6 @@ pub enum CType {
 }
 
 impl CType {
-    // TODO: Find a better way to handle these primitive types
-    pub fn i64() -> CType {
-        let program = Program::get_program();
-        let output_lang = program.env.get("ALAN_OUTPUT_LANG").unwrap().clone();
-        Program::return_program(program);
-        match output_lang.as_str() {
-            "rs" => CType::Type(
-                "i64".to_string(),
-                Box::new(CType::Binds(
-                    Box::new(CType::TString("i64".to_string())),
-                    Vec::new(),
-                )),
-            ),
-            "js" => CType::Type(
-                "i64".to_string(),
-                Box::new(CType::Binds(
-                    Box::new(CType::Import(
-                        Box::new(CType::TString("alan_std.I64".to_string())),
-                        Box::new(CType::Type(
-                            "RootBacking".to_string(),
-                            Box::new(CType::Node(Box::new(CType::Dependency(
-                                Box::new(CType::TString("alan_std".to_string())),
-                                Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
-                                )),
-                            )))),
-                        )),
-                    )),
-                    Vec::new(),
-                )),
-            ),
-            _ => unreachable!(),
-        }
-    }
-    pub fn f64() -> CType {
-        let program = Program::get_program();
-        let output_lang = program.env.get("ALAN_OUTPUT_LANG").unwrap().clone();
-        Program::return_program(program);
-        match output_lang.as_str() {
-            "rs" => CType::Type(
-                "f64".to_string(),
-                Box::new(CType::Binds(
-                    Box::new(CType::TString("f64".to_string())),
-                    Vec::new(),
-                )),
-            ),
-            "js" => CType::Type(
-                "f64".to_string(),
-                Box::new(CType::Binds(
-                    Box::new(CType::Import(
-                        Box::new(CType::TString("alan_std.F64".to_string())),
-                        Box::new(CType::Type(
-                            "RootBacking".to_string(),
-                            Box::new(CType::Node(Box::new(CType::Dependency(
-                                Box::new(CType::TString("alan_std".to_string())),
-                                Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
-                                )),
-                            )))),
-                        )),
-                    )),
-                    Vec::new(),
-                )),
-            ),
-            _ => unreachable!(),
-        }
-    }
-    pub fn bool() -> CType {
-        let program = Program::get_program();
-        let output_lang = program.env.get("ALAN_OUTPUT_LANG").unwrap().clone();
-        Program::return_program(program);
-        match output_lang.as_str() {
-            "rs" => CType::Type(
-                "bool".to_string(),
-                Box::new(CType::Binds(
-                    Box::new(CType::TString("bool".to_string())),
-                    Vec::new(),
-                )),
-            ),
-            "js" => CType::Type(
-                "bool".to_string(),
-                Box::new(CType::Binds(
-                    Box::new(CType::Import(
-                        Box::new(CType::TString("alan_std.Bool".to_string())),
-                        Box::new(CType::Type(
-                            "RootBacking".to_string(),
-                            Box::new(CType::Node(Box::new(CType::Dependency(
-                                Box::new(CType::TString("alan_std".to_string())),
-                                Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
-                                )),
-                            )))),
-                        )),
-                    )),
-                    Vec::new(),
-                )),
-            ),
-            _ => unreachable!(),
-        }
-    }
-    pub fn string() -> CType {
-        let program = Program::get_program();
-        let output_lang = program.env.get("ALAN_OUTPUT_LANG").unwrap().clone();
-        Program::return_program(program);
-        match output_lang.as_str() {
-            "rs" => CType::Type(
-                "string".to_string(),
-                Box::new(CType::Binds(
-                    Box::new(CType::TString("String".to_string())),
-                    Vec::new(),
-                )),
-            ),
-            "js" => CType::Type(
-                "string".to_string(),
-                Box::new(CType::Binds(
-                    Box::new(CType::Import(
-                        Box::new(CType::TString("alan_std.Str".to_string())),
-                        Box::new(CType::Type(
-                            "RootBacking".to_string(),
-                            Box::new(CType::Node(Box::new(CType::Dependency(
-                                Box::new(CType::TString("alan_std".to_string())),
-                                Box::new(CType::TString(
-                                    "https://github.com/alantech/alan.git".to_string(),
-                                )),
-                            )))),
-                        )),
-                    )),
-                    Vec::new(),
-                )),
-            ),
-            _ => unreachable!(),
-        }
-    }
     #[allow(clippy::inherent_to_string)]
     pub fn to_string(&self) -> String {
         self.to_strict_string(true)
@@ -2324,7 +2191,7 @@ impl CType {
                                     // Create an accessor function for this value, but do not add
                                     // it to the args array to construct it. The accessor function
                                     // will return this value as a string.
-                                    let string = CType::string();
+                                    let string = scope.resolve_type("string").unwrap().clone();
                                     fs.push(Function {
                                         name: n.clone(),
                                         typen: CType::Function(
@@ -2346,7 +2213,7 @@ impl CType {
                                     // Create an accessor function for this value, but do not add
                                     // it to the args array to construct it. The accessor function
                                     // will return this value as an i64.
-                                    let int64 = CType::i64();
+                                    let int64 = scope.resolve_type("i64").unwrap().clone();
                                     fs.push(Function {
                                         name: n.clone(),
                                         typen: CType::Function(
@@ -2365,7 +2232,7 @@ impl CType {
                                     // Create an accessor function for this value, but do not add
                                     // it to the args array to construct it. The accessor function
                                     // will return this value as an f64.
-                                    let float64 = CType::f64();
+                                    let float64 = scope.resolve_type("f64").unwrap().clone();
                                     fs.push(Function {
                                         name: n.clone(),
                                         typen: CType::Function(
@@ -2384,7 +2251,7 @@ impl CType {
                                     // Create an accessor function for this value, but do not add
                                     // it to the args array to construct it. The accessor function
                                     // will return this value as a bool.
-                                    let booln = CType::bool();
+                                    let booln = scope.resolve_type("bool").unwrap().clone();
                                     fs.push(Function {
                                         name: n.clone(),
                                         typen: CType::Function(
@@ -2469,7 +2336,7 @@ impl CType {
                         // Create an accessor function for this value, but do not add
                         // it to the args array to construct it. The accessor function
                         // will return this value as a string.
-                        let string = CType::string();
+                        let string = scope.resolve_type("string").unwrap().clone();
                         fs.push(Function {
                             name: n.clone(),
                             typen: CType::Function(Box::new(t.clone()), Box::new(string.clone())),
@@ -2485,7 +2352,7 @@ impl CType {
                         // Create an accessor function for this value, but do not add
                         // it to the args array to construct it. The accessor function
                         // will return this value as an i64.
-                        let int64 = CType::i64();
+                        let int64 = scope.resolve_type("i64").unwrap().clone();
                         fs.push(Function {
                             name: n.clone(),
                             typen: CType::Function(Box::new(t.clone()), Box::new(int64.clone())),
@@ -2501,7 +2368,7 @@ impl CType {
                         // Create an accessor function for this value, but do not add
                         // it to the args array to construct it. The accessor function
                         // will return this value as an f64.
-                        let float64 = CType::f64();
+                        let float64 = scope.resolve_type("f64").unwrap().clone();
                         fs.push(Function {
                             name: n.clone(),
                             typen: CType::Function(Box::new(t.clone()), Box::new(float64.clone())),
@@ -2517,7 +2384,7 @@ impl CType {
                         // Create an accessor function for this value, but do not add
                         // it to the args array to construct it. The accessor function
                         // will return this value as a bool.
-                        let booln = CType::bool();
+                        let booln = scope.resolve_type("bool").unwrap().clone();
                         fs.push(Function {
                             name: n.clone(),
                             typen: CType::Function(Box::new(t.clone()), Box::new(booln.clone())),
@@ -2675,7 +2542,7 @@ impl CType {
             }
             CType::Int(i) => {
                 // TODO: Support construction of other integer types
-                let int64 = CType::i64();
+                let int64 = scope.resolve_type("i64").unwrap().clone();
                 fs.push(Function {
                     name: constructor_fn_name.clone(),
                     typen: CType::Function(Box::new(CType::Void), Box::new(int64.clone())),
@@ -2691,7 +2558,7 @@ impl CType {
             }
             CType::Float(f) => {
                 // TODO: Support construction of other float types
-                let float64 = CType::f64();
+                let float64 = scope.resolve_type("f64").unwrap().clone();
                 fs.push(Function {
                     name: constructor_fn_name.clone(),
                     typen: CType::Function(Box::new(CType::Void), Box::new(float64.clone())),
@@ -2706,25 +2573,33 @@ impl CType {
                 });
             }
             CType::Bool(b) => {
-                let booln = CType::bool();
-                fs.push(Function {
-                    name: constructor_fn_name.clone(),
-                    typen: CType::Function(Box::new(CType::Void), Box::new(booln.clone())),
-                    microstatements: vec![Microstatement::Return {
-                        value: Some(Box::new(Microstatement::Value {
-                            typen: booln,
-                            representation: match b {
-                                true => "true".to_string(),
-                                false => "false".to_string(),
-                            },
-                        })),
-                    }],
-                    kind: FnKind::Normal,
-                    origin_scope_path: scope.path.clone(),
-                });
+                // A special exception exists for a few booleans that are created *before* the bool
+                // type is created in the root scope. TODO: Find a better solution for this so they
+                // have accessor functions defined for run-time code to use them.
+                match scope.resolve_type("bool") {
+                    Some(boolt) => {
+                        let booln = boolt.clone();
+                        fs.push(Function {
+                            name: constructor_fn_name.clone(),
+                            typen: CType::Function(Box::new(CType::Void), Box::new(booln.clone())),
+                            microstatements: vec![Microstatement::Return {
+                                value: Some(Box::new(Microstatement::Value {
+                                    typen: booln,
+                                    representation: match b {
+                                        true => "true".to_string(),
+                                        false => "false".to_string(),
+                                    },
+                                })),
+                            }],
+                            kind: FnKind::Normal,
+                            origin_scope_path: scope.path.clone(),
+                        });
+                    }
+                    None => {}
+                }
             }
             CType::TString(s) => {
-                let string = CType::string();
+                let string = scope.resolve_type("string").unwrap().clone();
                 fs.push(Function {
                     name: constructor_fn_name.clone(),
                     typen: CType::Function(Box::new(CType::Void), Box::new(string.clone())),

--- a/alan/src/program/microstatement.rs
+++ b/alan/src/program/microstatement.rs
@@ -278,14 +278,16 @@ pub fn baseassignablelist_to_microstatements<'a>(
             BaseChunk::Constant(c) => {
                 match c {
                     parse::Constants::Bool(b) => {
+                        let booln = scope.resolve_type("bool").unwrap().clone();
                         prior_value = Some(Microstatement::Value {
-                            typen: CType::bool(),
+                            typen: booln,
                             representation: b.clone(),
                         });
                     }
                     parse::Constants::Strn(s) => {
+                        let string = scope.resolve_type("string").unwrap().clone();
                         prior_value = Some(Microstatement::Value {
-                            typen: CType::string(),
+                            typen: string,
                             representation: if s.starts_with('"') {
                                 s.clone()
                             } else {
@@ -299,18 +301,20 @@ pub fn baseassignablelist_to_microstatements<'a>(
                     }
                     parse::Constants::Num(n) => match n {
                         parse::Number::RealNum(r) => {
+                            let float64 = scope.resolve_type("f64").unwrap().clone();
                             prior_value = Some(Microstatement::Value {
                                 // TODO: Replace this with the `CType::Float` and have built-ins
                                 // that accept them
-                                typen: CType::f64(),
+                                typen: float64,
                                 representation: r.clone(),
                             });
                         }
                         parse::Number::IntNum(i) => {
+                            let int64 = scope.resolve_type("i64").unwrap().clone();
                             prior_value = Some(Microstatement::Value {
                                 // TODO: Replace this with `CType::Int` and have built-ins that
                                 // accept them
-                                typen: CType::i64(),
+                                typen: int64,
                                 representation: i.clone(),
                             });
                         }

--- a/alan/src/program/scope.rs
+++ b/alan/src/program/scope.rs
@@ -239,7 +239,7 @@ impl<'a> Scope<'a> {
         }
     }
 
-    pub fn resolve_type(&'a self, typename: &String) -> Option<&CType> {
+    pub fn resolve_type(&'a self, typename: &str) -> Option<&CType> {
         // Tries to find the specified type within the portion of the program accessible from the
         // current scope (so first checking the current scope, then all imports, then the root
         // scope) Returns a reference to the type and the scope it came from.

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -116,8 +116,8 @@ type Rs = Env{"ALAN_OUTPUT_LANG"} == "rs";
 type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
-type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
-type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git#gpgpu-run-list"};
+type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git#gpgpu-run-list"};
 
 // Defining derived types
 type void = ();
@@ -1615,6 +1615,8 @@ fn GPGPU(src: string, buf: GBuffer) -> GPGPU {
 }
 fn{Rs} run "alan_std::gpu_run" <- RootBacking :: Mut{GPGPU};
 fn{Js} run "alan_std.gpuRun" <- RootBacking :: GPGPU;
+fn{Rs} run "alan_std::gpu_run_list" <- RootBacking :: Mut{GPGPU[]};
+fn{Js} run "alan_std.gpuRunList" <- RootBacking :: GPGPU[];
 fn{Rs} read{T}(gb: GBuffer) = {"alan_std::read_buffer" <- RootBacking :: GBuffer -> T[]}(gb);
 fn{Js} read{T} "alan_std.readBuffer" <- RootBacking :: GBuffer -> T[];
 fn{Rs} replace{T} "alan_std::replace_buffer" <- RootBacking :: (GBuffer, T[]) -> ()!;

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -116,8 +116,8 @@ type Rs = Env{"ALAN_OUTPUT_LANG"} == "rs";
 type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
-type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git#gpgpu-run-list"};
-type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git#gpgpu-run-list"};
+type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
 
 // Defining derived types
 type void = ();


### PR DESCRIPTION
I also improved the primitive type situation to use the version defined in the root scope (with one downside as there are a few compile-time boolean constants defined *before* the runtime boolean type is defined, and their run-time accessor functions are therefore not created, but I'll come back to that later). This improvement means in the future a change that only requires the root scope to be changed will not require a change in the compiler during testing.
