### PR TITLE
Remove a useless `getOrExit` function that could never be called

### DIFF
--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -249,7 +249,6 @@ fn{Js} getOr{T} (v: T!, d: T) = {"((v, d) => v instanceof alan_std.AlanError ? d
 fn{Rs} getOrExit{T} (v: T!) = {Method{"unwrap"} :: Own{T!} -> T}(v);
 fn{Js} getOrExit{T} (v: T!) = {"((a) => { if (!(a instanceof alan_std.AlanError)) { return a; } else { process.exit(101); } })" :: T! -> T}(v);
 fn{Rs} getOrExit{T} (v: T?) = {Method{"unwrap"} :: Own{T?} -> T}(v);
-fn{Js} getOrExit{T} (v: T?) = {"((a) => a)" :: T? -> T}(v);
 fn{Js} getOrExit{T} (v: T?) = {"((a) => { if (a !== null && a !== undefined) { return a; } else { process.exit(101); } })" :: T? -> T}(v);
 fn{Rs} Error{T} (e: string) = {"Err" :: Own{Error} -> T!}(
   {Method{"into"} :: Own{string} -> Error}(e));


### PR DESCRIPTION
While working on documentation, I realized that this function definition can't ever actually be called (and didn't do what it was supposed to, anyways), so I deleted it. Tests passed locally.
