### PR TITLE
Implement `storageBarrier`

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -841,7 +841,7 @@ test_gpgpu!(gpu_storage_barrier => r#"
       let id = gFor(3, 3);
       let temp = GBuffer{f32}(9);
       let out = GBuffer{f32}(9);
-      /*let compute = [
+      let compute = [
         // Something that generates a buffer independently
         temp[id.x + 3 * id.y].store((id.x.gf32 + id.y.gf32).asI32).build,
         // Something that creates a new buffer based on the prior buffer
@@ -850,8 +850,8 @@ test_gpgpu!(gpu_storage_barrier => r#"
             temp[id.x + 3 * id.y].asF32 +
             if(id.x < 2, temp[id.x + 1 + 3 * id.y].asF32, 0.0.gf32)) / 3.0).asI32).build
       ];
-      compute.run;*/
-      let compute = [
+      compute.run;
+      /*let compute = [
         // Something that generates a buffer independently
         temp[id.x + 3 * id.y].store((id.x.gf32 + id.y.gf32).asI32),
         // Storage Barrier
@@ -861,8 +861,7 @@ test_gpgpu!(gpu_storage_barrier => r#"
             ((if(id.x > 0, temp[id.x - 1 + 3 * id.y].asF32, 0.0.gf32) +
             temp[id.x + 3 * id.y].asF32 +
             if(id.x < 2, temp[id.x + 1 + 3 * id.y].asF32, 0.0.gf32)) / 3.0).asI32)
-      ].build.run;
-      //temp.read{f32}.map(fn (v: f32) = v.string(2)).join(", ").print;
+      ].build.run;*/
       out.read{f32}.map(fn (v: f32) = v.string(2)).join(", ").print;
     }
     export fn{Js} main {
@@ -871,7 +870,7 @@ test_gpgpu!(gpu_storage_barrier => r#"
       let out = GBuffer{f32}(9);
       // Hack to get this to work in JS, because the generic is not passed through there
       {"((b) => { b.ValKind = alan_std.F32; })" :: GBuffer}(out);
-      /*let compute = [
+      let compute = [
         // Something that generates a buffer independently
         temp[id.x + 3 * id.y].store((id.x.gf32 + id.y.gf32).asI32).build,
         // Something that creates a new buffer based on the prior buffer
@@ -880,8 +879,8 @@ test_gpgpu!(gpu_storage_barrier => r#"
             temp[id.x + 3 * id.y].asF32 +
             if(id.x < 2, temp[id.x + 1 + 3 * id.y].asF32, 0.0.gf32)) / 3.0).asI32).build
       ];
-      compute.run;*/
-      let compute = [
+      compute.run;
+      /*let compute = [
         // Something that generates a buffer independently
         temp[id.x + 3 * id.y].store((id.x.gf32 + id.y.gf32).asI32),
         // Storage Barrier
@@ -891,8 +890,7 @@ test_gpgpu!(gpu_storage_barrier => r#"
             ((if(id.x > 0, temp[id.x - 1 + 3 * id.y].asF32, 0.0.gf32) +
             temp[id.x + 3 * id.y].asF32 +
             if(id.x < 2, temp[id.x + 1 + 3 * id.y].asF32, 0.0.gf32)) / 3.0).asI32)
-      ].build.run;
-      //temp.read{f32}.map(fn (v: f32) = v.string(2)).join(", ").print;
+      ].build.run;*/
       out.read{f32}.map(fn (v: f32) = v.string(2)).join(", ").print;
     }"#;
     stdout "0.33, 1.00, 1.00, 1.00, 2.00, 1.67, 1.67, 3.00, 2.33\n";

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -836,6 +836,38 @@ test_gpgpu!(gpu_determinant => r#"
     stdout "-2.0\n";
 );
 
+test_gpgpu!(gpu_storage_barrier => r#"
+    export fn main {
+      let id = gFor(3, 3);
+      let temp = GBuffer{f32}(9);
+      let out = GBuffer{f32}(9);
+      /*let compute = [
+        // Something that generates a buffer independently
+        temp[id.x + 3 * id.y].store((id.x.gf32 + id.y.gf32).asI32).build,
+        // Something that creates a new buffer based on the prior buffer
+        out[id.x + 3 * id.y].store(
+            ((if(id.x > 0, temp[id.x - 1 + 3 * id.y].asF32, 0.0.gf32) +
+            temp[id.x + 3 * id.y].asF32 +
+            if(id.x < 2, temp[id.x + 1 + 3 * id.y].asF32, 0.0.gf32)) / 3.0).asI32).build
+      ];
+      compute.run;*/
+      let compute = [
+        // Something that generates a buffer independently
+        temp[id.x + 3 * id.y].store((id.x.gf32 + id.y.gf32).asI32),
+        // Storage Barrier
+        storageBarrier(),
+        // Something that creates a new buffer based on the prior buffer
+        out[id.x + 3 * id.y].store(
+            ((if(id.x > 0, temp[id.x - 1 + 3 * id.y].asF32, 0.0.gf32) +
+            temp[id.x + 3 * id.y].asF32 +
+            if(id.x < 2, temp[id.x + 1 + 3 * id.y].asF32, 0.0.gf32)) / 3.0).asI32)
+      ].build.run;
+      //temp.read{f32}.map(fn (v: f32) = v.string(2)).join(", ").print;
+      out.read{f32}.map(fn (v: f32) = v.string(2)).join(", ").print;
+    }"#;
+    stdout "0.33, 1.00, 1.00, 1.00, 2.00, 1.67, 1.67, 3.00, 2.33\n";
+);
+
 // TODO: Fix u64 numeric constants to get u64 bitwise tests in the new test suite
 test!(u64_bitwise => r#"
     prefix u64 as ~ precedence 10

--- a/alan_compiler/src/lntojs/typen.rs
+++ b/alan_compiler/src/lntojs/typen.rs
@@ -77,7 +77,7 @@ pub fn ctype_to_jtype(
                 Ok((
                     format!(
                         "class {} {{\n  constructor({}) {{\n    {}\n  }}\n}}",
-                        n,
+                        n.replace("\"", "_"), // TODO: How is this happening?
                         out.join(", "),
                         out.iter()
                             .map(|s| format!("    this.{} = {};", s, s))

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -4303,6 +4303,12 @@ impl CType {
         Arc::new(out)
     }
     pub fn and(a: Arc<CType>, b: Arc<CType>) -> Arc<CType> {
+        if let CType::Type(_, t) = &*a {
+            return CType::and(t.clone(), b);
+        }
+        if let CType::Type(_, t) = &*b {
+            return CType::and(a, t.clone());
+        }
         Arc::new(match (&*a, &*b) {
             (CType::Int(a), CType::Int(b)) => CType::Int(*a & *b),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(*a && *b),
@@ -4318,6 +4324,12 @@ impl CType {
         })
     }
     pub fn or(a: Arc<CType>, b: Arc<CType>) -> Arc<CType> {
+        if let CType::Type(_, t) = &*a {
+            return CType::or(t.clone(), b);
+        }
+        if let CType::Type(_, t) = &*b {
+            return CType::or(a, t.clone());
+        }
         Arc::new(match (&*a, &*b) {
             (CType::Int(a), CType::Int(b)) => CType::Int(*a | *b),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(*a || *b),
@@ -4333,6 +4345,12 @@ impl CType {
         })
     }
     pub fn xor(a: Arc<CType>, b: Arc<CType>) -> Arc<CType> {
+        if let CType::Type(_, t) = &*a {
+            return CType::xor(t.clone(), b);
+        }
+        if let CType::Type(_, t) = &*b {
+            return CType::xor(a, t.clone());
+        }
         Arc::new(match (&*a, &*b) {
             (CType::Int(a), CType::Int(b)) => CType::Int(*a ^ *b),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(*a ^ *b),
@@ -4343,11 +4361,17 @@ impl CType {
                 CType::Xor(vec![a.clone(), b.clone()])
             }
             _ => CType::fail(
-                "Or{A, B} must be provided two values of the same type, either integer or boolean",
+                "Xor{A, B} must be provided two values of the same type, either integer or boolean",
             ),
         })
     }
     pub fn nand(a: Arc<CType>, b: Arc<CType>) -> Arc<CType> {
+        if let CType::Type(_, t) = &*a {
+            return CType::nand(t.clone(), b);
+        }
+        if let CType::Type(_, t) = &*b {
+            return CType::nand(a, t.clone());
+        }
         Arc::new(match (&*a, &*b) {
             (CType::Int(a), CType::Int(b)) => CType::Int(!(*a & *b)),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(!(*a && *b)),
@@ -4361,6 +4385,12 @@ impl CType {
         })
     }
     pub fn nor(a: Arc<CType>, b: Arc<CType>) -> Arc<CType> {
+        if let CType::Type(_, t) = &*a {
+            return CType::nor(t.clone(), b);
+        }
+        if let CType::Type(_, t) = &*b {
+            return CType::nor(a, t.clone());
+        }
         Arc::new(match (&*a, &*b) {
             (CType::Int(a), CType::Int(b)) => CType::Int(!(*a | *b)),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(!(*a || *b)),
@@ -4376,6 +4406,12 @@ impl CType {
         })
     }
     pub fn xnor(a: Arc<CType>, b: Arc<CType>) -> Arc<CType> {
+        if let CType::Type(_, t) = &*a {
+            return CType::xnor(t.clone(), b);
+        }
+        if let CType::Type(_, t) = &*b {
+            return CType::xnor(a, t.clone());
+        }
         Arc::new(match (&*a, &*b) {
             (CType::Int(a), CType::Int(b)) => CType::Int(!(*a ^ *b)),
             (CType::Bool(a), CType::Bool(b)) => CType::Bool(!(*a ^ *b)),
@@ -4389,6 +4425,12 @@ impl CType {
         })
     }
     pub fn eq(a: Arc<CType>, b: Arc<CType>) -> Arc<CType> {
+        if let CType::Type(_, t) = &*a {
+            return CType::eq(t.clone(), b);
+        }
+        if let CType::Type(_, t) = &*b {
+            return CType::eq(a, t.clone());
+        }
         Arc::new(match (&*a, &*b) {
             (CType::Int(a), CType::Int(b)) => CType::Bool(*a == *b),
             (CType::Float(a), CType::Float(b)) => CType::Bool(*a == *b),
@@ -4404,6 +4446,12 @@ impl CType {
         })
     }
     pub fn neq(a: Arc<CType>, b: Arc<CType>) -> Arc<CType> {
+        if let CType::Type(_, t) = &*a {
+            return CType::neq(t.clone(), b);
+        }
+        if let CType::Type(_, t) = &*b {
+            return CType::neq(a, t.clone());
+        }
         Arc::new(match (&*a, &*b) {
             (CType::Int(a), CType::Int(b)) => CType::Bool(*a != *b),
             (CType::Float(a), CType::Float(b)) => CType::Bool(*a != *b),
@@ -4419,6 +4467,12 @@ impl CType {
         })
     }
     pub fn lt(a: Arc<CType>, b: Arc<CType>) -> Arc<CType> {
+        if let CType::Type(_, t) = &*a {
+            return CType::lt(t.clone(), b);
+        }
+        if let CType::Type(_, t) = &*b {
+            return CType::lt(a, t.clone());
+        }
         Arc::new(match (&*a, &*b) {
             (CType::Int(a), CType::Int(b)) => CType::Bool(*a < *b),
             (CType::Float(a), CType::Float(b)) => CType::Bool(*a < *b),
@@ -4433,6 +4487,12 @@ impl CType {
         })
     }
     pub fn lte(a: Arc<CType>, b: Arc<CType>) -> Arc<CType> {
+        if let CType::Type(_, t) = &*a {
+            return CType::lte(t.clone(), b);
+        }
+        if let CType::Type(_, t) = &*b {
+            return CType::lte(a, t.clone());
+        }
         Arc::new(match (&*a, &*b) {
             (CType::Int(a), CType::Int(b)) => CType::Bool(*a <= *b),
             (CType::Float(a), CType::Float(b)) => CType::Bool(*a <= *b),
@@ -4447,6 +4507,12 @@ impl CType {
         })
     }
     pub fn gt(a: Arc<CType>, b: Arc<CType>) -> Arc<CType> {
+        if let CType::Type(_, t) = &*a {
+            return CType::gt(t.clone(), b);
+        }
+        if let CType::Type(_, t) = &*b {
+            return CType::gt(a, t.clone());
+        }
         Arc::new(match (&*a, &*b) {
             (CType::Int(a), CType::Int(b)) => CType::Bool(*a > *b),
             (CType::Float(a), CType::Float(b)) => CType::Bool(*a > *b),
@@ -4461,6 +4527,12 @@ impl CType {
         })
     }
     pub fn gte(a: Arc<CType>, b: Arc<CType>) -> Arc<CType> {
+        if let CType::Type(_, t) = &*a {
+            return CType::gte(t.clone(), b);
+        }
+        if let CType::Type(_, t) = &*b {
+            return CType::gte(a, t.clone());
+        }
         Arc::new(match (&*a, &*b) {
             (CType::Int(a), CType::Int(b)) => CType::Bool(*a >= *b),
             (CType::Float(a), CType::Float(b)) => CType::Bool(*a >= *b),

--- a/alan_compiler/src/program/program.rs
+++ b/alan_compiler/src/program/program.rs
@@ -26,6 +26,15 @@ Program {
             env.insert(k.to_string(), v.to_string());
         }
         env.insert("ALAN_OUTPUT_LANG".to_string(), "rs".to_string());
+        env.insert("ALAN_PLATFORM".to_string(), if cfg!(target_os="windows") {
+            "windows".to_string()
+        } else if cfg!(target_os="macos") {
+            "macos".to_string()
+        } else if cfg!(target_os="linux") {
+            "linux".to_string()
+        } else {
+            "what".to_string()
+        });
         env
     },
 }));
@@ -42,6 +51,7 @@ Program {
             env.insert("ALAN_TARGET".to_string(), "release".to_string());
         }
         env.insert("ALAN_OUTPUT_LANG".to_string(), "js".to_string());
+        env.insert("ALAN_PLATFORM".to_string(), "browser".to_string());
         env
     },
 }));

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -4992,7 +4992,7 @@ fn lte(a: gvec4i, b: gvec4i) = glte{gvec4i, gvec4b}(a, b);
 fn lte(a: gvec4f, b: gvec4f) = glte{gvec4f, gvec4b}(a, b);
 
 fn ggt{I, O}(a: I, b: I) {
-  let varName = '('.concat(a.varName).concat(' < ').concat(b.varName).concat(')');
+  let varName = '('.concat(a.varName).concat(' > ').concat(b.varName).concat(')');
   let statements = a.statements.concat(b.statements);
   let buffers = a.buffers.union(b.buffers);
   return {O}(varName, statements, buffers);
@@ -5017,7 +5017,7 @@ fn gt(a: gvec4i, b: gvec4i) = ggt{gvec4i, gvec4b}(a, b);
 fn gt(a: gvec4f, b: gvec4f) = ggt{gvec4f, gvec4b}(a, b);
 
 fn ggte{I, O}(a: I, b: I) {
-  let varName = '('.concat(a.varName).concat(' <= ').concat(b.varName).concat(')');
+  let varName = '('.concat(a.varName).concat(' >= ').concat(b.varName).concat(')');
   let statements = a.statements.concat(b.statements);
   let buffers = a.buffers.union(b.buffers);
   return {O}(varName, statements, buffers);
@@ -5421,7 +5421,6 @@ fn pack2x16float(v: gvec2f) {
 }
 // No CPU-side equivalent as `f16` is only available in Rust nightly and not at all in JS-land.
 
-
 fn unpack4x8snorm(v: gu32) {
   let varName = 'unpack4x8snorm('.concat(v.varName).concat(')');
   let statements = v.statements.clone;
@@ -5490,6 +5489,19 @@ fn unpack2x16float(v: gu32) {
   return gvec2f(varName, statements, buffers);
 }
 // Also not doing this on the CPU side
+
+// storageBarrier is a synchronization mechanism on writes to storage buffers up to that point, to
+// make sure further reads/writes can expect all prior logical reads/writes to have completed. This
+// can be useful for operations where you need multiple prior outputs as the new input, like doing
+// a gaussian blur on an image, the current pixel is dependent on a set of pixels surrounding it, so
+// rather than having two different shaders, one to first create the image buffer and the second to
+// blur it, you can combine them and insert the storage barrier between the steps to avoid the extra
+// machinery of another shader compilation and work scheduling, or you could do it in a loop which
+// would be infeasible otherwise. It's a pure side-effect function, though, so using it "properly"
+// in the GPGPU binding in Alan is trickier. (Really only possible with the array-based `run`.
+fn storageBarrier() = WgpuType{"storageBarrier"}(
+  "storageBarrier()", Dict("storageBarrier()", "storageBarrier()"), Set{GBuffer}()
+);
 
 // GBuffer methods
 

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -114,6 +114,10 @@ type Release = Env{"ALAN_TARGET"} == "release";
 type Debug = Env{"ALAN_TARGET"} == "debug";
 type Rs = Env{"ALAN_OUTPUT_LANG"} == "rs";
 type Js = Env{"ALAN_OUTPUT_LANG"} == "js";
+type Lin = Env{"ALAN_PLATFORM"} == "linux";
+type Win = Env{"ALAN_PLATFORM"} == "windows";
+type Mac = Env{"ALAN_PLATFORM"} == "macos";
+type Browser = Env{"ALAN_PLATFORM"} == "browser"; // Technically not necessary, always also Js
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
 type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};


### PR DESCRIPTION
This supposedly will fail on Metal since each execution is being done in a separate workgroup and Metal doesn't provide `storageBarrier` guarantees across workgroups (despite the naming and there being a `workgroupBarrier` that should be the one constrained per workgroup) but I figured I may as well test it out with my two Apple machines and see what happens.

I may still discourage using `storageBarrier` since making a pipeline with two shaders that is guaranteed to work as expected is nearly identical in Alan instead of a big pain-in-the-butt in normal WebGPU.

Eg

```rs
[
  someGpuCompute(),
  storageBarrier(),
  someMoreCompute()
].build.run;
```

vs

```rs
[
  someGpuCompute().build,
  someMoreCompute().build,
].run;
```

But if this does work, it is theoretically faster and can be used in loops of indeterminant iterations (though I don't expose GPU loops, yet).
