### PR TITLE
Enable window transparency

### DIFF
--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -5356,7 +5356,7 @@ fn{Rs} mouseY Method{"mouse_y"} :: Mut{Window} -> u32;
 fn{Rs} cursorVisible Method{"cursor_visible"} :: Mut{Window} -> ();
 fn{Rs} cursorInvisible Method{"cursor_invisible"} :: Mut{Window} -> ();
 fn{Rs} transparent Method{"transparent"} :: Mut{Window} -> ();
-fn{Js} opaque Method{"opaque"} :: Mut{Window} -> ();
+fn{Rs} opaque Method{"opaque"} :: Mut{Window} -> ();
 fn{Rs} runtime Method{"runtime"} :: Window -> u32;
 fn{Rs} context Property{"context.clone()"} :: Frame -> GBuffer;
 fn{Rs} framebuffer Property{"framebuffer.clone()"} :: Frame -> GBuffer;

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -116,7 +116,7 @@ type Rs = Env{"ALAN_OUTPUT_LANG"} == "rs";
 type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
-type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git#transparent"};
 type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
 
 // Defining derived types
@@ -5355,6 +5355,8 @@ fn{Rs} mouseX Method{"mouse_x"} :: Mut{Window} -> u32;
 fn{Rs} mouseY Method{"mouse_y"} :: Mut{Window} -> u32;
 fn{Rs} cursorVisible Method{"cursor_visible"} :: Mut{Window} -> ();
 fn{Rs} cursorInvisible Method{"cursor_invisible"} :: Mut{Window} -> ();
+fn{Rs} transparent Method{"transparent"} :: Mut{Window} -> ();
+fn{Js} opaque Method{"opaque"} :: Mut{Window} -> ();
 fn{Rs} runtime Method{"runtime"} :: Window -> u32;
 fn{Rs} context Property{"context.clone()"} :: Frame -> GBuffer;
 fn{Rs} framebuffer Property{"framebuffer.clone()"} :: Frame -> GBuffer;

--- a/alan/src/std/root.ln
+++ b/alan/src/std/root.ln
@@ -116,7 +116,7 @@ type Rs = Env{"ALAN_OUTPUT_LANG"} == "rs";
 type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
-type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git#transparent"};
+type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
 type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
 
 // Defining derived types

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1186,6 +1186,7 @@ pub struct AlanWindowContext {
     mouse_x: Option<u32>,
     mouse_y: Option<u32>,
     cursor_visible: bool,
+    transparent: bool,
 }
 
 impl AlanWindowContext {
@@ -1238,6 +1239,14 @@ impl AlanWindowContext {
 
     pub fn cursor_invisible(&mut self) {
         self.cursor_visible = false;
+    }
+
+    pub fn transparent(&mut self) {
+        self.transparent = true;
+    }
+
+    pub fn opaque(&mut self) {
+        self.transparent = true;
     }
 }
 
@@ -1456,7 +1465,9 @@ where
                     self.window_gpu_init();
                 }
                 let window = self.context.window.as_ref().unwrap();
+                // TODO: These shouldn't be set every frame
                 window.set_cursor_visible(self.context.cursor_visible);
+                window.set_transparent(self.context.transparent);
                 let mut size = window.inner_size();
                 size.width = size.width.max(1);
                 size.height = size.height.max(1);
@@ -1627,6 +1638,7 @@ where
             mouse_x: None,
             mouse_y: None,
             cursor_visible: true,
+            transparent: false,
         },
         instance: None,
         surface: None,

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1484,7 +1484,7 @@ where
                 config.present_mode = wgpu::PresentMode::Fifo;
                 config.desired_maximum_frame_latency = 3;
                 config.alpha_mode = if self.context.transparent {
-                    wgpu::CompositeAlphaMode::PostMultiplied
+                    wgpu::CompositeAlphaMode::PreMultiplied
                 } else {
                     wgpu::CompositeAlphaMode::Auto
                 };

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1483,6 +1483,11 @@ where
                     wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::RENDER_ATTACHMENT;
                 config.present_mode = wgpu::PresentMode::Fifo;
                 config.desired_maximum_frame_latency = 3;
+                config.alpha_mode = if self.context.transparent {
+                    wgpu::CompositeAlphaMode::PostMultiplied
+                } else {
+                    wgpu::CompositeAlphaMode::Auto
+                };
                 surface.configure(device, &config);
                 let frame = surface.get_current_texture().unwrap();
                 let mut encoder =

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1639,6 +1639,7 @@ where
     // Potentially mutate the context by calling the context function, but ignore the context
     // vector it creates
     context_fn(&mut context);
+    println!("is transparent: {}", context.transparent);
     let config = Window::default_attributes().with_transparent(context.transparent);
     let event_loop = EventLoop::new().unwrap();
     event_loop.set_control_flow(ControlFlow::Poll); // TODO: This should also be configurable


### PR DESCRIPTION
This gets window transparency working. It only supports pre-multiplied transparency, though, which requires the `RGB` channels to have `A` multiplied onto them for it to work. Not difficult, but perhaps not expected that a "full bright red" is actually `127` if the alpha is `127`, and weird stuff happens if it goes above that.

I can probably have a helper function to do that for users to simulate `PostMultiplied` mode, though.

I also had to make it so the context function *is* called first in order to get the transparency flag for `X11` windows set properly. Transparency won't work at all for the browser, so I guess toggleable transparency is just a "nice to have." (I wonder why the program's running under XWayland instead of directly on Wayland, though).
