### PR TITLE
Eliminate many Function clones

### DIFF
--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -167,9 +167,9 @@ pub fn from_microstatement(
                         if parent_fn.origin_scope_path != scope.path {
                             let program = Program::get_program();
                             let out = match program.scope_by_file(&parent_fn.origin_scope_path) {
-                                Ok(original_scope) => original_scope
-                                    .resolve_function_by_type(representation, typen)
-                                    .cloned(),
+                                Ok(original_scope) => {
+                                    original_scope.resolve_function_by_type(representation, typen)
+                                }
                                 Err(_) => None,
                             };
                             Program::return_program(program);
@@ -178,7 +178,7 @@ pub fn from_microstatement(
                             None
                         }
                     }
-                    f => f.cloned(), // TODO: Can I avoid this?
+                    f => f,
                 };
                 match &f {
                     None => {

--- a/alan_compiler/src/lntors/function.rs
+++ b/alan_compiler/src/lntors/function.rs
@@ -168,9 +168,9 @@ pub fn from_microstatement(
                         if parent_fn.origin_scope_path != scope.path {
                             let program = Program::get_program();
                             let out = match program.scope_by_file(&parent_fn.origin_scope_path) {
-                                Ok(original_scope) => original_scope
-                                    .resolve_function_by_type(representation, typen)
-                                    .cloned(),
+                                Ok(original_scope) => {
+                                    original_scope.resolve_function_by_type(representation, typen)
+                                }
                                 Err(_) => None,
                             };
                             Program::return_program(program);
@@ -179,7 +179,7 @@ pub fn from_microstatement(
                             None
                         }
                     }
-                    f => f.cloned(), // TODO: Can I avoid this?
+                    f => f,
                 };
                 match &f {
                     None => {

--- a/alan_compiler/src/program/function.rs
+++ b/alan_compiler/src/program/function.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::ctype::{withtypeoperatorslist_to_ctype, CType};
 use super::microstatement::{statement_to_microstatements, Microstatement};
 use super::scope::merge;
@@ -292,13 +294,13 @@ impl Function {
                     // TODO: Why can't I box this up into a function?
                     merge!(scope, temp_scope);
                     let degrouped_input = input_type.degroup();
-                    let function = Function {
+                    let function = Arc::new(Function {
                         name,
                         typen: CType::Function(Box::new(degrouped_input), Box::new(rettype)),
                         microstatements: Vec::new(),
                         kind,
                         origin_scope_path: scope.path.clone(),
-                    };
+                    });
                     if is_export {
                         scope
                             .exports
@@ -550,13 +552,13 @@ impl Function {
             }
             _ => unreachable!(),
         }
-        let function = Function {
+        let function = Arc::new(Function {
             name,
             typen,
             microstatements,
             kind,
             origin_scope_path: scope.path.clone(),
-        };
+        });
         if is_export {
             scope
                 .exports
@@ -577,7 +579,7 @@ impl Function {
         mut scope: Scope<'a>,
         generic_function: &Function,
         generic_types: Vec<CType>,
-    ) -> Result<(Scope<'a>, Function), Box<dyn std::error::Error>> {
+    ) -> Result<(Scope<'a>, Arc<Function>), Box<dyn std::error::Error>> {
         match &generic_function.kind {
             FnKind::Normal
             | FnKind::External(_)
@@ -674,14 +676,14 @@ impl Function {
                         .collect::<Vec<String>>()
                         .join("_")
                 ); // Really bad
-                let f = Function {
+                let f = Arc::new(Function {
                     name,
                     // TODO: Can I eliminate this indirection?
                     typen: args_and_rettype_to_type(args, rettype),
                     microstatements,
                     kind,
                     origin_scope_path: scope.path.clone(),
-                };
+                });
                 if scope.functions.contains_key(&f.name) {
                     let func_vec = scope.functions.get_mut(&f.name).unwrap();
                     func_vec.insert(0, f.clone());
@@ -782,14 +784,14 @@ impl Function {
                         .collect::<Vec<String>>()
                         .join("_")
                 ); // Really bad
-                let f = Function {
+                let f = Arc::new(Function {
                     name,
                     // TODO: Can I eliminate this indirection?
                     typen: args_and_rettype_to_type(args, rettype),
                     microstatements,
                     kind,
                     origin_scope_path: scope.path.clone(),
-                };
+                });
                 if scope.functions.contains_key(&f.name) {
                     let func_vec = scope.functions.get_mut(&f.name).unwrap();
                     func_vec.insert(0, f.clone());

--- a/alan_compiler/src/program/microstatement.rs
+++ b/alan_compiler/src/program/microstatement.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::ctype::{withtypeoperatorslist_to_ctype, CType};
 use super::function::{type_to_args, type_to_rettype};
 use super::scope::merge;
@@ -26,11 +28,11 @@ pub enum Microstatement {
         typen: CType,
     },
     FnCall {
-        function: Function,
+        function: Arc<Function>,
         args: Vec<Microstatement>,
     },
     Closure {
-        function: Function,
+        function: Arc<Function>,
     },
     VarCall {
         name: String,
@@ -635,7 +637,7 @@ pub fn baseassignablelist_to_microstatements<'a>(
                     }
                     _ => unreachable!(),
                 }
-                let function = Function {
+                let function = Arc::new(Function {
                     name: match &f.optname {
                         Some(name) => name.clone(),
                         None => "closure".to_string(),
@@ -644,7 +646,7 @@ pub fn baseassignablelist_to_microstatements<'a>(
                     microstatements: ms,
                     kind,
                     origin_scope_path: scope.path.clone(),
-                };
+                });
                 prior_value = Some(Microstatement::Closure { function });
             }
             BaseChunk::ArrayAccessor(a) => {


### PR DESCRIPTION
This speeds up compilation of the `Hello, World!` app by ~33% both natively and in the browser.

That still puts it in the seconds range, which isn't great, but baby steps. :)

The majority of the time left is almost evenly split between generating Rust/JS-compatible names for types/functions and actually constructing the function objects. I'm going to dig in a bit on the former to see if I can speed that up (it's kinda crazy how long that's taking), but for the latter the only solution is to make function creation lazy, which I have been avoiding, but maybe I shouldn't?
