### PR TITLE
Faster `to_strict_string`, `accepts`, and slightly faster `to_functional_string`

### DIFF
--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -174,11 +174,11 @@ impl CType {
                 }
                 CType::Binds(n, ts) => {
                     str_parts.push("Binds{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         ctype_stack.push(t);
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                     }
                     ctype_stack.push(n);
@@ -222,50 +222,50 @@ impl CType {
                 CType::Group(t) => match strict {
                     true => {
                         str_parts.push("(");
-                        ctype_stack.push(&close_paren);
+                        ctype_stack.push(close_paren);
                         ctype_stack.push(t);
                     }
                     false => ctype_stack.push(t),
                 },
                 CType::Function(i, o) => {
                     ctype_stack.push(o);
-                    ctype_stack.push(&fnarrow);
+                    ctype_stack.push(fnarrow);
                     ctype_stack.push(i);
                 }
                 CType::Call(n, f) => {
                     ctype_stack.push(f);
-                    ctype_stack.push(&fncall);
+                    ctype_stack.push(fncall);
                     ctype_stack.push(n);
                 }
                 CType::Infix(o) => {
                     str_parts.push("Infix{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(o);
                 }
                 CType::Prefix(o) => {
                     str_parts.push("Prefix{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(o);
                 }
                 CType::Method(f) => {
                     str_parts.push("Method{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(f);
                 }
                 CType::Property(p) => {
                     str_parts.push("Property{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(p);
                 }
                 CType::Cast(t) => {
                     str_parts.push("Cast{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Own(t) => match strict {
                     true => {
                         str_parts.push("Own{");
-                        ctype_stack.push(&close_brace);
+                        ctype_stack.push(close_brace);
                         ctype_stack.push(t);
                     }
                     false => ctype_stack.push(t),
@@ -273,7 +273,7 @@ impl CType {
                 CType::Deref(t) => match strict {
                     true => {
                         str_parts.push("Deref{");
-                        ctype_stack.push(&close_brace);
+                        ctype_stack.push(close_brace);
                         ctype_stack.push(t);
                     }
                     false => ctype_stack.push(t),
@@ -281,7 +281,7 @@ impl CType {
                 CType::Mut(t) => match strict {
                     true => {
                         str_parts.push("Mut{");
-                        ctype_stack.push(&close_brace);
+                        ctype_stack.push(close_brace);
                         ctype_stack.push(t);
                     }
                     false => ctype_stack.push(t),
@@ -289,31 +289,31 @@ impl CType {
                 CType::Dependency(n, v) => match strict {
                     true => {
                         str_parts.push("Dependency{");
-                        ctype_stack.push(&close_brace);
+                        ctype_stack.push(close_brace);
                         ctype_stack.push(v);
-                        ctype_stack.push(&comma);
+                        ctype_stack.push(comma);
                         ctype_stack.push(n);
                     }
                     false => {
                         ctype_stack.push(v);
-                        ctype_stack.push(&depat);
+                        ctype_stack.push(depat);
                         ctype_stack.push(n);
                     }
                 },
                 CType::Rust(d) => {
                     str_parts.push("Rust{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(d);
                 }
                 CType::Node(d) => {
                     str_parts.push("Node{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(d);
                 }
                 CType::From(d) => match strict {
                     true => {
                         str_parts.push("From{");
-                        ctype_stack.push(&close_brace);
+                        ctype_stack.push(close_brace);
                         ctype_stack.push(d);
                     }
                     false => {
@@ -324,21 +324,21 @@ impl CType {
                 CType::Import(n, d) => match strict {
                     true => {
                         str_parts.push("Import{");
-                        ctype_stack.push(&close_brace);
+                        ctype_stack.push(close_brace);
                         ctype_stack.push(d);
-                        ctype_stack.push(&comma);
+                        ctype_stack.push(comma);
                         ctype_stack.push(n);
                     }
                     false => {
                         ctype_stack.push(d);
-                        ctype_stack.push(&imarrow);
+                        ctype_stack.push(imarrow);
                         ctype_stack.push(n);
                     }
                 },
                 CType::Tuple(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
@@ -354,33 +354,33 @@ impl CType {
                 CType::Either(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&or);
+                            ctype_stack.push(or);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Prop(t, p) => {
                     ctype_stack.push(p);
-                    ctype_stack.push(&dot);
+                    ctype_stack.push(dot);
                     ctype_stack.push(t);
                 }
                 CType::AnyOf(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&and);
+                            ctype_stack.push(and);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Buffer(t, s) => {
-                    ctype_stack.push(&close_bracket);
+                    ctype_stack.push(close_bracket);
                     ctype_stack.push(s);
-                    ctype_stack.push(&open_bracket);
+                    ctype_stack.push(open_bracket);
                     ctype_stack.push(t);
                 }
                 CType::Array(t) => {
-                    ctype_stack.push(&close_bracket);
-                    ctype_stack.push(&open_bracket);
+                    ctype_stack.push(close_bracket);
+                    ctype_stack.push(open_bracket);
                     ctype_stack.push(t);
                 }
                 CType::Fail(m) => {
@@ -391,7 +391,7 @@ impl CType {
                 CType::Add(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&add);
+                            ctype_stack.push(add);
                         }
                         ctype_stack.push(t);
                     }
@@ -399,7 +399,7 @@ impl CType {
                 CType::Sub(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&sub);
+                            ctype_stack.push(sub);
                         }
                         ctype_stack.push(t);
                     }
@@ -407,7 +407,7 @@ impl CType {
                 CType::Mul(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&mul);
+                            ctype_stack.push(mul);
                         }
                         ctype_stack.push(t);
                     }
@@ -415,7 +415,7 @@ impl CType {
                 CType::Div(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&div);
+                            ctype_stack.push(div);
                         }
                         ctype_stack.push(t);
                     }
@@ -423,7 +423,7 @@ impl CType {
                 CType::Mod(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&tmod);
+                            ctype_stack.push(tmod);
                         }
                         ctype_stack.push(t);
                     }
@@ -431,27 +431,27 @@ impl CType {
                 CType::Pow(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&pow);
+                            ctype_stack.push(pow);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Min(ts) => {
                     str_parts.push("Min{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Max(ts) => {
                     str_parts.push("Max{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
@@ -462,57 +462,57 @@ impl CType {
                 }
                 CType::Len(t) => {
                     str_parts.push("Len{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Size(t) => {
                     str_parts.push("Size{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::FileStr(t) => {
                     str_parts.push("FileStr{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Concat(a, b) => {
                     str_parts.push("Concat{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(b);
-                    ctype_stack.push(&comma);
+                    ctype_stack.push(comma);
                     ctype_stack.push(a);
                 }
                 CType::Env(ts) => {
                     str_parts.push("Env{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::EnvExists(t) => {
                     str_parts.push("EnvExists{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::TIf(t, ts) => {
                     str_parts.push("If{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
-                    ctype_stack.push(&comma);
+                    ctype_stack.push(comma);
                     ctype_stack.push(t);
                 }
                 CType::And(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&band);
+                            ctype_stack.push(band);
                         }
                         ctype_stack.push(t);
                     }
@@ -520,7 +520,7 @@ impl CType {
                 CType::Or(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&bor);
+                            ctype_stack.push(bor);
                         }
                         ctype_stack.push(t);
                     }
@@ -528,7 +528,7 @@ impl CType {
                 CType::Xor(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&xor);
+                            ctype_stack.push(xor);
                         }
                         ctype_stack.push(t);
                     }
@@ -540,7 +540,7 @@ impl CType {
                 CType::Nand(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&nand);
+                            ctype_stack.push(nand);
                         }
                         ctype_stack.push(t);
                     }
@@ -548,7 +548,7 @@ impl CType {
                 CType::Nor(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&nor);
+                            ctype_stack.push(nor);
                         }
                         ctype_stack.push(t);
                     }
@@ -556,7 +556,7 @@ impl CType {
                 CType::Xnor(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&xnor);
+                            ctype_stack.push(xnor);
                         }
                         ctype_stack.push(t);
                     }
@@ -564,7 +564,7 @@ impl CType {
                 CType::TEq(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&eq);
+                            ctype_stack.push(eq);
                         }
                         ctype_stack.push(t);
                     }
@@ -572,7 +572,7 @@ impl CType {
                 CType::Neq(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&neq);
+                            ctype_stack.push(neq);
                         }
                         ctype_stack.push(t);
                     }
@@ -580,7 +580,7 @@ impl CType {
                 CType::Lt(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&lt);
+                            ctype_stack.push(lt);
                         }
                         ctype_stack.push(t);
                     }
@@ -588,7 +588,7 @@ impl CType {
                 CType::Lte(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&lte);
+                            ctype_stack.push(lte);
                         }
                         ctype_stack.push(t);
                     }
@@ -596,7 +596,7 @@ impl CType {
                 CType::Gt(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&gt);
+                            ctype_stack.push(gt);
                         }
                         ctype_stack.push(t);
                     }
@@ -604,7 +604,7 @@ impl CType {
                 CType::Gte(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&gte);
+                            ctype_stack.push(gte);
                         }
                         ctype_stack.push(t);
                     }
@@ -637,11 +637,11 @@ impl CType {
                 }
                 CType::Binds(n, ts) => {
                     str_parts.push("Binds{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         ctype_stack.push(t);
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                     }
                     ctype_stack.push(n);
@@ -709,93 +709,93 @@ impl CType {
                 CType::Group(t) => ctype_stack.push(t),
                 CType::Function(i, o) => {
                     str_parts.push("Function{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(o);
-                    ctype_stack.push(&comma);
+                    ctype_stack.push(comma);
                     ctype_stack.push(i);
                 }
                 CType::Call(n, f) => {
                     str_parts.push("Call{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(f);
-                    ctype_stack.push(&comma);
+                    ctype_stack.push(comma);
                     ctype_stack.push(n);
                 }
                 CType::Infix(o) => {
                     str_parts.push("Infix{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(o);
                 }
                 CType::Prefix(o) => {
                     str_parts.push("Prefix{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(o);
                 }
                 CType::Method(f) => {
                     str_parts.push("Method{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(f);
                 }
                 CType::Property(p) => {
                     str_parts.push("Property{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(p);
                 }
                 CType::Cast(t) => {
                     str_parts.push("Cast{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Own(t) => {
                     str_parts.push("Own{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Deref(t) => {
                     str_parts.push("Deref{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Mut(t) => {
                     str_parts.push("Mut{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Dependency(n, v) => {
                     str_parts.push("Dependency{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(v);
-                    ctype_stack.push(&comma);
+                    ctype_stack.push(comma);
                     ctype_stack.push(n);
                 }
                 CType::Rust(d) => {
                     str_parts.push("Rust{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(d);
                 }
                 CType::Node(d) => {
                     str_parts.push("Node{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(d);
                 }
                 CType::From(d) => {
                     str_parts.push("From{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(d);
                 }
                 CType::Import(n, d) => {
                     str_parts.push("Import{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(d);
-                    ctype_stack.push(&comma);
+                    ctype_stack.push(comma);
                     ctype_stack.push(n);
                 }
                 CType::Tuple(ts) => {
                     str_parts.push("Tuple{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
@@ -804,46 +804,46 @@ impl CType {
                     str_parts.push("Field{");
                     str_parts.push(l);
                     str_parts.push(", ");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Either(ts) => {
                     str_parts.push("Either{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Prop(t, p) => {
                     str_parts.push("Prop{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(p);
-                    ctype_stack.push(&comma);
+                    ctype_stack.push(comma);
                     ctype_stack.push(t);
                 }
                 CType::AnyOf(ts) => {
                     str_parts.push("AnyOf{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Buffer(t, s) => {
                     str_parts.push("Buffer{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(s);
-                    ctype_stack.push(&comma);
+                    ctype_stack.push(comma);
                     ctype_stack.push(t);
                 }
                 CType::Array(t) => {
                     str_parts.push("Array{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Fail(m) => {
@@ -853,259 +853,259 @@ impl CType {
                 }
                 CType::Add(ts) => {
                     str_parts.push("Add{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Sub(ts) => {
                     str_parts.push("Sub{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Mul(ts) => {
                     str_parts.push("Mul{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Div(ts) => {
                     str_parts.push("Div{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Mod(ts) => {
                     str_parts.push("Mod{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Pow(ts) => {
                     str_parts.push("Pow{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Min(ts) => {
                     str_parts.push("Min{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Max(ts) => {
                     str_parts.push("Max{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Neg(t) => {
                     str_parts.push("Neg{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Len(t) => {
                     str_parts.push("Len{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Size(t) => {
                     str_parts.push("Size{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::FileStr(t) => {
                     str_parts.push("FileStr{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Concat(a, b) => {
                     str_parts.push("Concat{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(b);
-                    ctype_stack.push(&comma);
+                    ctype_stack.push(comma);
                     ctype_stack.push(a);
                 }
                 CType::Env(ts) => {
                     str_parts.push("Env{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::EnvExists(t) => {
                     str_parts.push("EnvExists{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::TIf(t, ts) => {
                     str_parts.push("If{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
-                    ctype_stack.push(&comma);
+                    ctype_stack.push(comma);
                     ctype_stack.push(t);
                 }
                 CType::And(ts) => {
                     str_parts.push("And{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Or(ts) => {
                     str_parts.push("Or{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Xor(ts) => {
                     str_parts.push("Xor{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Not(t) => {
                     str_parts.push("Not{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
                 CType::Nand(ts) => {
                     str_parts.push("Nand{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Nor(ts) => {
                     str_parts.push("Nor{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Xnor(ts) => {
                     str_parts.push("Xnor{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::TEq(ts) => {
                     str_parts.push("Eq{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Neq(ts) => {
                     str_parts.push("Neq{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Lt(ts) => {
                     str_parts.push("Lt{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Lte(ts) => {
                     str_parts.push("Lte{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Gt(ts) => {
                     str_parts.push("Gt{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }
                 }
                 CType::Gte(ts) => {
                     str_parts.push("Gte{");
-                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
-                            ctype_stack.push(&comma);
+                            ctype_stack.push(comma);
                         }
                         ctype_stack.push(t);
                     }

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use super::function::{type_to_args, type_to_rettype};
 use super::ArgKind;
@@ -79,292 +79,547 @@ pub enum CType {
     Gte(Vec<CType>),
 }
 
+static CLOSE_BRACE: OnceLock<CType> = OnceLock::new();
+static CLOSE_PAREN: OnceLock<CType> = OnceLock::new();
+static COMMA: OnceLock<CType> = OnceLock::new();
+static FNARROW: OnceLock<CType> = OnceLock::new();
+static FNCALL: OnceLock<CType> = OnceLock::new();
+static DEPAT: OnceLock<CType> = OnceLock::new();
+static IMARROW: OnceLock<CType> = OnceLock::new();
+static OR: OnceLock<CType> = OnceLock::new();
+static DOT: OnceLock<CType> = OnceLock::new();
+static AND: OnceLock<CType> = OnceLock::new();
+static OPEN_BRACKET: OnceLock<CType> = OnceLock::new();
+static CLOSE_BRACKET: OnceLock<CType> = OnceLock::new();
+static ADD: OnceLock<CType> = OnceLock::new();
+static SUB: OnceLock<CType> = OnceLock::new();
+static MUL: OnceLock<CType> = OnceLock::new();
+static DIV: OnceLock<CType> = OnceLock::new();
+static MOD: OnceLock<CType> = OnceLock::new();
+static POW: OnceLock<CType> = OnceLock::new();
+static BAND: OnceLock<CType> = OnceLock::new();
+static BOR: OnceLock<CType> = OnceLock::new();
+static XOR: OnceLock<CType> = OnceLock::new();
+static NAND: OnceLock<CType> = OnceLock::new();
+static NOR: OnceLock<CType> = OnceLock::new();
+static XNOR: OnceLock<CType> = OnceLock::new();
+static EQ: OnceLock<CType> = OnceLock::new();
+static NEQ: OnceLock<CType> = OnceLock::new();
+static LT: OnceLock<CType> = OnceLock::new();
+static LTE: OnceLock<CType> = OnceLock::new();
+static GT: OnceLock<CType> = OnceLock::new();
+static GTE: OnceLock<CType> = OnceLock::new();
+
 impl CType {
     #[allow(clippy::inherent_to_string)]
     pub fn to_string(&self) -> String {
         self.to_strict_string(true)
     }
     pub fn to_strict_string(&self, strict: bool) -> String {
-        match self {
-            CType::Void => "()".to_string(),
-            CType::Infer(s, _) => s.clone(), // TODO: Replace this
-            CType::Type(n, t) => match strict {
-                true => n.to_string(),
-                false => t.to_strict_string(strict),
-            },
-            CType::Generic(n, a, _) => format!("{}{{{}}}", n, a.join(", ")),
-            CType::Binds(n, ts) => format!(
-                "Binds{{{}{}{}}}",
-                n.to_strict_string(strict),
-                if ts.is_empty() { "" } else { ", " },
-                ts.iter()
-                    .map(|t| t.to_strict_string(strict))
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            ),
-            CType::IntrinsicGeneric(s, l) => format!(
-                "{}{{{}}}",
-                s,
-                (0..*l)
-                    .map(|b| format!("arg{}", b))
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            ),
-            CType::Int(i) => format!("{}", i),
-            CType::Float(f) => format!("{}", f),
-            CType::Bool(b) => match b {
-                true => "true".to_string(),
-                false => "false".to_string(),
-            },
-            CType::TString(s) => s.clone(),
-            CType::Group(t) => match strict {
-                true => format!("({})", t.to_strict_string(strict)),
-                false => t.to_strict_string(strict),
-            },
-            CType::Function(i, o) => format!(
-                "{} -> {}",
-                i.to_strict_string(strict),
-                o.to_strict_string(strict)
-            ),
-            CType::Call(n, f) => format!(
-                "{} :: {}",
-                n.to_strict_string(strict),
-                f.to_strict_string(strict)
-            ),
-            CType::Infix(o) => format!("Infix{{{}}}", o.to_strict_string(strict)),
-            CType::Prefix(o) => format!("Prefix{{{}}}", o.to_strict_string(strict)),
-            CType::Method(f) => format!("Method{{{}}}", f.to_strict_string(strict)),
-            CType::Property(p) => format!("Property{{{}}}", p.to_strict_string(strict)),
-            CType::Cast(t) => format!("Cast{{{}}}", t.to_strict_string(strict)),
-            CType::Own(t) => {
-                if strict {
-                    format!("Own{{{}}}", t.to_strict_string(strict))
-                } else {
-                    t.to_strict_string(strict)
+        let mut unavoidable_strings = Vec::new();
+        let mut str_parts = Vec::new();
+        let mut ctype_stack = vec![self];
+        // Hacky re-use of CType::Infer to insert constant strings into the ctype stack
+        let close_brace =
+            CLOSE_BRACE.get_or_init(|| CType::Infer("}".to_string(), "}".to_string()));
+        let close_paren =
+            CLOSE_PAREN.get_or_init(|| CType::Infer(")".to_string(), ")".to_string()));
+        let comma = COMMA.get_or_init(|| CType::Infer(", ".to_string(), ", ".to_string()));
+        let fnarrow = FNARROW.get_or_init(|| CType::Infer(" -> ".to_string(), " -> ".to_string()));
+        let fncall = FNCALL.get_or_init(|| CType::Infer(" :: ".to_string(), " :: ".to_string()));
+        let depat = DEPAT.get_or_init(|| CType::Infer(" @ ".to_string(), " @ ".to_string()));
+        let imarrow = IMARROW.get_or_init(|| CType::Infer(" <- ".to_string(), " <- ".to_string()));
+        let or = OR.get_or_init(|| CType::Infer(" | ".to_string(), " | ".to_string()));
+        let dot = DOT.get_or_init(|| CType::Infer(".".to_string(), ".".to_string()));
+        let and = AND.get_or_init(|| CType::Infer(" & ".to_string(), " & ".to_string()));
+        let open_bracket =
+            OPEN_BRACKET.get_or_init(|| CType::Infer("[".to_string(), "[".to_string()));
+        let close_bracket =
+            CLOSE_BRACKET.get_or_init(|| CType::Infer("]".to_string(), "]".to_string()));
+        let add = ADD.get_or_init(|| CType::Infer(" + ".to_string(), " + ".to_string()));
+        let sub = SUB.get_or_init(|| CType::Infer(" - ".to_string(), " - ".to_string()));
+        let mul = MUL.get_or_init(|| CType::Infer(" * ".to_string(), " * ".to_string()));
+        let div = DIV.get_or_init(|| CType::Infer(" / ".to_string(), " / ".to_string()));
+        let tmod = MOD.get_or_init(|| CType::Infer(" % ".to_string(), " % ".to_string()));
+        let pow = POW.get_or_init(|| CType::Infer(" ** ".to_string(), " ** ".to_string()));
+        let band = BAND.get_or_init(|| CType::Infer(" && ".to_string(), " && ".to_string()));
+        let bor = BOR.get_or_init(|| CType::Infer(" || ".to_string(), " || ".to_string()));
+        let xor = XOR.get_or_init(|| CType::Infer(" ^ ".to_string(), " ^ ".to_string()));
+        let nand = NAND.get_or_init(|| CType::Infer(" !& ".to_string(), " !& ".to_string()));
+        let nor = NOR.get_or_init(|| CType::Infer(" !| ".to_string(), " !| ".to_string()));
+        let xnor = XNOR.get_or_init(|| CType::Infer(" !^ ".to_string(), " !^ ".to_string()));
+        let eq = EQ.get_or_init(|| CType::Infer(" == ".to_string(), " == ".to_string()));
+        let neq = NEQ.get_or_init(|| CType::Infer(" != ".to_string(), " != ".to_string()));
+        let lt = LT.get_or_init(|| CType::Infer(" < ".to_string(), " < ".to_string()));
+        let lte = LTE.get_or_init(|| CType::Infer(" <= ".to_string(), " <= ".to_string()));
+        let gt = GT.get_or_init(|| CType::Infer(" > ".to_string(), " > ".to_string()));
+        let gte = GTE.get_or_init(|| CType::Infer(" >= ".to_string(), " >= ".to_string()));
+        while let Some(element) = ctype_stack.pop() {
+            match element {
+                CType::Void => str_parts.push("()"),
+                CType::Infer(s, _) => str_parts.push(s),
+                CType::Type(n, t) => match strict {
+                    true => str_parts.push(n),
+                    false => ctype_stack.push(t),
+                },
+                CType::Generic(n, gs, _) => {
+                    str_parts.push(n);
+                    str_parts.push("{");
+                    for g in gs {
+                        str_parts.push(g);
+                        str_parts.push(", ");
+                    }
+                    str_parts.pop();
+                    str_parts.push("}");
+                }
+                CType::Binds(n, ts) => {
+                    str_parts.push("Binds{");
+                    ctype_stack.push(&close_brace);
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        ctype_stack.push(t);
+                        if i != 0 {
+                            ctype_stack.push(&comma);
+                        }
+                    }
+                    ctype_stack.push(n);
+                }
+                CType::IntrinsicGeneric(s, l) => {
+                    str_parts.push(s);
+                    str_parts.push("{");
+                    for i in 0..*l {
+                        let l = unavoidable_strings.len();
+                        unavoidable_strings.push(format!("arg{}", i));
+                        let p = unavoidable_strings.as_ptr();
+                        unsafe {
+                            str_parts.push(p.add(l).as_ref().unwrap());
+                        }
+                        str_parts.push(", ");
+                    }
+                    str_parts.pop();
+                    str_parts.push("}");
+                }
+                CType::Int(i) => {
+                    let l = unavoidable_strings.len();
+                    unavoidable_strings.push(format!("{}", i));
+                    let p = unavoidable_strings.as_ptr();
+                    unsafe {
+                        str_parts.push(p.add(l).as_ref().unwrap());
+                    }
+                }
+                CType::Float(f) => {
+                    let l = unavoidable_strings.len();
+                    unavoidable_strings.push(format!("{}", f));
+                    let p = unavoidable_strings.as_ptr();
+                    unsafe {
+                        str_parts.push(p.add(l).as_ref().unwrap());
+                    }
+                }
+                CType::Bool(b) => match b {
+                    true => str_parts.push("true"),
+                    false => str_parts.push("false"),
+                },
+                CType::TString(s) => str_parts.push(s),
+                CType::Group(t) => match strict {
+                    true => {
+                        str_parts.push("(");
+                        ctype_stack.push(&close_paren);
+                        ctype_stack.push(t);
+                    }
+                    false => ctype_stack.push(t),
+                },
+                CType::Function(i, o) => {
+                    ctype_stack.push(o);
+                    ctype_stack.push(&fnarrow);
+                    ctype_stack.push(i);
+                }
+                CType::Call(n, f) => {
+                    ctype_stack.push(f);
+                    ctype_stack.push(&fncall);
+                    ctype_stack.push(n);
+                }
+                CType::Infix(o) => {
+                    str_parts.push("Infix{");
+                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(o);
+                }
+                CType::Prefix(o) => {
+                    str_parts.push("Prefix{");
+                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(o);
+                }
+                CType::Method(f) => {
+                    str_parts.push("Method{");
+                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(f);
+                }
+                CType::Property(p) => {
+                    str_parts.push("Property{");
+                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(p);
+                }
+                CType::Cast(t) => {
+                    str_parts.push("Cast{");
+                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(t);
+                }
+                CType::Own(t) => match strict {
+                    true => {
+                        str_parts.push("Own{");
+                        ctype_stack.push(&close_brace);
+                        ctype_stack.push(t);
+                    }
+                    false => ctype_stack.push(t),
+                },
+                CType::Deref(t) => match strict {
+                    true => {
+                        str_parts.push("Deref{");
+                        ctype_stack.push(&close_brace);
+                        ctype_stack.push(t);
+                    }
+                    false => ctype_stack.push(t),
+                },
+                CType::Mut(t) => match strict {
+                    true => {
+                        str_parts.push("Mut{");
+                        ctype_stack.push(&close_brace);
+                        ctype_stack.push(t);
+                    }
+                    false => ctype_stack.push(t),
+                },
+                CType::Dependency(n, v) => match strict {
+                    true => {
+                        str_parts.push("Dependency{");
+                        ctype_stack.push(&close_brace);
+                        ctype_stack.push(v);
+                        ctype_stack.push(&comma);
+                        ctype_stack.push(n);
+                    }
+                    false => {
+                        ctype_stack.push(v);
+                        ctype_stack.push(&depat);
+                        ctype_stack.push(n);
+                    }
+                },
+                CType::Rust(d) => {
+                    str_parts.push("Rust{");
+                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(d);
+                }
+                CType::Node(d) => {
+                    str_parts.push("Node{");
+                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(d);
+                }
+                CType::From(d) => match strict {
+                    true => {
+                        str_parts.push("From{");
+                        ctype_stack.push(&close_brace);
+                        ctype_stack.push(d);
+                    }
+                    false => {
+                        str_parts.push("<- ");
+                        ctype_stack.push(d);
+                    }
+                },
+                CType::Import(n, d) => match strict {
+                    true => {
+                        str_parts.push("Import{");
+                        ctype_stack.push(&close_brace);
+                        ctype_stack.push(d);
+                        ctype_stack.push(&comma);
+                        ctype_stack.push(n);
+                    }
+                    false => {
+                        ctype_stack.push(d);
+                        ctype_stack.push(&imarrow);
+                        ctype_stack.push(n);
+                    }
+                },
+                CType::Tuple(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&comma);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Field(l, t) => match strict {
+                    true => {
+                        str_parts.push(l);
+                        str_parts.push(": ");
+                        ctype_stack.push(t);
+                    }
+                    false => ctype_stack.push(t),
+                },
+                CType::Either(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&or);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Prop(t, p) => {
+                    ctype_stack.push(p);
+                    ctype_stack.push(&dot);
+                    ctype_stack.push(t);
+                }
+                CType::AnyOf(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&and);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Buffer(t, s) => {
+                    ctype_stack.push(&close_bracket);
+                    ctype_stack.push(s);
+                    ctype_stack.push(&open_bracket);
+                    ctype_stack.push(t);
+                }
+                CType::Array(t) => {
+                    ctype_stack.push(&close_bracket);
+                    ctype_stack.push(&open_bracket);
+                    ctype_stack.push(t);
+                }
+                CType::Fail(m) => {
+                    str_parts.push("Fail{");
+                    str_parts.push(m);
+                    str_parts.push("}");
+                }
+                CType::Add(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&add);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Sub(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&sub);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Mul(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&mul);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Div(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&div);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Mod(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&tmod);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Pow(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&pow);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Min(ts) => {
+                    str_parts.push("Min{");
+                    ctype_stack.push(&close_brace);
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&comma);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Max(ts) => {
+                    str_parts.push("Max{");
+                    ctype_stack.push(&close_brace);
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&comma);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Neg(t) => {
+                    str_parts.push("-");
+                    ctype_stack.push(t);
+                }
+                CType::Len(t) => {
+                    str_parts.push("Len{");
+                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(t);
+                }
+                CType::Size(t) => {
+                    str_parts.push("Size{");
+                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(t);
+                }
+                CType::FileStr(t) => {
+                    str_parts.push("FileStr{");
+                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(t);
+                }
+                CType::Concat(a, b) => {
+                    str_parts.push("Concat{");
+                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(b);
+                    ctype_stack.push(&comma);
+                    ctype_stack.push(a);
+                }
+                CType::Env(ts) => {
+                    str_parts.push("Env{");
+                    ctype_stack.push(&close_brace);
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&comma);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::EnvExists(t) => {
+                    str_parts.push("EnvExists{");
+                    ctype_stack.push(&close_brace);
+                    ctype_stack.push(t);
+                }
+                CType::TIf(t, ts) => {
+                    str_parts.push("If{");
+                    ctype_stack.push(&close_brace);
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&comma);
+                        }
+                        ctype_stack.push(t);
+                    }
+                    ctype_stack.push(&comma);
+                    ctype_stack.push(t);
+                }
+                CType::And(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&band);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Or(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&bor);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Xor(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&xor);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Not(t) => {
+                    str_parts.push("!");
+                    ctype_stack.push(t);
+                }
+                CType::Nand(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&nand);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Nor(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&nor);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Xnor(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&xnor);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::TEq(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&eq);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Neq(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&neq);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Lt(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&lt);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Lte(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&lte);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Gt(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&gt);
+                        }
+                        ctype_stack.push(t);
+                    }
+                }
+                CType::Gte(ts) => {
+                    for (i, t) in ts.iter().rev().enumerate() {
+                        if i != 0 {
+                            ctype_stack.push(&gte);
+                        }
+                        ctype_stack.push(t);
+                    }
                 }
             }
-            CType::Deref(t) => {
-                if strict {
-                    format!("Deref{{{}}}", t.to_strict_string(strict))
-                } else {
-                    t.to_strict_string(strict)
-                }
-            }
-            CType::Mut(t) => {
-                if strict {
-                    format!("Mut{{{}}}", t.to_strict_string(strict))
-                } else {
-                    t.to_strict_string(strict)
-                }
-            }
-            CType::Dependency(n, v) => {
-                if strict {
-                    format!(
-                        "Dependency{{{}, {}}}",
-                        n.to_strict_string(strict),
-                        v.to_strict_string(strict)
-                    )
-                } else {
-                    format!(
-                        "{} @ {}",
-                        n.to_strict_string(strict),
-                        v.to_strict_string(strict)
-                    )
-                }
-            }
-            CType::Rust(d) => format!("Rust{{{}}}", d.to_strict_string(strict)),
-            CType::Node(d) => format!("Node{{{}}}", d.to_strict_string(strict)),
-            CType::From(d) => {
-                if strict {
-                    format!("From{{{}}}", d.to_strict_string(strict))
-                } else {
-                    format!("<- {}", d.to_strict_string(strict))
-                }
-            }
-            CType::Import(n, d) => {
-                if strict {
-                    format!(
-                        "Import{{{}, {}}}",
-                        n.to_strict_string(strict),
-                        d.to_strict_string(strict)
-                    )
-                } else {
-                    format!(
-                        "{} <- {}",
-                        n.to_strict_string(strict),
-                        d.to_strict_string(strict)
-                    )
-                }
-            }
-            CType::Tuple(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(", "),
-            CType::Field(l, t) => match strict {
-                true => format!("{}: {}", l, t.to_strict_string(strict)),
-                false => t.to_strict_string(strict),
-            },
-            CType::Either(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" | "),
-            CType::Prop(t, p) => format!(
-                "{}.{}",
-                t.to_strict_string(strict),
-                p.to_strict_string(strict)
-            ),
-            CType::AnyOf(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" & "),
-            CType::Buffer(t, s) => format!(
-                "{}[{}]",
-                t.to_strict_string(strict),
-                s.to_strict_string(strict)
-            ),
-            CType::Array(t) => format!("{}[]", t.to_strict_string(strict)),
-            CType::Fail(m) => format!("Fail{{{}}}", m),
-            CType::Add(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" + "),
-            CType::Sub(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" - "),
-            CType::Mul(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" * "),
-            CType::Div(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" / "),
-            CType::Mod(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" % "),
-            CType::Pow(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" ** "),
-            CType::Min(ts) => format!(
-                "Min{{{}}}",
-                ts.iter()
-                    .map(|t| t.to_strict_string(strict))
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            ),
-            CType::Max(ts) => format!(
-                "Max{{{}}}",
-                ts.iter()
-                    .map(|t| t.to_strict_string(strict))
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            ),
-            CType::Neg(t) => format!("-{}", t.to_strict_string(strict)),
-            CType::Len(t) => format!("Len{{{}}}", t.to_strict_string(strict)),
-            CType::Size(t) => format!("Size{{{}}}", t.to_strict_string(strict)),
-            CType::FileStr(t) => format!("FileStr{{{}}}", t.to_strict_string(strict)),
-            CType::Concat(a, b) => format!(
-                "Concat{{{}, {}}}",
-                a.to_strict_string(strict),
-                b.to_strict_string(strict)
-            ),
-            CType::Env(ts) => format!(
-                "Env{{{}}}",
-                ts.iter()
-                    .map(|t| t.to_strict_string(strict))
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            ),
-            CType::EnvExists(t) => format!("EnvExists{{{}}}", t.to_strict_string(strict)),
-            CType::TIf(t, ts) => format!(
-                "If{{{}, {}}}",
-                t.to_strict_string(strict),
-                ts.iter()
-                    .map(|t| t.to_strict_string(strict))
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            ),
-            CType::And(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" && "),
-            CType::Or(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" || "),
-            CType::Xor(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" ^ "),
-            CType::Not(t) => format!("!{}", t.to_strict_string(strict)),
-            CType::Nand(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" !& "),
-            CType::Nor(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" !| "),
-            CType::Xnor(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" !^ "),
-            CType::TEq(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" == "),
-            CType::Neq(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" != "),
-            CType::Lt(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" < "),
-            CType::Lte(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" <= "),
-            CType::Gt(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" > "),
-            CType::Gte(ts) => ts
-                .iter()
-                .map(|t| t.to_strict_string(strict))
-                .collect::<Vec<String>>()
-                .join(" >= "),
         }
+        str_parts.join("")
     }
     pub fn to_functional_string(&self) -> String {
         let mut unavoidable_strings = Vec::new();
         let mut str_parts = Vec::new();
         let mut ctype_stack = vec![self];
-        let close_brace = CType::Infer("}".to_string(), "}".to_string()); // Hack for this speedup
-        let comma = CType::Infer(", ".to_string(), ", ".to_string()); // Similar hack
+        let close_brace =
+            CLOSE_BRACE.get_or_init(|| CType::Infer("}".to_string(), "}".to_string()));
+        let comma = COMMA.get_or_init(|| CType::Infer(", ".to_string(), ", ".to_string()));
         while let Some(element) = ctype_stack.pop() {
             match element {
                 CType::Void => str_parts.push("void"),
@@ -1974,7 +2229,7 @@ impl CType {
                 }
             }
             // TODO: Do this without stringification
-            (a, b) => a.degroup().to_strict_string(false) == b.degroup().to_strict_string(false),
+            (a, b) => a.to_strict_string(false) == b.to_strict_string(false),
         }
     }
 

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -116,9 +116,10 @@ impl CType {
         self.to_strict_string(true)
     }
     pub fn to_strict_string(&self, strict: bool) -> String {
-        let mut unavoidable_strings = Vec::new();
-        let mut str_parts = Vec::new();
-        let mut ctype_stack = vec![self];
+        let mut unavoidable_strings = Vec::with_capacity(64);
+        let mut str_parts = Vec::with_capacity(1024);
+        let mut ctype_stack = Vec::with_capacity(64);
+        ctype_stack.push(self);
         // Hacky re-use of CType::Infer to insert constant strings into the ctype stack
         let close_brace =
             CLOSE_BRACE.get_or_init(|| CType::Infer("}".to_string(), "}".to_string()));
@@ -614,9 +615,10 @@ impl CType {
         str_parts.join("")
     }
     pub fn to_functional_string(&self) -> String {
-        let mut unavoidable_strings = Vec::new();
-        let mut str_parts = Vec::new();
-        let mut ctype_stack = vec![self];
+        let mut unavoidable_strings = Vec::with_capacity(64);
+        let mut str_parts = Vec::with_capacity(1024);
+        let mut ctype_stack = Vec::with_capacity(64);
+        ctype_stack.push(self);
         let close_brace =
             CLOSE_BRACE.get_or_init(|| CType::Infer("}".to_string(), "}".to_string()));
         let comma = COMMA.get_or_init(|| CType::Infer(", ".to_string(), ", ".to_string()));


### PR DESCRIPTION
I followed the pattern in `to_functional_string` with `to_strict_string`, and the initial version was actually *slower* on average than the original that constructs a ton of temporary strings.

I was puzzled by this, but then realized that Rust was not able to turn the `CType::Infer` values I was creating at the beginning of the loop into constants, and was actually constructing those strings on each call. Because the number of these quasi-constant strings needed for `to_strict_string` was much higher, this pushed the average number of string allocations *up* instead of down.

So I used `OnceLock` to lazily create a singleton for each of these quasi-constants and *that* gave me the speedup, and I re-used this in `to_functional_string` to make that slightly faster, as well.

While rewriting `to_strict_string` I realized that the `accepts` method, which was the actual largest bottleneck (via using `to_strict_string` mostly), didn't need to call the `degroup` method because the string output would be identical either way, so I dropped that and got a further performance boost. Now the `Hello, World` example program takes just 2 seconds to compile on my laptop, and running it in Firefox is now faster than what the native compiler was a couple of days ago at just under 3 seconds (while Chrome is sitting at about 5.5 seconds).
