### PR TITLE
Window rendering in Javascript using WebGPU

### DIFF
--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -117,7 +117,7 @@ type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
 type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
-type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Js} RootBacking = Node{"alan_std" @ "https://github.com/alantech/alan.git#js-window"};
 
 // Defining derived types
 type void = ();
@@ -5376,22 +5376,37 @@ fn map{G, G2}(gb: GBuffer, f: (G, gu32) -> G2) {
 
 /// Window-related bindings
 type{Rs} Window = Binds{"alan_std::AlanWindowContext" <- RootBacking};
+type{Js} Window = Binds{"AlanWindowContext"};
 type{Rs} Frame = Binds{"alan_std::AlanWindowFrame" <- RootBacking};
+type{Js} Frame = Binds{"AlanWindowFrame"};
 
 fn{Rs} window "alan_std::run_window" <- RootBacking :: (Mut{(Mut{Window}) -> ()}, Mut{(Mut{Window}) -> u32[]}, (Frame) -> GPGPU[]) -> ()!;
+fn{Js} window "alan_std.runWindow" <- RootBacking :: (Window -> (), Window -> u32[], Frame -> GPGPU[]) -> ()!;
 fn{Rs} width Method{"width"} :: Window -> u32;
+fn{Js} width "alan_std.contextWidth" <- RootBacking :: Window -> u32;
 fn{Rs} height Method{"height"} :: Window -> u32;
+fn{Js} height "alan_std.contextHeight" <- RootBacking :: Window -> u32;
 fn{Rs} bufferWidth Method{"buffer_width"} :: Window -> u32;
+fn{Js} bufferWidth "alan_std.contextBufferWidth" <- RootBacking :: Window -> u32;
 fn{Rs} mouseX Method{"mouse_x"} :: Mut{Window} -> u32;
+fn{Js} mouseX "alan_std.contextMouseX" <- RootBacking :: Window -> u32;
 fn{Rs} mouseY Method{"mouse_y"} :: Mut{Window} -> u32;
+fn{Js} mouseY "alan_std.contextMouseY" <- RootBacking :: Window -> u32;
 fn{Rs} cursorVisible Method{"cursor_visible"} :: Mut{Window} -> ();
+fn{Js} cursorVisible "alan_std.contextCursorVisible" <- RootBacking :: Window -> ();
 fn{Rs} cursorInvisible Method{"cursor_invisible"} :: Mut{Window} -> ();
+fn{Js} cursorInvisible "alan_std.contextCursorInvisible" <- RootBacking :: Window -> ();
 fn{Rs} transparent Method{"transparent"} :: Mut{Window} -> ();
+fn{Js} transparent "alan_std.contextTransparent" <- RootBacking :: Window -> ();
 fn{Rs} opaque Method{"opaque"} :: Mut{Window} -> ();
+fn{Js} opaque "alan_std.contextOpaque" <- RootBacking :: Window -> ();
 fn{Rs} runtime Method{"runtime"} :: Window -> u32;
+fn{Js} runtime "alan_std.contextRuntime" <- RootBacking :: Window -> u32;
 fn{Rs} context Property{"context.clone()"} :: Frame -> GBuffer;
+fn{Js} context "alan_std.frameContext" <- RootBacking :: Frame -> GBuffer;
 fn{Rs} framebuffer Property{"framebuffer.clone()"} :: Frame -> GBuffer;
-fn{Rs} pixel Frame = gFor(-1, -2); // Magic numbers for the binding
+fn{Js} framebuffer "alan_std.frameFramebuffer" <- RootBacking :: Frame -> GBuffer;
+fn pixel Frame = gFor(-1, -2); // Magic numbers for the binding
 
 /// Process exit-related bindings
 fn{Rs} ExitCode "std::process::ExitCode::from" :: Own{u8} -> ExitCode;

--- a/alan_std.js
+++ b/alan_std.js
@@ -972,6 +972,63 @@ export async function replaceBuffer(b, v) {
 }
 
 /// Window-related types and functions
+
+export function contextWidth(context) {
+  return new U32(context.canvas.width);
+}
+
+export function contextHeight(context) {
+  return new U32(context.canvas.height);
+}
+
+export function contextBufferWidth(context) {
+  return new U32(context.bufferWidth);
+}
+
+export function contextMouseX(context) {
+  if (typeof(context.mouseX) === "undefined") {
+    context.mouseX = new U32(0);
+    context.mouseY = new U32(0);
+  }
+  return context.mouseX;
+}
+
+export function contextMouseY(context) {
+  if (typeof(context.mouseY) === "undefined") {
+    context.mouseX = new U32(0);
+    context.mouseY = new U32(0);
+  }
+  return context.mouseY;
+}
+
+export function contextCursorVisible(context) {
+  context.cursorVisible = true;
+}
+
+export function contextCursorInvisible(context) {
+  context.cursorVisible = false;
+}
+
+export function contextTransparent(context) {
+  context.transparent = true;
+}
+
+export function contextOpaque(context) {
+  context.transparent = false;
+}
+
+export function contextRuntime(context) {
+  return f32AsU32(new F32((Performance.now() - context.start) / 1000.0));
+}
+
+export function frameContext(frame) {
+  return frame.context;
+}
+
+export function frameFramebuffer(frame) {
+  return frame.framebuffer;
+}
+
 export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
   let context = {
     canvas: undefined,

--- a/alan_std.js
+++ b/alan_std.js
@@ -1054,6 +1054,12 @@ export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
     canvas.style['top'] = '0px';
     canvas.style['width'] = '100%';
     canvas.style['height'] = '100%';
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    document.body.addEventListener("resize", () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    });
     if (!context.cursorVisible) {
       canvas.style['cursor'] = 'none';
     }

--- a/alan_std.js
+++ b/alan_std.js
@@ -1018,7 +1018,7 @@ export function contextOpaque(context) {
 }
 
 export function contextRuntime(context) {
-  return f32AsU32(new F32((Performance.now() - context.start) / 1000.0));
+  return f32AsU32(new F32((performance.now() - context.start) / 1000.0));
 }
 
 export function frameContext(frame) {
@@ -1040,7 +1040,7 @@ export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
     transparent: false,
   };
   await initialContextFn(context);
-  context.start = Performance.now();
+  context.start = performance.now();
   // If the `initialContextFn` doesn't attach a canvas, we make one to take up the whole window
   if (!context.canvas) {
     let canvas = document.createElement('canvas');

--- a/alan_std.js
+++ b/alan_std.js
@@ -1226,7 +1226,7 @@ export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
       bytesPerRow: context.bufferWidth,
     }, {
       texture: frame,
-    }, [frame.width, frame.height, 1]);
+    }, [width, height, 1]);
     queue.submit([encoder.finish()]);
     requestAnimationFrame(redraw);
   }

