### PR TITLE
Add an `initial_context_fn` to eliminate useless work per frame

### DIFF
--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -116,7 +116,7 @@ type Rs = Env{"ALAN_OUTPUT_LANG"} == "rs";
 type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
-type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git#initial-context-fn"};
 type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
 
 // Defining derived types
@@ -5378,7 +5378,7 @@ fn map{G, G2}(gb: GBuffer, f: (G, gu32) -> G2) {
 type{Rs} Window = Binds{"alan_std::AlanWindowContext" <- RootBacking};
 type{Rs} Frame = Binds{"alan_std::AlanWindowFrame" <- RootBacking};
 
-fn{Rs} window "alan_std::run_window" <- RootBacking :: (Mut{(Mut{Window}) -> u32[]}, (Frame) -> GPGPU[]) -> ()!;
+fn{Rs} window "alan_std::run_window" <- RootBacking :: (Mut{(Mut{Window}) -> ()}, Mut{(Mut{Window}) -> u32[]}, (Frame) -> GPGPU[]) -> ()!;
 fn{Rs} width Method{"width"} :: Window -> u32;
 fn{Rs} height Method{"height"} :: Window -> u32;
 fn{Rs} bufferWidth Method{"buffer_width"} :: Window -> u32;

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -116,7 +116,7 @@ type Rs = Env{"ALAN_OUTPUT_LANG"} == "rs";
 type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
-type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git#initial-context-fn"};
+type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
 type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
 
 // Defining derived types

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1627,7 +1627,11 @@ where
     }
 }
 
-pub fn run_window<C, R>(mut context_fn: C, gpgpu_shader_fn: R) -> Result<(), AlanError>
+pub fn run_window<C, R>(
+    mut initial_context_fn: impl FnMut(&mut AlanWindowContext) -> (),
+    context_fn: C,
+    gpgpu_shader_fn: R,
+) -> Result<(), AlanError>
 where
     C: FnMut(&mut AlanWindowContext) -> Vec<u32>,
     R: Fn(&AlanWindowFrame) -> Vec<GPGPU>,
@@ -1641,10 +1645,7 @@ where
         cursor_visible: true,
         transparent: false,
     };
-    // Potentially mutate the context by calling the context function, but ignore the context
-    // vector it creates
-    context_fn(&mut context);
-    println!("is transparent: {}", context.transparent);
+    initial_context_fn(&mut context);
     let config = Window::default_attributes().with_transparent(context.transparent);
     let event_loop = EventLoop::new().unwrap();
     event_loop.set_control_flow(ControlFlow::Poll); // TODO: This should also be configurable

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1628,7 +1628,7 @@ where
 }
 
 pub fn run_window<C, R>(
-    mut initial_context_fn: impl FnMut(&mut AlanWindowContext) -> (),
+    mut initial_context_fn: impl FnMut(&mut AlanWindowContext),
     context_fn: C,
     gpgpu_shader_fn: R,
 ) -> Result<(), AlanError>


### PR DESCRIPTION
- **Run an initial context function separate from the per-frame context function**
- **Update the window function binding**
