### PR TITLE
Fix crash on MacOS, but improve on all platforms

### DIFF
--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1562,6 +1562,7 @@ where
                     .as_ref()
                     .unwrap()
                     .set_title(&format!("Render time: {:.3}", render_time.as_secs_f64()));
+                std::thread::sleep(std::time::Duration::from_millis(100));
                 self.context.window.as_ref().unwrap().request_redraw();
             }
             _ => {} // Ignore all other events

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1223,6 +1223,7 @@ where
     config: Option<WindowAttributes>,
     context: AlanWindowContext,
     instance: Option<wgpu::Instance>,
+    surface: Option<wgpu::Surface>,
     adapter: Option<wgpu::Adapter>,
     device: Option<wgpu::Device>,
     queue: Option<wgpu::Queue>,
@@ -1246,11 +1247,15 @@ where
         if self.instance.is_none() {
             self.instance = Some(wgpu::Instance::default());
         }
+        if self.surface.is_none() {
+            let instance = self.instance.as_ref().unwrap();
+            self.surface = Some(instance
+                .create_surface(self.context.window.as_ref().unwrap())
+                .unwrap());
+        }
         if self.adapter.is_none() {
             let instance = self.instance.as_ref().unwrap();
-            let surface = instance
-                .create_surface(self.context.window.as_ref().unwrap())
-                .unwrap();
+            let surface = self.surface.as_ref().unwrap();
             self.adapter = Some(
                 pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
                     power_preference: wgpu::PowerPreference::default(), // TODO: Configure this
@@ -1422,9 +1427,7 @@ where
                 size.width = size.width.max(1);
                 size.height = size.height.max(1);
                 let instance = self.instance.as_ref().unwrap();
-                let surface = instance
-                    .create_surface(self.context.window.as_ref().unwrap())
-                    .unwrap();
+                let surface = self.surface.as_ref().unwrap();
                 let adapter = self.adapter.as_ref().unwrap();
                 let device = self.device.as_ref().unwrap();
                 let old_context_buffer_id = self.context_buffer.as_ref().unwrap().id.clone();

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1566,7 +1566,6 @@ where
                     .as_ref()
                     .unwrap()
                     .set_title(&format!("Render time: {:.3}", render_time.as_secs_f64()));
-                std::thread::sleep(std::time::Duration::from_millis(100));
                 self.context.window.as_ref().unwrap().request_redraw();
             }
             _ => {} // Ignore all other events


### PR DESCRIPTION
While debugging what's going on, I realized that the memory consumption on MacOS was growing per frame by inserting a sleep in the render loop. After spending a *lot* of time debating whether or not I should switch MacOS under-the-hood to a "traditional" vertex+fragment shader stack that copies the values out of the compute shader buffer instead of using `copy_buffer_to_texture`, I realized that there was *one* `wgpu` object that I was creating every frame that maybe shouldn't be: the surface.

I had originally avoided that because I didn't want to deal with the lifetime issues surrounding it, and it didn't seem to matter for Linux and Windows; it didn't seem to "create" anything. But perhaps on MacOS it is *actually* creating something? That would explain the weird window shadow insanity I would see after some time, where it looked like it was drawing multiple shadows on top of each other. And it would also explain the memory growth rate if it really was creating a new rendering surface every frame (the fact that it could do that and still have the most impressive framerate of all of my test machines is even crazier).

I found [this StackOverflow question and answer](https://stackoverflow.com/questions/78728851/cannot-create-wgpu-surface-due-to-lifetime-constraint) and patterned after it to hold onto the window and surface in a way that would let me bypass lifetime issues (rather, the winit API kinda forces this: I can't give it an struct that implements `ApplicationHandler` where that struct has a lifetime parameter, so *something* above the `ApplicationHandler` needs to own the window lifetime, and `Arc` is the easy escape hatch to do so).

This *does* fix the issue on MacOS, which is great! Confusingly it also reduces the framerate that I see back to the same level I see on Linux -- perhaps there was some sort of lock on the surface texture being displayed that was being bypassed when I was writing to different surfaces each frame? In any case, this was a major blocker to officially releasing 0.2.0 that is now fixed. :)
