### PR TITLE
Fix GPU rendering path

### DIFF
--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -5598,10 +5598,10 @@ fn{Js} opaque "alan_std.contextOpaque" <- RootBacking :: Window -> ();
 fn{Rs} runtime Method{"runtime"} :: Window -> u32;
 fn{Js} runtime "alan_std.contextRuntime" <- RootBacking :: Window -> u32;
 // TODO: Be less opinionated on the context and framebuffer types, maybe?
-fn{Rs} context(f: Frame) = GBuffer{gu32}({Property{"context.clone()"} :: Frame -> GBufferRaw}(f));
-fn{Js} context(f: Frame) = GBuffer{gu32}({"alan_std.frameContext" <- RootBacking :: Frame -> GBufferRaw}(f));
-fn{Rs} framebuffer(f: Frame) = GBuffer{gu32}({Property{"framebuffer.clone()"} :: Frame -> GBufferRaw}(f));
-fn{Js} framebuffer(f: Frame) = GBuffer{gu32}({"alan_std.frameFramebuffer" <- RootBacking :: Frame -> GBufferRaw}(f));
+fn{Rs} context(f: Frame) = GBuffer{u32}({Property{"context.clone()"} :: Frame -> GBufferRaw}(f));
+fn{Js} context(f: Frame) = GBuffer{u32}({"alan_std.frameContext" <- RootBacking :: Frame -> GBufferRaw}(f));
+fn{Rs} framebuffer(f: Frame) = GBuffer{u32}({Property{"framebuffer.clone()"} :: Frame -> GBufferRaw}(f));
+fn{Js} framebuffer(f: Frame) = GBuffer{u32}({"alan_std.frameFramebuffer" <- RootBacking :: Frame -> GBufferRaw}(f));
 fn pixel Frame = gFor(-1, -2); // Magic numbers for the binding
 
 /// Process exit-related functions


### PR DESCRIPTION
I don't have a test for this yet, so I didn't catch this mistake. I used the `gu32` type instead of the `u32` type as the generic argument for the `GBuffer` the GPU rendering type creates for the context and framebuffer buffers, which prevented it from compiling correctly.

A demo program that uses these types is included below:

```rs
export fn main {
  print('hi');
  window(fn (win: Mut{Window}) {
    win.cursorInvisible;
    win.transparent;
  }, fn (win: Mut{Window}) = [
    win.width, win.height, win.runtime, win.mouseX, win.mouseY
  ], fn (frame: Frame) {
    let id = frame.pixel;
    let width = frame.context[0];
    let height = frame.context[1];
    let time = frame.context[2].asF32;
    let mouseX = frame.context[3];
    let mouseY = frame.context[4];
    let per10sec = time / 10.0;
    let per15sec = time / 20.0;
    let cycle = 2.0 * abs(per10sec - floor(per10sec) - 0.5);
    let slowcycle = 2.0 * abs(per15sec - floor(per15sec) - 0.5);
    let alpha = max(0.0, min(1.0, 2.0 - gvec2f(slowcycle * abs(id.x.gi32 - width / 2) / 5, slowcycle * abs(id.y.gi32 - height / 2) / 5).magnitude));
    let light = 1.0 / gvec2f(abs(mouseX.gi32 - id.x).gf32, abs(mouseY.gi32 - id.y).gf32).magnitude;
    let red = min(1.0, alpha * (light + cycle * gf32(id.x) / gf32(width)));
    let green = min(1.0, alpha * (light + 1.0 - red));
    let blue = min(1.0, alpha * (light + gf32(id.y) / gf32(height)));
    let loc = id.x + (frame.framebuffer.len / height) * id.y;
    let compute = frame.framebuffer[loc].store(pack4x8unorm(gvec4f(blue, green, red, alpha)));
    let plan = compute.build;
    print('Generated shader:\n');
    plan.shader.print;
    return [plan];
  });
  print('bye');
}
```
