### PR TITLE
Implement `fma`

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -788,6 +788,26 @@ test_gpgpu!(gpu_inverse_sqrt => r#"
     stdout "[0.5, 0.2]\n";
 );
 
+test_gpgpu!(gpu_fma => r#"
+    export fn{Js} main {
+      let b = GBuffer([2.0.f32, 3.0.f32, 4.0.f32]);
+      let id = gFor(1);
+      let out = GBuffer{f32}(1);
+      // Hack to get this to work in JS, because the generic is not passed through there
+      {"((b) => { b.ValKind = alan_std.F32; })" :: GBuffer}(out);
+      out[id].store(fma(b[0].asF32, b[1].asF32, b[2].asF32).asI32).build.run;
+      (out.read{f32}[0]!!).string(1).print;
+    }
+    export fn{Rs} main {
+      let b = GBuffer([2.0.f32, 3.0.f32, 4.0.f32]);
+      let id = gFor(1);
+      let out = GBuffer{f32}(1);
+      out[id].store(fma(b[0].asF32, b[1].asF32, b[2].asF32).asI32).build.run;
+      (out.read{f32}[0]!!).string(1).print;
+    }"#;
+    stdout "10.0\n";
+);
+
 // TODO: Fix u64 numeric constants to get u64 bitwise tests in the new test suite
 test!(u64_bitwise => r#"
     prefix u64 as ~ precedence 10

--- a/alan/test.ln
+++ b/alan/test.ln
@@ -451,7 +451,8 @@ export fn{Test} main {
       .assert(eq, 0.5.f32.saturate, 0.5.f32)
       .assert(eq, 1.5.f32.saturate, 1.0.f32))
     .it('dot').assert(eq, {f32[2]}(3.f32, 4.f32) *. {f32[2]}(3.f32, 4.f32), 25.f32)
-    .it('inverseSqrt').assert(eq, 4.f32.inverseSqrt, 0.5.f32);
+    .it('inverseSqrt').assert(eq, 4.f32.inverseSqrt, 0.5.f32)
+    .it('fma').assert(eq, 2.f32.fma(3.f32, 4.f32), 10.f32);
 
   test.describe("Basic math tests f64")
     .it("add")
@@ -495,7 +496,8 @@ export fn{Test} main {
       .assert(eq, 0.5.saturate, 0.5)
       .assert(eq, 1.5.saturate, 1.0))
     .it('dot').assert(eq, {f64[2]}(3.0, 4.0) *. {f64[2]}(3.0, 4.0), 25.0)
-    .it('inverseSqrt').assert(eq, 25.0.inverseSqrt, 0.2);
+    .it('inverseSqrt').assert(eq, 25.0.inverseSqrt, 0.2)
+    .it('fma').assert(eq, 2.0.fma(3.0, 4.0), 10.0);
 
   test.describe("Basic math tests")
     .it("grouping")
@@ -964,7 +966,13 @@ export fn{Test} main {
     .it('normalize', fn (test: Mut{Testing}) = test
       .assert(eq, [1.0, 0.0, 0.0].normalize.map(fn (v: f64) = string(v)).join(', '), '1, 0, 0')
       .assert(eq, [3.0, 4.0].normalize.map(fn (v: f64) = string(v)).join(', '), '0.6, 0.8'))
-    .it('inverseSqrt').assert(eq, [4.0, 25.0].inverseSqrt.map(fn (v: f64) = string(v)).join(', '), '0.5, 0.2');
+    .it('inverseSqrt').assert(eq, [4.0, 25.0].inverseSqrt.map(fn (v: f64) = string(v)).join(', '), '0.5, 0.2')
+    .it('fma')
+      .assert(
+        eq,
+        (fma([2.0, 3.0, 4.0], [3.0, 4.0, 2.0], [4.0, 2.0, 3.0])!!)
+          .map(fn (v: f64) = string(v, 1)).join(', '),
+        '10.0, 14.0, 11.0');
 
   test.describe("Buffers")
     .it("join", fn (test: Mut{Testing}) {
@@ -1042,7 +1050,13 @@ export fn{Test} main {
     .it('normalize', fn (test: Mut{Testing}) = test
       .assert(eq, {f64[3]}(1.0, 0.0, 0.0).normalize.map(fn (v: f64) = string(v)).join(', '), '1, 0, 0')
       .assert(eq, {f64[2]}(3.0, 4.0).normalize.map(fn (v: f64) = string(v)).join(', '), '0.6, 0.8'))
-    .it('inverseSqrt').assert(eq, {f64[2]}(4.0, 25.0).inverseSqrt.map(fn (v: f64) = string(v)).join(', '), '0.5, 0.2');
+    .it('inverseSqrt').assert(eq, {f64[2]}(4.0, 25.0).inverseSqrt.map(fn (v: f64) = string(v)).join(', '), '0.5, 0.2')
+    .it('fma')
+      .assert(
+        eq,
+        fma({f64[3]}(2.0, 3.0, 4.0), {f64[3]}(3.0, 4.0, 2.0), {f64[3]}(4.0, 2.0, 3.0))
+          .map(fn (v: f64) = string(v, 1)).join(', '),
+        '10.0, 14.0, 11.0');
 
   test.describe("Conditionals")
     .it("if function")

--- a/alan_compiler/src/lntors/function.rs
+++ b/alan_compiler/src/lntors/function.rs
@@ -1127,7 +1127,14 @@ pub fn from_microstatement(
                                 let enum_name = match &*enum_type {
                                     CType::Field(n, _) => Ok(n.clone()),
                                     CType::Type(n, _) => Ok(n.clone()),
-                                    _ => Err(format!("Cannot generate an constructor function for {} type as the input type has no name?", function.name)),
+                                    CType::Array(_) => {
+                                        // TODO: Handle this better
+                                        return Ok(("".to_string(), out, deps));
+                                    }
+                                    _ => {
+                                        println!("function {:?}", function);
+                                        Err(format!("Cannot generate an constructor function for {} type as the input type has no name?", function.name))
+                                    }
                                 }?;
                                 for t in ts {
                                     let inner_type = t.clone().degroup();

--- a/alan_compiler/src/lntors/function.rs
+++ b/alan_compiler/src/lntors/function.rs
@@ -1125,17 +1125,10 @@ pub fn from_microstatement(
                                     None => Arc::new(CType::Void),
                                 };
                                 let enum_name = match &*enum_type {
-                                    CType::Field(n, _) => Ok(n.clone()),
-                                    CType::Type(n, _) => Ok(n.clone()),
-                                    CType::Array(_) => {
-                                        // TODO: Handle this better
-                                        return Ok(("".to_string(), out, deps));
-                                    }
-                                    _ => {
-                                        println!("function {:?}", function);
-                                        Err(format!("Cannot generate an constructor function for {} type as the input type has no name?", function.name))
-                                    }
-                                }?;
+                                    CType::Field(n, _) => n.clone(),
+                                    CType::Type(n, _) => n.clone(),
+                                    _ => enum_type.clone().to_callable_string(),
+                                };
                                 for t in ts {
                                     let inner_type = t.clone().degroup();
                                     match &*inner_type {
@@ -1542,7 +1535,92 @@ pub fn from_microstatement(
                                             },
                                             _ => {}
                                         },
-                                        _ => {}
+                                        _ => {
+                                            if ts.len() == 2 {
+                                                if let CType::Void = &*ts[1] {
+                                                    if let CType::Void = &**t {
+                                                        return Ok(("None".to_string(), out, deps));
+                                                    } else {
+                                                        return Ok((
+                                                            format!(
+                                                                "Some({})",
+                                                                match argstrs[0]
+                                                                    .strip_prefix("&mut ")
+                                                                {
+                                                                    Some(s) => s,
+                                                                    None => &argstrs[0],
+                                                                }
+                                                            ),
+                                                            out,
+                                                            deps,
+                                                        ));
+                                                    }
+                                                } else if let CType::Type(name, _) = &*ts[1] {
+                                                    if name == "Error" {
+                                                        let (okrustname, d) =
+                                                            typen::ctype_to_rtype(
+                                                                ts[0].clone(),
+                                                                true,
+                                                                deps,
+                                                            )?;
+                                                        deps = d;
+                                                        let (errrustname, d) =
+                                                            typen::ctype_to_rtype(
+                                                                ts[1].clone(),
+                                                                true,
+                                                                deps,
+                                                            )?;
+                                                        deps = d;
+                                                        if let CType::Binds(..) = &**t {
+                                                            return Ok((
+                                                                format!(
+                                                                    "Err::<{}, {}>({})",
+                                                                    okrustname,
+                                                                    errrustname,
+                                                                    match argstrs[0]
+                                                                        .strip_prefix("&mut ")
+                                                                    {
+                                                                        Some(s) => s,
+                                                                        None => &argstrs[0],
+                                                                    }
+                                                                ),
+                                                                out,
+                                                                deps,
+                                                            ));
+                                                        } else {
+                                                            return Ok((
+                                                                format!(
+                                                                    "Ok::<{}, {}>({})",
+                                                                    okrustname,
+                                                                    errrustname,
+                                                                    match argstrs[0]
+                                                                        .strip_prefix("&mut ")
+                                                                    {
+                                                                        Some(s) => s,
+                                                                        None => &argstrs[0],
+                                                                    }
+                                                                ),
+                                                                out,
+                                                                deps,
+                                                            ));
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            return Ok((
+                                                format!(
+                                                    "{}::{}({})",
+                                                    function.name,
+                                                    enum_name,
+                                                    match argstrs[0].strip_prefix("&mut ") {
+                                                        Some(s) => s,
+                                                        None => &argstrs[0],
+                                                    },
+                                                ),
+                                                out,
+                                                deps,
+                                            ));
+                                        }
                                     }
                                 }
                                 return Err(format!("Cannot generate a constructor function for {} type as it is not part of the {} type", enum_name, function.name).into());

--- a/alan_compiler/src/lntors/typen.rs
+++ b/alan_compiler/src/lntors/typen.rs
@@ -98,7 +98,13 @@ pub fn ctype_to_rtype(
                                 deps = res.1;
                                 out.push(s);
                             }
-                            enum_type_strs.push(format!("({}", out.join(", ")));
+                            enum_type_strs.push(format!("({})", out.join(", ")));
+                        }
+                        CType::Array(t) => {
+                            let res = ctype_to_rtype(t, in_function_type, deps)?;
+                            let s = res.0;
+                            deps = res.1;
+                            enum_type_strs.push(format!("Vec<{}>", s));
                         }
                         otherwise => {
                             return Err(format!("TODO: What is this? {:?}", otherwise).into());

--- a/alan_compiler/src/lntors/typen.rs
+++ b/alan_compiler/src/lntors/typen.rs
@@ -100,14 +100,12 @@ pub fn ctype_to_rtype(
                             }
                             enum_type_strs.push(format!("({})", out.join(", ")));
                         }
-                        CType::Array(t) => {
+                        _otherwise => {
                             let res = ctype_to_rtype(t.clone(), in_function_type, deps)?;
                             let s = res.0;
                             deps = res.1;
-                            enum_type_strs.push(format!("Vec<{}>", s));
-                        }
-                        otherwise => {
-                            return Err(format!("TODO: What is this? {:?}", otherwise).into());
+                            let name = t.clone().to_callable_string();
+                            enum_type_strs.push(format!("{}({})", name, s));
                         }
                     }
                 }

--- a/alan_compiler/src/lntors/typen.rs
+++ b/alan_compiler/src/lntors/typen.rs
@@ -101,7 +101,7 @@ pub fn ctype_to_rtype(
                             enum_type_strs.push(format!("({})", out.join(", ")));
                         }
                         CType::Array(t) => {
-                            let res = ctype_to_rtype(t, in_function_type, deps)?;
+                            let res = ctype_to_rtype(t.clone(), in_function_type, deps)?;
                             let s = res.0;
                             deps = res.1;
                             enum_type_strs.push(format!("Vec<{}>", s));

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -615,6 +615,8 @@ fn{Js} round Method{"roundTiesEven"} :: f32 -> f32;
 fn magnitude f32 = arg0.abs;
 fn{Rs} inverseSqrt (v: f32) = {Method{"recip"} :: f32 -> f32}(sqrt(v));
 fn{Js} inverseSqrt (v: f32) = 1.0.f32 / sqrt(v);
+fn{Rs} fma Method{"mul_add"} :: (f32, f32, f32) -> f32;
+fn{Js} fma "((a, b, c) => new alan_std.F32(a.val * b.val + c.val))" <- RootBacking :: (f32, f32, f32) -> f32;
 
 fn{Rs} add Infix{"+"} :: (f64, f64) -> f64;
 fn{Js} add "((a, b) => new alan_std.F64(a.val + b.val))" <- RootBacking :: (f64, f64) -> f64;
@@ -703,6 +705,8 @@ fn{Js} round Method{"roundTiesEven"} :: f64 -> f64;
 fn magnitude f64 = arg0.abs;
 fn{Rs} inverseSqrt (v: f64) = {Method{"recip"} :: f64 -> f64}(sqrt(v));
 fn{Js} inverseSqrt (v: f64) = 1.0 / sqrt(v);
+fn{Rs} fma Method{"mul_add"} :: (f64, f64, f64) -> f64;
+fn{Js} fma "((a, b, c) => new alan_std.F32(a.val * b.val + c.val))" <- RootBacking :: (f64, f64, f64) -> f64;
 
 /// Unsigned Integer-related functions and function bindings
 fn{Rs} add Method{"wrapping_add"} :: (u8, Deref{u8}) -> u8;
@@ -1335,6 +1339,22 @@ fn normalize (arr: f64[]) {
 }
 fn inverseSqrt(arr: f32[]) = arr.map(inverseSqrt);
 fn inverseSqrt(arr: f64[]) = arr.map(inverseSqrt);
+fn fma(a: f32[], b: f32[], c: f32[]) -> Fallible{f32[]} {
+  return if(a.len == b.len && b.len == c.len, fn {
+    // TODO: Figure out why I need to explicitly wrap this in `Fallible{f32[]}(...)` instead of just
+    // using the `!` postfix operator
+    return Fallible{f32[]}(a.map(fn (v: f32, i: i64) = v.fma(b[i]!!, c[i]!!)));
+  }, fn {
+    return Error{f32[]}("Fused multiply-add on arrays requires equal-length arrays");
+  });
+}
+fn fma(a: f64[], b: f64[], c: f64[]) -> Fallible{f64[]} {
+  return if(a.len == b.len && b.len == c.len, fn {
+    return Fallible{f64[]}(a.map(fn (v: f64, i: i64) = v.fma(b[i]!!, c[i]!!)));
+  }, fn {
+    return Error{f64[]}("Fused multiply-add on arrays requires equal-length arrays");
+  });
+}
 
 /// Buffer related bindings
 fn{Rs} get{T, S} "alan_std::getbuffer" <- RootBacking :: (T[S], i64) -> T?;
@@ -1342,7 +1362,7 @@ fn len{T, S}(T[S]) = {S}();
 fn{Js} get{T, S} "((b, i) => { let idx = Number(i.val); if (idx >= 0 && idx < b.length) { return b[idx]; } else { return null; } })" :: (T[S], i64) -> T?;
 fn{Rs} map{T, S, U} "alan_std::mapbuffer_onearg" <- RootBacking :: (T[S], T -> U) -> (U[S]);
 fn{Js} map{T, S, U} (a: T[S], f: T -> U) = {"Promise.all" :: Buffer{U, S} -> Buffer{U, S}}({Method{"map"} :: (Buffer{T, S}, T -> U) -> Buffer{U, S}}(a, f));
-fn{Rs} map{T, S, U} "alan_std::mapbuffer_twoarg" <- RootBacking :: (T[S], (T, i64) -> U) -> (U[S]);
+fn{Rs} map{T, S, U} "alan_std::mapbuffer_twoarg" <- RootBacking :: (Buffer{T, S}, (T, i64) -> U) -> Buffer{U, S};
 fn{Js} map{T, S, U} (a: T[S], f: (T, i64) -> U) = {"Promise.all" :: Buffer{U, S} -> Buffer{U, S}}({Method{"map"} :: (Buffer{T, S}, (T, i32) -> U) -> Buffer{U, S}}(a, fn (v: T, i: i32) = f(v, i.i64)));
 fn{Rs} reduce{T, S} "alan_std::reducebuffer_sametype" <- RootBacking :: (T[S], (T, T) -> T) -> T?;
 fn{Js} reduce{T, S} (a: T[S], f: (T, T) -> T) = {"(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i]); } return out; })" :: (T[S], (T, T) -> T) -> T?}(a, f);
@@ -1398,6 +1418,8 @@ fn normalize{S} (arr: f64[S]) {
 }
 fn inverseSqrt{S}(buf: f32[S]) = buf.map(inverseSqrt);
 fn inverseSqrt{S}(buf: f64[S]) = buf.map(inverseSqrt);
+fn fma{S}(a: Buffer{f32, S}, b: Buffer{f32, S}, c: Buffer{f32, S}) = a.map(fn (v: f32, i: i64) = v.fma(b[i]!!, c[i]!!));
+fn fma{S}(a: Buffer{f64, S}, b: Buffer{f64, S}, c: Buffer{f64, S}) = a.map(fn (v: f64, i: i64) = v.fma(b[i]!!, c[i]!!));
 
 /// Dictionary-related bindings
 fn{Rs} Dict{K, V} "alan_std::OrderedHashMap::new" <- RootBacking :: () -> Dict{K, V};
@@ -4078,6 +4100,23 @@ fn round(v: gf32) = gRound(v);
 fn round(v: gvec2f) = gRound(v);
 fn round(v: gvec3f) = gRound(v);
 fn round(v: gvec4f) = gRound(v);
+
+fn gFma{I}(a: I, b: I, c: I) {
+  let varName = 'fma('
+    .concat(a.varName)
+    .concat(', ')
+    .concat(b.varName)
+    .concat(', ')
+    .concat(c.varName)
+    .concat(')');
+  let statements = a.statements.concat(b.statements).concat(c.statements);
+  let buffers = a.buffers.union(b.buffers).union(c.buffers);
+  return {I}(varName, statements, buffers);
+}
+fn fma(a: gf32, b: gf32, c: gf32) = gFma(a, b, c);
+fn fma(a: gvec2f, b: gvec2f, c: gvec2f) = gFma(a, b, c);
+fn fma(a: gvec3f, b: gvec3f, c: gvec3f) = gFma(a, b, c);
+fn fma(a: gvec4f, b: gvec4f, c: gvec4f) = gFma(a, b, c);
 
 fn gadd{A, B}(a: A, b: B) {
   let varName = '('.concat(a.varName).concat(' + ').concat(b.varName).concat(')');

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -615,7 +615,7 @@ fn{Js} round Method{"roundTiesEven"} :: f32 -> f32;
 fn magnitude f32 = arg0.abs;
 fn{Rs} inverseSqrt (v: f32) = {Method{"recip"} :: f32 -> f32}(sqrt(v));
 fn{Js} inverseSqrt (v: f32) = 1.0.f32 / sqrt(v);
-fn{Rs} fma Method{"mul_add"} :: (f32, f32, f32) -> f32;
+fn{Rs} fma Method{"mul_add"} :: (f32, Deref{f32}, Deref{f32}) -> f32;
 fn{Js} fma "((a, b, c) => new alan_std.F32(a.val * b.val + c.val))" <- RootBacking :: (f32, f32, f32) -> f32;
 
 fn{Rs} add Infix{"+"} :: (f64, f64) -> f64;
@@ -705,7 +705,7 @@ fn{Js} round Method{"roundTiesEven"} :: f64 -> f64;
 fn magnitude f64 = arg0.abs;
 fn{Rs} inverseSqrt (v: f64) = {Method{"recip"} :: f64 -> f64}(sqrt(v));
 fn{Js} inverseSqrt (v: f64) = 1.0 / sqrt(v);
-fn{Rs} fma Method{"mul_add"} :: (f64, f64, f64) -> f64;
+fn{Rs} fma Method{"mul_add"} :: (f64, Deref{f64}, Deref{f64}) -> f64;
 fn{Js} fma "((a, b, c) => new alan_std.F32(a.val * b.val + c.val))" <- RootBacking :: (f64, f64, f64) -> f64;
 
 /// Unsigned Integer-related functions and function bindings


### PR DESCRIPTION
This took more work than I expected, because I ran into an unexpected issue with `Fallible` and `Maybe` when given an `Array` as the inner type.

This was due to both of those being based on `Either` and unlabeled types not working because you can't access their value directly (as you can't write a function call for the inner type without a name).

Now an automatic function name is added to all types via `to_callable_string` to prevent the compilation failure, though it is still impossible for a bare `Either` to work with it because that function name isn't added into the scope. I need to think some more on if/how to tackle this. Perhaps using `.0`, `.1`, etc like tuples?