--- a/alan_std.js
+++ b/alan_std.js
@@ -1223,7 +1223,7 @@ export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
     contextBuffer = newContextBuffer;
     encoder.copyBufferToTexture({
       buffer,
-      bytesPerRow: context.bufferWidth,
+      bytesPerRow: context.bufferWidth / 4,
     }, {
       texture: frame,
     }, [frame.width, frame.height, 1]);

--- a/alan_std.js
+++ b/alan_std.js
@@ -1030,6 +1030,8 @@ export function frameFramebuffer(frame) {
 }
 
 export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
+  // None of this can run before `document.body` exists, so let's wait for that
+  await new Promise((r) => document.addEventListener("DOMContextLoaded", () => r()));
   let context = {
     canvas: undefined,
     start: undefined,

--- a/alan_std.js
+++ b/alan_std.js
@@ -1162,8 +1162,7 @@ export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
       }
       let x = 0;
       let y = 0;
-      let z = 1;
-      switch (gg.workgroupSizes[0]) {
+      switch (gg.workgroupSizes[0].val) {
       case -1:
         x = width;
         break;
@@ -1171,9 +1170,9 @@ export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
         x = height;
         break;
       default:
-        x = gg.workgroupSizes[0];
+        x = gg.workgroupSizes[0].val;
       }
-      switch (gg.workgroupSizes[1]) {
+      switch (gg.workgroupSizes[1].val) {
       case -1:
         y = width;
         break;
@@ -1181,8 +1180,9 @@ export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
         y = height;
         break;
       default:
-        y = gg.workgroupSizes[0];
+        y = gg.workgroupSizes[1].val;
       }
+      let z = gg.workgroupSizes[2].val;
       cpass.dispatchWorkgroups(x, y, z);
       cpass.end();
     }

--- a/alan_std.js
+++ b/alan_std.js
@@ -1132,7 +1132,7 @@ export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
     let frame = surface.getCurrentTexture();
     let encoder = device.createCommandEncoder();
     let contextArray = await contextFn(context);
-    let newContextBuffer = await createBuffer({
+    let newContextBuffer = await device.createBuffer({
       mappedAtCreation: true,
       size: contextArray.length * 4,
       usage: storageBufferType(),

--- a/alan_std.js
+++ b/alan_std.js
@@ -982,7 +982,7 @@ export function contextHeight(context) {
 }
 
 export function contextBufferWidth(context) {
-  return new U32(context.bufferWidth);
+  return new U32(context.bufferWidth / 4);
 }
 
 export function contextMouseX(context) {

--- a/alan_std.js
+++ b/alan_std.js
@@ -1031,7 +1031,7 @@ export function frameFramebuffer(frame) {
 
 export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
   // None of this can run before `document.body` exists, so let's wait for that
-  await new Promise((r) => document.addEventListener("DOMContextLoaded", () => r()));
+  await new Promise((r) => document.addEventListener("DOMContentLoaded", () => r()));
   let context = {
     canvas: undefined,
     start: undefined,

--- a/alan_std.js
+++ b/alan_std.js
@@ -1223,7 +1223,7 @@ export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
     contextBuffer = newContextBuffer;
     encoder.copyBufferToTexture({
       buffer,
-      bytesPerRow: context.bufferWidth / 4,
+      bytesPerRow: context.bufferWidth,
     }, {
       texture: frame,
     }, [frame.width, frame.height, 1]);

--- a/alan_std.js
+++ b/alan_std.js
@@ -1231,4 +1231,5 @@ export async function runWindow(initialContextFn, contextFn, gpgpuShaderFn) {
     requestAnimationFrame(redraw);
   }
   requestAnimationFrame(redraw);
+  await new Promise((r) => {}); // Block this path forever to match Rust behavior
 }


### PR DESCRIPTION
- **Implement `runWindow` for JS**
- **Implement support functions**
- **Implement js bindings**
- **performance is lowercase in JS for some reason, breaking past conventions**
- **Wait for `document.body` to exist**
- **Fix typo in event name**
- **Fix workgroup size mangling hack**
- **Inline the buffer creation to make sure the same device instance is used to create them as the one associated with the canvas**
- **Fix typo on one buffer creation call**
- **Make the canvas actually use the real width and height, and resize appropriately**
- **This doesn't seem right, but let's see what it does**
- **Revert "This doesn't seem right, but let's see what it does"**
- **Perhaps this is the source of the rendering glitch**
- **After reviewing the Rust code, I think this is the source of the error**
- **It shouldn't be printing 'bye' in the console**
