### PR TITLE
Mouse position and cursor visibility support

### DIFF
--- a/alan/src/lntors/function.rs
+++ b/alan/src/lntors/function.rs
@@ -72,7 +72,10 @@ pub fn from_microstatement(
             let arg_names = function
                 .args()
                 .into_iter()
-                .map(|(n, _, _)| n)
+                .map(|(n, k, _)| match k {
+                    ArgKind::Mut => format!("mut {}", n),
+                    _ => n,
+                })
                 .collect::<Vec<String>>();
             let mut inner_statements = Vec::new();
             for ms in &function.microstatements {

--- a/alan/src/lntors/typen.rs
+++ b/alan/src/lntors/typen.rs
@@ -27,7 +27,10 @@ pub fn ctype_to_rtype(
                                     let res = ctype_to_rtype(t, true, deps)?;
                                     let s = res.0;
                                     deps = res.1;
-                                    out.push(s);
+                                    out.push(match &t {
+                                        CType::Mut(_) => format!("mut {}", s),
+                                        _ => s,
+                                    });
                                 }
                                 out.join(", &")
                             },
@@ -35,7 +38,10 @@ pub fn ctype_to_rtype(
                                 let res = ctype_to_rtype(otherwise, true, deps)?;
                                 let s = res.0;
                                 deps = res.1;
-                                s
+                                match &otherwise {
+                                    CType::Mut(_) => format!("mut {}", s),
+                                    _ => s,
+                                }
                             }
                         }, {
                             let res = ctype_to_rtype(o, true, deps)?;

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -116,7 +116,7 @@ type Rs = Env{"ALAN_OUTPUT_LANG"} == "rs";
 type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
-type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git#mouse-position-support"};
 type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
 
 // Defining derived types
@@ -1646,8 +1646,8 @@ fn{Rs} GBuffer{T}(bu: BufferUsages, size: i64) = {"alan_std::create_empty_buffer
 fn{Js} GBuffer{T}(bu: BufferUsages, size: i64) = {"alan_std.createEmptyBuffer" <- RootBacking :: (BufferUsages, i32) -> GBuffer}(bu, size.i32);
 fn GBuffer{T}(vals: T[]) = GBuffer{T}(storageBuffer(), vals);
 fn GBuffer{T}(size: i64) = GBuffer{T}(storageBuffer(), size);
-fn{Rs} len "alan_std::bufferlen" <- RootBacking :: GBuffer -> i64;
-fn{Js} len "alan_std.bufferlen" <- RootBacking :: GBuffer -> i64;
+fn{Rs} cpulen "alan_std::bufferlen" <- RootBacking :: GBuffer -> i64;
+fn{Js} cpulen "alan_std.bufferlen" <- RootBacking :: GBuffer -> i64;
 fn{Rs} id "alan_std::buffer_id" <- RootBacking :: GBuffer -> string;
 fn{Js} id "alan_std.bufferid" <- RootBacking :: GBuffer -> string;
 fn{Rs} GPGPU "alan_std::GPGPU::new" <- RootBacking :: (Own{string}, Own{Array{Array{GBuffer}}}, Deref{i64[3]}) -> GPGPU;
@@ -1670,7 +1670,7 @@ fn GPGPU(src: string, buf: GBuffer) -> GPGPU {
   // and the Z limit becomes the division + 1, while the remainder is executed division and
   // remainder on the A constant, division + 1, and this remainder becomes the X limit (plus 1).
   // Including this big explanation in case I've made an off-by-one error here ;)
-  let l = buf.len;
+  let l = buf.cpulen;
   let zDiv = l / 4_294_836_225;
   let z = zDiv + 1;
   let zRem = l % 4_294_836_225;
@@ -1822,6 +1822,12 @@ fn gbool(gi: gi32) = gPrimitiveConvert{gi32, gbool}(gi);
 fn gbool(gf: gf32) = gPrimitiveConvert{gf32, gbool}(gf);
 fn gbool(gb: gbool) = gb;
 fn gbool{T}(b: T) = gbool(b.bool);
+
+fn len(gb: GBuffer) = gu32(
+  'arrayLength(&'.concat(gb.id).concat(')'),
+  Dict{string, string}(),
+  Set(gb)
+);
 
 // Vector types and constructors
 type gvec2u = WgpuType{"vec2u"};
@@ -4363,6 +4369,38 @@ fn pow(a: gvec4f, b: gvec4f) = gpow(a, b);
 fn pow{T}(a: gvec4f, b: T) = pow(a, b.gvec4f);
 fn pow{T}(a: T, b: gvec4f) = pow(a.gvec4f, b);
 
+fn gmin{I}(a: I, b: I) {
+  let varName = 'min('.concat(a.varName).concat(', ').concat(b.varName).concat(')');
+  let statements = a.statements.concat(b.statements);
+  let buffers = a.buffers.union(b.buffers);
+  return {I}(varName, statements, buffers);
+}
+fn min(a: gf32, b: gf32) = gmin(a, b);
+fn min{A}(a: A, b: gf32) = gmin(a.gf32, b);
+fn min{B}(a: gf32, b: B) = gmin(a, b.gf32);
+fn min(a: gu32, b: gu32) = gmin(a, b);
+fn min{A}(a: A, b: gu32) = gmin(a.gu32, b);
+fn min{B}(a: gu32, b: B) = gmin(a, b.gu32);
+fn min(a: gi32, b: gi32) = gmin(a, b);
+fn min{A}(a: A, b: gi32) = gmin(a.gi32, b);
+fn min{B}(a: gi32, b: B) = gmin(a, b.gi32);
+
+fn gmax{I}(a: I, b: I) {
+  let varName = 'max('.concat(a.varName).concat(', ').concat(b.varName).concat(')');
+  let statements = a.statements.concat(b.statements);
+  let buffers = a.buffers.union(b.buffers);
+  return {I}(varName, statements, buffers);
+}
+fn max(a: gf32, b: gf32) = gmax(a, b);
+fn max{A}(a: A, b: gf32) = gmax(a.gf32, b);
+fn max{B}(a: gf32, b: B) = gmax(a, b.gf32);
+fn max(a: gu32, b: gu32) = gmax(a, b);
+fn max{A}(a: A, b: gu32) = gmax(a.gu32, b);
+fn max{B}(a: gu32, b: B) = gmax(a, b.gu32);
+fn max(a: gi32, b: gi32) = gmax(a, b);
+fn max{A}(a: A, b: gi32) = gmax(a.gi32, b);
+fn max{B}(a: gi32, b: B) = gmax(a, b.gi32);
+
 fn gsqrt{I}(v: I) {
   let varName = 'sqrt('.concat(v.varName).concat(')');
   return {I}(varName, v.statements, v.buffers);
@@ -4907,7 +4945,12 @@ fn and{T}(a: T, b: gu32) = gand(a.gu32, b);
 fn and(a: gi32, b: gi32) = gand(a, b);
 fn and{T}(a: gi32, b: T) = gand(a, b.gi32);
 fn and{T}(a: T, b: gi32) = gand(a.gi32, b);
-fn and(a: gbool, b: gbool) = gand(a, b);
+fn and(a: gbool, b: gbool) {
+  let varName = '('.concat(a.varName).concat(' && ').concat(b.varName).concat(')');
+  let statements = a.statements.concat(b.statements);
+  let buffers = a.buffers.union(b.buffers);
+  return gbool(varName, statements, buffers);
+}
 fn and{T}(a: gbool, b: T) = gand(a, b.gbool);
 fn and{T}(a: T, b: gbool) = gand(a.gbool, b);
 fn and(a: gvec2u, b: gvec2u) = gand(a, b);
@@ -5257,33 +5300,33 @@ fn map{G, G2}(gb: GBuffer, f: G -> G2) {
   return out;
 }*/
 fn map(gb: GBuffer, f: gu32 -> gu32) {
-  let idx = gFor(gb.len);
+  let idx = gFor(gb.cpulen);
   let val = gb[idx].asU32;
-  let out = GBuffer{u32}(gb.len);
+  let out = GBuffer{u32}(gb.cpulen);
   let compute = out[idx].store(f(val).asI32);
   compute.build.run;
   return out;
 }
 fn map(gb: GBuffer, f: gi32 -> gi32) {
-  let idx = gFor(gb.len);
+  let idx = gFor(gb.cpulen);
   let val = gb[idx];
-  let out = GBuffer{i32}(gb.len);
+  let out = GBuffer{i32}(gb.cpulen);
   let compute = out[idx].store(f(val));
   compute.build.run;
   return out;
 }
 fn map(gb: GBuffer, f: gf32 -> gf32) {
-  let idx = gFor(gb.len);
+  let idx = gFor(gb.cpulen);
   let val = gb[idx].asF32;
-  let out = GBuffer{f32}(gb.len);
+  let out = GBuffer{f32}(gb.cpulen);
   let compute = out[idx].store(f(val).asI32);
   compute.build.run;
   return out;
 }
 fn{Js} map(gb: GBuffer, f: gf32 -> gf32) { // TODO: Get rid of this jank
-  let idx = gFor(gb.len);
+  let idx = gFor(gb.cpulen);
   let val = gb[idx].asF32;
-  let out = GBuffer{f32}(gb.len); // The JS binding currently ignores this
+  let out = GBuffer{f32}(gb.cpulen); // The JS binding currently ignores this
   {"((b) => { b.ValKind = alan_std.F32; })" :: GBuffer}(out); // Trick to get it to work for now
   let compute = out[idx].store(f(val).asI32);
   compute.build.run;
@@ -5292,9 +5335,9 @@ fn{Js} map(gb: GBuffer, f: gf32 -> gf32) { // TODO: Get rid of this jank
 // This one technically only works for i32/u32/f32 by chance. Once the issue above is fixed, this
 // one can be fixed, too.
 fn map{G, G2}(gb: GBuffer, f: (G, gu32) -> G2) {
-  let idx = gFor(gb.len);
+  let idx = gFor(gb.cpulen);
   let val = gb[idx];
-  let out = GBuffer{i32}(gb.len);
+  let out = GBuffer{i32}(gb.cpulen);
   let compute = out[idx].store(f(val, idx));
   compute.build.run;
   return out;
@@ -5304,15 +5347,18 @@ fn map{G, G2}(gb: GBuffer, f: (G, gu32) -> G2) {
 type{Rs} Window = Binds{"alan_std::AlanWindowContext" <- RootBacking};
 type{Rs} Frame = Binds{"alan_std::AlanWindowFrame" <- RootBacking};
 
-fn{Rs} window "alan_std::run_window" <- RootBacking :: ((Window) -> u32[], (Frame) -> GPGPU[]) -> ()!;
+fn{Rs} window "alan_std::run_window" <- RootBacking :: (Mut{(Mut{Window}) -> u32[]}, (Frame) -> GPGPU[]) -> ()!;
 fn{Rs} width Method{"width"} :: Window -> u32;
 fn{Rs} height Method{"height"} :: Window -> u32;
 fn{Rs} bufferWidth Method{"buffer_width"} :: Window -> u32;
+fn{Rs} mouseX Method{"mouse_x"} :: Mut{Window} -> u32;
+fn{Rs} mouseY Method{"mouse_y"} :: Mut{Window} -> u32;
+fn{Rs} cursorVisible Method{"cursor_visible"} :: Mut{Window} -> ();
+fn{Rs} cursorInvisible Method{"cursor_invisible"} :: Mut{Window} -> ();
 fn{Rs} runtime Method{"runtime"} :: Window -> u32;
 fn{Rs} context Property{"context.clone()"} :: Frame -> GBuffer;
 fn{Rs} framebuffer Property{"framebuffer.clone()"} :: Frame -> GBuffer;
-fn{Rs} width Frame -> i64 = -1;
-fn{Rs} height Frame -> i64 = -2;
+fn{Rs} pixel Frame = gFor(-1, -2); // Magic numbers for the binding
 
 /// Process exit-related bindings
 fn{Rs} ExitCode "std::process::ExitCode::from" :: Own{u8} -> ExitCode;

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -116,7 +116,7 @@ type Rs = Env{"ALAN_OUTPUT_LANG"} == "rs";
 type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
-type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git#mouse-position-support"};
+type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
 type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
 
 // Defining derived types

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1185,6 +1185,7 @@ pub struct AlanWindowContext {
     buffer_width: Option<u32>,
     mouse_x: Option<u32>,
     mouse_y: Option<u32>,
+    cursor_visible: bool,
 }
 
 impl AlanWindowContext {
@@ -1229,6 +1230,14 @@ impl AlanWindowContext {
         } else {
             self.mouse_y.unwrap()
         }
+    }
+
+    pub fn cursor_visible(&mut self) {
+        self.cursor_visible = true;
+    }
+
+    pub fn cursor_invisible(&mut self) {
+        self.cursor_visible = false;
     }
 }
 
@@ -1446,7 +1455,9 @@ where
                 if !self.inited {
                     self.window_gpu_init();
                 }
-                let mut size = self.context.window.as_ref().unwrap().inner_size();
+                let window = self.context.window.as_ref().unwrap();
+                window.set_cursor_visible(self.context.cursor_visible);
+                let mut size = window.inner_size();
                 size.width = size.width.max(1);
                 size.height = size.height.max(1);
                 let surface = self.surface.as_ref().unwrap();
@@ -1615,6 +1626,7 @@ where
             buffer_width: None,
             mouse_x: None,
             mouse_y: None,
+            cursor_visible: true,
         },
         instance: None,
         surface: None,

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1239,7 +1239,7 @@ pub struct AlanWindowFrame {
 
 pub struct AlanWindow<C, R>
 where
-    C: Fn(&AlanWindowContext) -> Vec<u32>,
+    C: Fn(&mut AlanWindowContext) -> Vec<u32>,
     R: Fn(&AlanWindowFrame) -> Vec<GPGPU>,
 {
     config: Option<WindowAttributes>,
@@ -1259,7 +1259,7 @@ where
 
 impl<C, R> AlanWindow<C, R>
 where
-    C: Fn(&AlanWindowContext) -> Vec<u32>,
+    C: Fn(&mut AlanWindowContext) -> Vec<u32>,
     R: Fn(&AlanWindowFrame) -> Vec<GPGPU>,
 {
     fn window_gpu_init(&mut self) {
@@ -1356,7 +1356,7 @@ where
 
 impl<C, R> ApplicationHandler for AlanWindow<C, R>
 where
-    C: Fn(&AlanWindowContext) -> Vec<u32>,
+    C: Fn(&mut AlanWindowContext) -> Vec<u32>,
     R: Fn(&AlanWindowFrame) -> Vec<GPGPU>,
 {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
@@ -1605,7 +1605,7 @@ where
 
 pub fn run_window<C, R>(context_fn: C, gpgpu_shader_fn: R) -> Result<(), AlanError>
 where
-    C: Fn(&AlanWindowContext) -> Vec<u32>,
+    C: Fn(&mut AlanWindowContext) -> Vec<u32>,
     R: Fn(&AlanWindowFrame) -> Vec<GPGPU>,
 {
     let event_loop = EventLoop::new().unwrap();

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1216,7 +1216,7 @@ impl AlanWindowContext {
         if self.mouse_x.is_none() {
             self.mouse_x = Some(0);
             self.mouse_y = Some(0);
-            return 0;
+            0
         } else {
             self.mouse_x.unwrap()
         }
@@ -1226,7 +1226,7 @@ impl AlanWindowContext {
         if self.mouse_y.is_none() {
             self.mouse_x = Some(0);
             self.mouse_y = Some(0);
-            return 0;
+            0
         } else {
             self.mouse_y.unwrap()
         }
@@ -1601,7 +1601,7 @@ where
                 self.context.window.as_ref().unwrap().request_redraw();
             }
             WindowEvent::CursorMoved { position, .. } => {
-                if !self.context.mouse_x.is_none() {
+                if self.context.mouse_x.is_some() {
                     self.context.mouse_x = Some(position.x as u32);
                     self.context.mouse_y = Some(position.y as u32);
                 }

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1239,7 +1239,7 @@ pub struct AlanWindowFrame {
 
 pub struct AlanWindow<C, R>
 where
-    C: Fn(&mut AlanWindowContext) -> Vec<u32>,
+    C: FnMut(&mut AlanWindowContext) -> Vec<u32>,
     R: Fn(&AlanWindowFrame) -> Vec<GPGPU>,
 {
     config: Option<WindowAttributes>,
@@ -1259,7 +1259,7 @@ where
 
 impl<C, R> AlanWindow<C, R>
 where
-    C: Fn(&mut AlanWindowContext) -> Vec<u32>,
+    C: FnMut(&mut AlanWindowContext) -> Vec<u32>,
     R: Fn(&AlanWindowFrame) -> Vec<GPGPU>,
 {
     fn window_gpu_init(&mut self) {
@@ -1356,7 +1356,7 @@ where
 
 impl<C, R> ApplicationHandler for AlanWindow<C, R>
 where
-    C: Fn(&mut AlanWindowContext) -> Vec<u32>,
+    C: FnMut(&mut AlanWindowContext) -> Vec<u32>,
     R: Fn(&AlanWindowFrame) -> Vec<GPGPU>,
 {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
@@ -1605,7 +1605,7 @@ where
 
 pub fn run_window<C, R>(context_fn: C, gpgpu_shader_fn: R) -> Result<(), AlanError>
 where
-    C: Fn(&mut AlanWindowContext) -> Vec<u32>,
+    C: FnMut(&mut AlanWindowContext) -> Vec<u32>,
     R: Fn(&AlanWindowFrame) -> Vec<GPGPU>,
 {
     let event_loop = EventLoop::new().unwrap();

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1591,11 +1591,8 @@ where
             }
             WindowEvent::CursorMoved { position, .. } => {
                 if !self.context.mouse_x.is_none() {
-                    let mut size = self.context.window.as_ref().unwrap().inner_size();
-                    size.width = size.width.max(1);
-                    size.height = size.height.max(1);
-                    self.context.mouse_x = Some((position.x * (size.width as f64)) as u32);
-                    self.context.mouse_y = Some((position.y * (size.height as f64)) as u32);
+                    self.context.mouse_x = Some(position.x as u32);
+                    self.context.mouse_y = Some(position.y as u32);
                 }
             }
             _ => {} // Ignore all other events

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1465,7 +1465,7 @@ where
                 let frame = surface.get_current_texture().unwrap();
                 let mut encoder =
                     device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-                let context_array = (self.context_fn)(&self.context);
+                let context_array = (self.context_fn)(&mut self.context);
                 let context_slice = &context_array[..];
                 let context_ptr = context_slice.as_ptr();
                 let context_u8_len = context_array.len() * 4;


### PR DESCRIPTION
I also made some other changes, like a GBuffer `len` producing a `gu32` moving the old `len` to `cpulen` (for the time being) (this let me get rid of `bufferWidth` from my example program, though I am keeping it around as a concept, for now, at least), and added the `min` and `max` functions (at least partially, I need to investigate if the piecewise vector behavior exists or not), etc.

The new example program is listed below:

```ln
export fn main {
  print('hi');
  window(fn (win: Mut{Window}) {
    win.cursorInvisible;
    return [
      win.width, win.height, win.runtime, win.mouseX, win.mouseY
    ];
  }, fn (frame: Frame) {
    let id = frame.pixel;
    let width = frame.context[0];
    let height = frame.context[1];
    let time = frame.context[2].asF32;
    let mouseX = frame.context[3];
    let mouseY = frame.context[4];
    let per10sec = time / 10.0;
    let cycle = 2.0 * abs(per10sec - floor(per10sec) - 0.5);
    let light = 1.0 / gvec2f(abs(mouseX - id.x).gf32, abs(mouseY - id.y).gf32).magnitude;
    let red = min(1.0, light + cycle * gf32(id.x) / gf32(width));
    let green = min(1.0, light + 1.0 - red);
    let blue = min(1.0, light + gf32(id.y) / gf32(height));
    let alpha = 1.0;
    let loc = id.x + (frame.framebuffer.len / height) * id.y;
    // TODO: Should not need the `.asI32` below
    let compute = frame.framebuffer[loc].store(pack4x8unorm(gvec4f(blue, green, red, alpha)).asI32);
    let plan = compute.build;
    print('Generated shader:\n');
    plan.shader.print;
    return [plan];
  });
  print('bye');
}
```
