### PR TITLE
Try to resolve a flaky test in the test suite

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -460,8 +460,9 @@ test!(print_function => r#"
 test!(duration_print => r#"
     export fn main() -> void {
         const i = now();
-        wait(100); // Increased from 10ms to 100ms because the node.js event loop seems less
-                   // capable of guaranteeing staying below 20ms in the delay here.
+        wait(110); // Increased from 10ms to 110ms because the node.js event loop seems less
+                   // capable of guaranteeing staying below 20ms in the delay here. Adding an extra
+                   // 10ms in case it accidentally waits 90-something ms instead.
         const d = i.elapsed;
         print(d);
     }"#;


### PR DESCRIPTION
The `duration_print` integration test has always been a little bit flaky, I think because it's sometimes running the callback slightly *before* 100ms instead of slightly *after*, so the check for `0.1...` is failing because it's `0.09...`

Adding an extra 10ms to make this far less likely to occur.
