### PR TITLE
A minor fix for the Tree type's find function

### DIFF
--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -1671,7 +1671,7 @@ fn reduce{T}(t: Tree{T}, f: (Node{T}, Node{T}, i64) -> Node{T}) = t.Array.reduce
 fn reduce{T, U}(t: Tree{T}, i: U, f: (U, Node{T}) -> U) = t.Array.reduce(i, f);
 fn reduce{T, U}(t: Tree{T}, i: U, f: (U, Node{T}, i64) -> U) = t.Array.reduce(i, f);
 
-fn find{T}(t: Tree{T}, f: (T) -> bool) = t.Array.find(f);
+fn find{T}(t: Tree{T}, f: (Node{T}) -> bool) = t.Array.find(f);
 
 /// Thread-related bindings
 fn{Rs} wait (t: i64) = {"std::thread::sleep" :: Own{Duration}}(


### PR DESCRIPTION
The `Tree` type is not tested, yet, because it's not yet complete, but I noticed that the `find` function for the type would have failed to compile because the callback function definition used the wrong type.
