### PR TITLE
Safer `GBuffer` (fallible if attempting to overallocate)

### DIFF
--- a/alan/benches/bench.ln
+++ b/alan/benches/bench.ln
@@ -16,7 +16,7 @@ fn bench(l: i64) {
   let t3 = now();
   // My laptop GPU can't handle a billion i32s in a single buffer, so that case is split in two
   if(l <= 100_000_000, fn {
-    let b = GBuffer(storageBuffer(), v);
+    let b = GBuffer(storageBuffer(), v)!!;
     let plan = GPGPU("
       @group(0)
       @binding(0)
@@ -36,7 +36,7 @@ fn bench(l: i64) {
     v3[0];
   }, fn {
     let v2 = filled(2.i32, 500_000_000);
-    let b = GBuffer(storageBuffer(), v2);
+    let b = GBuffer(storageBuffer(), v2)!!;
     let plan = GPGPU("
       @group(0)
       @binding(0)
@@ -53,7 +53,7 @@ fn bench(l: i64) {
     ", b);
     plan.run;
     b.read{i32};
-    let b = GBuffer(storageBuffer(), v2);
+    let b = GBuffer(storageBuffer(), v2)!!;
     let plan = GPGPU("
       @group(0)
       @binding(0)

--- a/alan/benches/buffer_shader_timings.ln
+++ b/alan/benches/buffer_shader_timings.ln
@@ -4,7 +4,7 @@ fn inner(l: i64) {
   let v = filled(1.i32, l);
   "Array creation time:     ".concat(t1.elapsed.f64.string).print;
   let t2 = now();
-  let b = GBuffer(v);
+  let b = GBuffer(v)!!;
   "GPU Buffer load time:    ".concat(t2.elapsed.f64.string).print;
   let t3 = now();
   let yMax = max(1, v.len / 10_000);

--- a/alan/benches/map.rs
+++ b/alan/benches/map.rs
@@ -108,7 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#);
     build!(t19_gpgpu_1 => r#"
         export fn main {
-          let b = GBuffer(storageBuffer(), filled(2.i32(), 1));
+          let b = GBuffer(storageBuffer(), filled(2.i32(), 1))!!;
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -130,7 +130,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#);
     build!(t20_gpgpu_10 => r#"
         export fn main {
-          let b = GBuffer(storageBuffer(), filled(2.i32(), 10));
+          let b = GBuffer(storageBuffer(), filled(2.i32(), 10))!!;
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -152,7 +152,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#);
     build!(t21_gpgpu_100 => r#"
         export fn main {
-          let b = GBuffer(storageBuffer(), filled(2.i32(), 100));
+          let b = GBuffer(storageBuffer(), filled(2.i32(), 100))!!;
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -174,7 +174,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#);
     build!(t22_gpgpu_1_000 => r#"
         export fn main {
-          let b = GBuffer(storageBuffer(), filled(2.i32(), 1_000));
+          let b = GBuffer(storageBuffer(), filled(2.i32(), 1_000))!!;
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -196,7 +196,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#);
     build!(t23_gpgpu_10_000 => r#"
         export fn main {
-          let b = GBuffer(storageBuffer(), filled(2.i32(), 10_000));
+          let b = GBuffer(storageBuffer(), filled(2.i32(), 10_000))!!;
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -218,7 +218,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#);
     build!(t24_gpgpu_100_000 => r#"
         export fn main {
-          let b = GBuffer(storageBuffer(), filled(2.i32(), 100_000));
+          let b = GBuffer(storageBuffer(), filled(2.i32(), 100_000))!!;
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -240,7 +240,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#);
     build!(t25_gpgpu_1_000_000 => r#"
         export fn main {
-          let b = GBuffer(storageBuffer(), filled(2.i32(), 1_000_000));
+          let b = GBuffer(storageBuffer(), filled(2.i32(), 1_000_000))!!;
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -262,7 +262,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#);
     build!(t26_gpgpu_10_000_000 => r#"
         export fn main {
-          let b = GBuffer(storageBuffer(), filled(2.i32(), 10_000_000));
+          let b = GBuffer(storageBuffer(), filled(2.i32(), 10_000_000))!!;
           let plan = GPGPU("
             @group(0)
             @binding(0)
@@ -284,7 +284,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#);
     build!(t27_gpgpu_100_000_000 => r#"
         export fn main {
-          let b = GBuffer(storageBuffer(), filled(2.i32(), 100_000_000));
+          let b = GBuffer(storageBuffer(), filled(2.i32(), 100_000_000))!!;
           let plan = GPGPU("
             @group(0)
             @binding(0)

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -516,7 +516,7 @@ test!(string_parse => r#"
 
 test_gpgpu!(hello_gpu => r#"
     export fn main {
-      let b = GBuffer(filled(2.i32, 4));
+      let b = GBuffer(filled(2.i32, 4))!!;
       let plan = GPGPU("
         @group(0)
         @binding(0)
@@ -535,7 +535,7 @@ test_gpgpu!(hello_gpu => r#"
 );
 test_gpgpu!(hello_gpu_new => r#"
     export fn main {
-      let b = GBuffer(filled(2.i32, 4));
+      let b = GBuffer(filled(2.i32, 4))!!;
       let idx = gFor(4);
       let compute = b[idx].store(b[idx] * idx.gi32);
       compute.build.run;
@@ -545,8 +545,8 @@ test_gpgpu!(hello_gpu_new => r#"
 );
 test_gpgpu!(list_of_gpu_tasks => r#"
     export fn main {
-      let b1 = GBuffer(filled(2.i32, 8));
-      let b2 = GBuffer(filled(5.i32, 4));
+      let b1 = GBuffer(filled(2.i32, 8))!!;
+      let b2 = GBuffer(filled(5.i32, 4))!!;
       let i1 = gFor(8);
       let i2 = gFor(4);
       let c1 = b1[i1].store(b1[i1] * i1.gi32);
@@ -560,7 +560,7 @@ test_gpgpu!(list_of_gpu_tasks => r#"
 
 test_gpgpu!(hello_gpu_odd => r#"
     export fn main {
-      let b = GBuffer(filled(2.i32, 4));
+      let b = GBuffer(filled(2.i32, 4))!!;
       let idx = gFor(4, 1);
       let compute = b[idx.i].store(b[idx.i] * idx.i.gi32 + 1);
       compute.build.run;
@@ -571,7 +571,7 @@ test_gpgpu!(hello_gpu_odd => r#"
 
 test_gpgpu!(gpu_map => r#"
     export fn main {
-        let b = GBuffer([1.i32, 2.i32, 3.i32, 4.i32]);
+        let b = GBuffer([1.i32, 2.i32, 3.i32, 4.i32])!!;
         let out = b.map(fn (val: gi32) = val + 2);
         out.read.print;
     }"#;
@@ -580,7 +580,7 @@ test_gpgpu!(gpu_map => r#"
 
 test_gpgpu!(gpu_if => r#"
     export fn main {
-        let b = GBuffer([1.i32, 2.i32, 3.i32, 4.i32]);
+        let b = GBuffer([1.i32, 2.i32, 3.i32, 4.i32])!!;
         let out = b.map(fn (val: gi32, i: gu32) = if(
             i % 2 == 0,
             val * i.gi32,
@@ -592,7 +592,7 @@ test_gpgpu!(gpu_if => r#"
 
 test_gpgpu!(gpu_replace => r#"
     export fn main {
-        let b = GBuffer([1.i32, 2.i32, 3.i32, 4.i32]);
+        let b = GBuffer([1.i32, 2.i32, 3.i32, 4.i32])!!;
         b.map(fn (val: gi32) = val + 2).read.print;
         b.replace([2.i32, 4.i32, 6.i32, 8.i32]);
         b.map(fn (val: gi32) = val / 2).read.print;
@@ -602,7 +602,7 @@ test_gpgpu!(gpu_replace => r#"
 
 test_gpgpu!(gpu_abs => r#"
     export fn main {
-        let b = GBuffer([1.i32, -2.i32, -3.i32, 4.i32]);
+        let b = GBuffer([1.i32, -2.i32, -3.i32, 4.i32])!!;
         b.map(fn (val: gi32) = val.abs).read.print;
     }"#;
     stdout "[1, 2, 3, 4]\n";
@@ -610,7 +610,7 @@ test_gpgpu!(gpu_abs => r#"
 
 test_gpgpu!(gpu_clz => r#"
     export fn main {
-        let b = GBuffer([1.i32, -2.i32, -3.i32, 4.i32]);
+        let b = GBuffer([1.i32, -2.i32, -3.i32, 4.i32])!!;
         // Don't need the generic on the `read` call, but leaving it to show it still works
         b.map(fn (val: gi32) = val.clz).read{i32}.print;
     }"#;
@@ -619,7 +619,7 @@ test_gpgpu!(gpu_clz => r#"
 
 test_gpgpu!(gpu_ones => r#"
     export fn main {
-        let b = GBuffer([1.i32, 2.i32, 3.i32, -1.i32]);
+        let b = GBuffer([1.i32, 2.i32, 3.i32, -1.i32])!!;
         b.map(fn (val: gi32) = val.ones).read.print;
     }"#;
     stdout "[1, 1, 2, 32]\n";
@@ -627,7 +627,7 @@ test_gpgpu!(gpu_ones => r#"
 
 test_gpgpu!(gpu_ctz => r#"
     export fn main {
-        let b = GBuffer([0.i32, 1.i32, 2.i32, -2_147_483_648.i32]);
+        let b = GBuffer([0.i32, 1.i32, 2.i32, -2_147_483_648.i32])!!;
         b.map(fn (val: gi32) = val.ctz).read.print;
     }"#;
     stdout "[32, 0, 1, 31]\n";
@@ -637,7 +637,7 @@ test_gpgpu!(gpu_cross => r#"
     // TODO: A nicer test involving `map`
 
     export fn main {
-      let b = GBuffer(filled(0.f32, 2));
+      let b = GBuffer(filled(0.f32, 2))!!;
       let idx = gFor(2);
       let compute = b[idx].store(if(
         idx == 0,
@@ -652,7 +652,7 @@ test_gpgpu!(gpu_cross => r#"
 
 test_gpgpu!(gpu_transpose => r#"
     export fn main {
-      let b = GBuffer([1.i32, 2.i32, 3.i32, 4.i32]);
+      let b = GBuffer([1.i32, 2.i32, 3.i32, 4.i32])!!;
       let m = gmat2x2f(b[0], b[1], b[2], b[3]).transpose;
       let idx = gFor(1);
       [
@@ -669,7 +669,7 @@ test_gpgpu!(gpu_transpose => r#"
 
 test_gpgpu!(gpu_reversebits => r#"
     export fn main {
-        let b = GBuffer([0.i32, 1.i32, 2.i32, (-2_147_483_648).i32]);
+        let b = GBuffer([0.i32, 1.i32, 2.i32, (-2_147_483_648).i32])!!;
         b.map(fn (val: gi32) = val.reverseBits).read.print;
     }"#;
     stdout "[0, -2147483648, 1073741824, 1]\n";
@@ -677,7 +677,7 @@ test_gpgpu!(gpu_reversebits => r#"
 
 test_gpgpu!(gpu_extractbits => r#"
     export fn main {
-        let b = GBuffer([0.u32, 1.u32, 2.u32, 5.u32]);
+        let b = GBuffer([0.u32, 1.u32, 2.u32, 5.u32])!!;
         b.map(fn (val: gu32) = val.extractBits(1, 2)).read.print;
     }"#;
     stdout "[0, 0, 1, 2]\n";
@@ -685,7 +685,7 @@ test_gpgpu!(gpu_extractbits => r#"
 
 test_gpgpu!(gpu_insertbits => r#"
     export fn main {
-        let b = GBuffer([0.u32, 31.u32]);
+        let b = GBuffer([0.u32, 31.u32])!!;
         b.map(fn (val: gu32) = val.insertBits(1, 2, 3)).read.print;
     }"#;
     stdout "[4, 7]\n";
@@ -695,7 +695,7 @@ test_gpgpu!(gpu_round => r#"
     export fn main {
       let b = GBuffer(
         [1.5.f32, 1.75.f32, 2.5.f32, 2.75.f32, (-1.5).f32, (-1.75).f32, (-2.5).f32, (-2.75).f32]
-      );
+      )!!;
       b.map(fn (val: gf32) = val.round).read.print;
     }"#;
     stdout "[2, 2, 2, 3, -2, -2, -2, -3]\n";
@@ -703,10 +703,10 @@ test_gpgpu!(gpu_round => r#"
 
 test_gpgpu!(gpu_magnitude => r#"
     export fn main {
-      let b = GBuffer([2.5.f32, -2.5.f32, 2.5.f32, -2.5.f32]);
+      let b = GBuffer([2.5.f32, -2.5.f32, 2.5.f32, -2.5.f32])!!;
       b.map(fn (val: gf32) = val.magnitude).read.print;
       let id = gFor(1);
-      let out = GBuffer{f32}(1);
+      let out = GBuffer{f32}(1)!!;
       let compute = out[id].store(gvec4f(b[0], b[1], b[2], b[3]).magnitude);
       compute.build.run;
       out.read.print;
@@ -716,9 +716,9 @@ test_gpgpu!(gpu_magnitude => r#"
 
 test_gpgpu!(gpu_normalize => r#"
     export fn main {
-      let b = GBuffer([3.0.f32, 4.0.f32]);
+      let b = GBuffer([3.0.f32, 4.0.f32])!!;
       let id = gFor(1);
-      let out = GBuffer{f32}(2);
+      let out = GBuffer{f32}(2)!!;
       let normal = gvec2f(b[0], b[1]).normalize;
       [out[id].store(normal.x), out[id + 1].store(normal.y)].build.run;
       out.read.map(fn (v: f32) = v.string(1)).join(', ').print;
@@ -728,7 +728,7 @@ test_gpgpu!(gpu_normalize => r#"
 
 test_gpgpu!(gpu_saturate => r#"
     export fn main {
-        let b = GBuffer([(-0.5).f32, 0.0.f32, 0.5.f32, 1.0.f32, 1.5.f32]);
+        let b = GBuffer([(-0.5).f32, 0.0.f32, 0.5.f32, 1.0.f32, 1.5.f32])!!;
         b.map(fn (val: gf32) = val.saturate).read.print;
     }"#;
     stdout "[0, 0, 0.5, 1, 1]\n";
@@ -736,9 +736,9 @@ test_gpgpu!(gpu_saturate => r#"
 
 test_gpgpu!(gpu_dot => r#"
     export fn main {
-      let b = GBuffer([3.0.f32, 4.0.f32]);
+      let b = GBuffer([3.0.f32, 4.0.f32])!!;
       let id = gFor(1);
-      let out = GBuffer{f32}(1);
+      let out = GBuffer{f32}(1)!!;
       let vec = gvec2f(b[0], b[1]);
       out[id].store(vec *. vec).build.run;
       out.read.map(fn (v: f32) = v.string(1)).join(', ').print;
@@ -748,7 +748,7 @@ test_gpgpu!(gpu_dot => r#"
 
 test_gpgpu!(gpu_inverse_sqrt => r#"
     export fn main {
-      let b = GBuffer([4.0.f32, 25.0.f32]);
+      let b = GBuffer([4.0.f32, 25.0.f32])!!;
       b.map(fn (val: gf32) = val.inverseSqrt).read.map(fn (v: f32) = v.string(1)).print;
     }"#;
     stdout "[0.5, 0.2]\n";
@@ -756,9 +756,9 @@ test_gpgpu!(gpu_inverse_sqrt => r#"
 
 test_gpgpu!(gpu_fma => r#"
     export fn main {
-      let b = GBuffer([2.0.f32, 3.0.f32, 4.0.f32]);
+      let b = GBuffer([2.0.f32, 3.0.f32, 4.0.f32])!!;
       let id = gFor(1);
-      let out = GBuffer{f32}(1);
+      let out = GBuffer{f32}(1)!!;
       out[id].store(fma(b[0], b[1], b[2])).build.run;
       (out.read[0]!!).string(1).print;
     }"#;
@@ -767,7 +767,7 @@ test_gpgpu!(gpu_fma => r#"
 
 test_gpgpu!(gpu_fract => r#"
     export fn main {
-      let b = GBuffer([1.0.f32, 3.14.f32]);
+      let b = GBuffer([1.0.f32, 3.14.f32])!!;
       b.map(fn (val: gf32) = val.fract).read.map(fn (v: f32) = v.string(2)).join(", ").print;
     }"#;
     stdout "0.00, 0.14\n";
@@ -775,9 +775,9 @@ test_gpgpu!(gpu_fract => r#"
 
 test_gpgpu!(gpu_determinant => r#"
     export fn main {
-      let b = GBuffer([1.0.f32, 2.0.f32, 3.0.f32, 4.0.f32]);
+      let b = GBuffer([1.0.f32, 2.0.f32, 3.0.f32, 4.0.f32])!!;
       let id = gFor(1);
-      let out = GBuffer{f32}(1);
+      let out = GBuffer{f32}(1)!!;
       out[id].store(gmat2x2f(b[0], b[1], b[2], b[3]).determinant).build.run;
       (out.read[0]!!).string(1).print;
     }"#;
@@ -790,8 +790,8 @@ test_gpgpu!(gpu_storage_barrier => r#"
       // across multiple threads running the same shader, which can let you do some work, then wait
       // to do more work that each thread may depend on the prior output of multiple threads to do
       let id = gFor(3, 3);
-      let temp = GBuffer{f32}(9);
-      let out = GBuffer{f32}(9);
+      let temp = GBuffer{f32}(9)!!;
+      let out = GBuffer{f32}(9)!!;
       let compute = [
         // Something that generates a buffer independently
         temp[id.x + 3 * id.y] = (id.x.gf32 + id.y.gf32),
@@ -815,8 +815,8 @@ test_gpgpu!(gpu_storage_barrier => r#"
       // that this means `storageBarrier` should never have been included in the WebGPU spec, but
       // here we are.
       let id = gFor(3, 3);
-      let temp = GBuffer{f32}(9);
-      let out = GBuffer{f32}(9);
+      let temp = GBuffer{f32}(9)!!;
+      let out = GBuffer{f32}(9)!!;
       let compute = [
         // Something that generates a buffer independently
         build(temp[id.x + 3 * id.y] = (id.x.gf32 + id.y.gf32)),
@@ -1504,43 +1504,43 @@ test_gpgpu!(gpu_trig => r#"
     export fn main {
       'Logarithms and e^x'.print;
       // Contrived way to get the GPU to do this work, don't follow this pattern for real GPU usage
-      GBuffer([e.f32]).map(fn (v: gf32) = exp(v)).read[0].getOrExit.string(2).print;
-      GBuffer([e.f32]).map(fn (v: gf32) = ln(v)).read[0].getOrExit.string(2).print;
-      GBuffer([e.f32]).map(fn (v: gf32) = log10(v)).read[0].getOrExit.string(2).print;
-      GBuffer([e.f32]).map(fn (v: gf32) = log2(v)).read[0].getOrExit.string(2).print;
+      GBuffer([e.f32]).getOrExit.map(fn (v: gf32) = exp(v)).read[0].getOrExit.string(2).print;
+      GBuffer([e.f32]).getOrExit.map(fn (v: gf32) = ln(v)).read[0].getOrExit.string(2).print;
+      GBuffer([e.f32]).getOrExit.map(fn (v: gf32) = log10(v)).read[0].getOrExit.string(2).print;
+      GBuffer([e.f32]).getOrExit.map(fn (v: gf32) = log2(v)).read[0].getOrExit.string(2).print;
 
       'Basic Trig functions'.print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = sin(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = cos(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = tan(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = sec(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = csc(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = cot(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = sin(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = cos(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = tan(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = sec(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = csc(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = cot(v)).read[0].getOrExit.string(2).print;
 
       'Inverse Trig functions'.print;
-      GBuffer([0.0.f32]).map(fn (v: gf32) = asin(v)).read[0].getOrExit.string(2).print;
-      GBuffer([1.0.f32]).map(fn (v: gf32) = acos(v)).read[0].getOrExit.string(2).print;
-      GBuffer([0.0.f32]).map(fn (v: gf32) = atan(v)).read[0].getOrExit.string(2).print;
-      GBuffer([1.0.f32]).map(fn (v: gf32) = atan2(v, 2.0)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = asec(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = acsc(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = acot(v)).read[0].getOrExit.string(2).print;
+      GBuffer([0.0.f32]).getOrExit.map(fn (v: gf32) = asin(v)).read[0].getOrExit.string(2).print;
+      GBuffer([1.0.f32]).getOrExit.map(fn (v: gf32) = acos(v)).read[0].getOrExit.string(2).print;
+      GBuffer([0.0.f32]).getOrExit.map(fn (v: gf32) = atan(v)).read[0].getOrExit.string(2).print;
+      GBuffer([1.0.f32]).getOrExit.map(fn (v: gf32) = atan2(v, 2.0)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = asec(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = acsc(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = acot(v)).read[0].getOrExit.string(2).print;
 
       'Hyperbolic Trig functions'.print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = sinh(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = cosh(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = tanh(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = sech(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = csch(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = coth(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = sinh(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = cosh(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = tanh(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = sech(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = csch(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = coth(v)).read[0].getOrExit.string(2).print;
 
       'Inverse Hyperbolic Trig functions'.print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = asinh(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = acosh(v)).read[0].getOrExit.string(2).print;
-      GBuffer([pi.f32 / 6.0.f32]).map(fn (v: gf32) = atanh(v)).read[0].getOrExit.string(2).print;
-      GBuffer([0.5.f32]).map(fn (v: gf32) = asech(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = acsch(v)).read[0].getOrExit.string(2).print;
-      GBuffer([tau.f32 / 6.0.f32]).map(fn (v: gf32) = acoth(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = asinh(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = acosh(v)).read[0].getOrExit.string(2).print;
+      GBuffer([pi.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = atanh(v)).read[0].getOrExit.string(2).print;
+      GBuffer([0.5.f32]).getOrExit.map(fn (v: gf32) = asech(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = acsch(v)).read[0].getOrExit.string(2).print;
+      GBuffer([tau.f32 / 6.0.f32]).getOrExit.map(fn (v: gf32) = acoth(v)).read[0].getOrExit.string(2).print;
     }"#;
     stdout r#"Logarithms and e^x
 15.15

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -966,7 +966,10 @@ pub fn from_microstatement(
                                         CType::Array(_) => {
                                             return Ok((argstrs[0].clone(), out, deps));
                                         }
-                                        CType::Tuple(ts) if inner_type.clone().to_callable_string() == enum_name => {
+                                        CType::Tuple(ts)
+                                            if inner_type.clone().to_callable_string()
+                                                == enum_name =>
+                                        {
                                             // Special-casing for Option and Result mapping. TODO:
                                             // Make this more centralized
                                             if ts.len() == 2 {

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -780,7 +780,7 @@ pub fn from_microstatement(
                                     CType::Type(n, _) => Ok(n.clone()),
                                     CType::Array(_) => Ok(enum_type.to_callable_string()),
                                     CType::Binds(..) => Ok(enum_type.to_callable_string()),
-                                    otherwise => Err(format!("Cannot generate an constructor function for {} type as the input type has no name? {:?}", ret_name, otherwise)),
+                                    otherwise => Err(format!("1. Cannot generate an constructor function for {} type as the input type has no name? {:?}", ret_name, otherwise)),
                                 }?;
                                 for t in ts {
                                     let inner_type = t.clone().degroup();
@@ -957,20 +957,16 @@ pub fn from_microstatement(
                                     CType::Type(n, _) => Ok(n.clone()),
                                     CType::Array(_) => Ok(enum_type.clone().to_callable_string()),
                                     CType::Binds(..) => Ok(enum_type.clone().to_callable_string()),
+                                    CType::Tuple(_) => Ok(enum_type.clone().to_callable_string()),
                                     otherwise => Err(format!("Cannot generate an constructor function for {} type as the input type has no name?, {:?}", function.name, otherwise)),
                                 }?;
                                 for t in ts {
-                                    let mut inner_type = t.clone().degroup();
-                                    if let CType::Tuple(ts) = &*inner_type {
-                                        if ts.len() == 1 {
-                                            inner_type = ts[0].clone();
-                                        }
-                                    }
+                                    let inner_type = t.clone().degroup();
                                     match &*inner_type {
                                         CType::Array(_) => {
                                             return Ok((argstrs[0].clone(), out, deps));
                                         }
-                                        CType::Field(n, _) if *n == enum_name => {
+                                        CType::Tuple(ts) if inner_type.clone().to_callable_string() == enum_name => {
                                             // Special-casing for Option and Result mapping. TODO:
                                             // Make this more centralized
                                             if ts.len() == 2 {
@@ -1010,10 +1006,7 @@ pub fn from_microstatement(
                                             }
                                             return Ok((argstrs[0].clone(), out, deps));
                                         }
-                                        CType::Field(_, f)
-                                            if f.clone().to_functional_string()
-                                                == enum_type.clone().to_functional_string() =>
-                                        {
+                                        CType::Field(n, _) if *n == enum_name => {
                                             // Special-casing for Option and Result mapping. TODO:
                                             // Make this more centralized
                                             if ts.len() == 2 {

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -515,7 +515,7 @@ pub fn from_microstatement(
                                     Ok((representation.clone(), out, deps))
                                 }
                                 otherwise => CType::fail(&format!(
-                                    "2. Bound types must be strings or node.js imports: {:?}",
+                                    "Bound types must be strings or node.js imports: {:?}",
                                     otherwise
                                 )),
                             },
@@ -780,7 +780,7 @@ pub fn from_microstatement(
                                     CType::Type(n, _) => Ok(n.clone()),
                                     CType::Array(_) => Ok(enum_type.to_callable_string()),
                                     CType::Binds(..) => Ok(enum_type.to_callable_string()),
-                                    otherwise => Err(format!("1. Cannot generate an constructor function for {} type as the input type has no name? {:?}", ret_name, otherwise)),
+                                    otherwise => Err(format!("Cannot generate an constructor function for {} type as the input type has no name? {:?}", ret_name, otherwise)),
                                 }?;
                                 for t in ts {
                                     let inner_type = t.clone().degroup();

--- a/alan_compiler/src/lntojs/typen.rs
+++ b/alan_compiler/src/lntojs/typen.rs
@@ -18,6 +18,9 @@ pub fn ctype_to_jtype(
         .into()),
         CType::Type(n, t) => match &**t {
             CType::Either(ts) => {
+                if ts.len() == 2 && (matches!(*ts[1], CType::Void) || matches!(&*ts[1], CType::Type(n, _) if n == "Error")) {
+                    return Ok(("".to_string(), deps));
+                }
                 for t in ts {
                     match &**t {
                         CType::Field(_, v) => {

--- a/alan_compiler/src/lntors/typen.rs
+++ b/alan_compiler/src/lntors/typen.rs
@@ -68,6 +68,9 @@ pub fn ctype_to_rtype(
         .into()),
         CType::Type(_, t) => match &**t {
             CType::Either(ts) => {
+                if ts.len() == 2 && (matches!(*ts[1], CType::Void) || matches!(&*ts[1], CType::Type(n, _) if n == "Error")) {
+                    return Ok(("".to_string(), deps));
+                }
                 let mut enum_type_strs = Vec::new();
                 for t in ts {
                     match &**t {
@@ -98,7 +101,8 @@ pub fn ctype_to_rtype(
                                 deps = res.1;
                                 out.push(s);
                             }
-                            enum_type_strs.push(format!("({})", out.join(", ")));
+                            let name = t.clone().to_callable_string();
+                            enum_type_strs.push(format!("{}({})", name, out.join(", ")));
                         }
                         _otherwise => {
                             let res = ctype_to_rtype(t.clone(), in_function_type, deps)?;

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -3415,7 +3415,7 @@ impl CType {
                     // Create a constructor fn
                     fs.push(Arc::new(Function {
                         name: constructor_fn_name.clone(),
-                        typen: Arc::new(CType::Function(e.clone(), t.clone())),
+                        typen: Arc::new(CType::Function(Arc::new(CType::Tuple(vec![Arc::new(CType::Field("arg0".to_string(), e.clone()))])), t.clone())),
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,
                         origin_scope_path: scope.path.clone(),

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -3415,7 +3415,13 @@ impl CType {
                     // Create a constructor fn
                     fs.push(Arc::new(Function {
                         name: constructor_fn_name.clone(),
-                        typen: Arc::new(CType::Function(Arc::new(CType::Tuple(vec![Arc::new(CType::Field("arg0".to_string(), e.clone()))])), t.clone())),
+                        typen: Arc::new(CType::Function(
+                            Arc::new(CType::Tuple(vec![Arc::new(CType::Field(
+                                "arg0".to_string(),
+                                e.clone(),
+                            ))])),
+                            t.clone(),
+                        )),
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,
                         origin_scope_path: scope.path.clone(),

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -259,7 +259,7 @@ fn{Js} Error "new alan_std.AlanError" <- RootBacking :: string -> Error;
 fn{Rs} exists{T} (m: T?) = {Method{"is_some"} :: T? -> bool}(m);
 fn{Js} exists{T} (m: T?) = {"((a) => new alan_std.Bool(a !== null))" <- RootBacking :: T? -> bool}(m);
 fn{Rs} exists{T} (m: T!) = {Method{"is_ok"} :: T! -> bool}(m);
-fn{Js} exists{T} (m: T!) = {"((a) => new alan_std.Bool(!(a instanceof alan_std.AlanError))" <- RootBacking :: T! -> bool}(m);
+fn{Js} exists{T} (m: T!) = {"((a) => new alan_std.Bool(!(a instanceof alan_std.AlanError)))" <- RootBacking :: T! -> bool}(m);
 fn{Rs} string(e: Error) = {"format!" :: ("{}", Error) -> string}(e);
 fn{Js} string Property{"message"} :: Error -> string;
 

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -127,8 +127,8 @@ type Mac = Env{"ALAN_PLATFORM"} == "macos";
 type Browser = Env{"ALAN_PLATFORM"} == "browser"; // Technically not necessary, always also Js
 
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
-type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
-type{Js} RootBacking = Nodejs{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git#safer-gbuffer"};
+type{Js} RootBacking = Nodejs{"alan_std" @ "https://github.com/alantech/alan.git#safer-gbuffer"};
 
 // Defining derived types
 type void = ();
@@ -258,6 +258,8 @@ fn{Js} Error{T} "new alan_std.AlanError" <- RootBacking :: string -> T!;
 fn{Js} Error "new alan_std.AlanError" <- RootBacking :: string -> Error;
 fn{Rs} exists{T} (m: T?) = {Method{"is_some"} :: T? -> bool}(m);
 fn{Js} exists{T} (m: T?) = {"((a) => new alan_std.Bool(a !== null))" <- RootBacking :: T? -> bool}(m);
+fn{Rs} exists{T} (m: T!) = {Method{"is_ok"} :: T! -> bool}(m);
+fn{Js} exists{T} (m: T!) = {"((a) => new alan_std.Bool(!(a instanceof alan_std.AlanError))" <- RootBacking :: T! -> bool}(m);
 fn{Rs} string(e: Error) = {"format!" :: ("{}", Error) -> string}(e);
 fn{Js} string Property{"message"} :: Error -> string;
 
@@ -1812,10 +1814,30 @@ fn{Rs} mapWriteBuffer "alan_std::map_write_buffer_type" <- RootBacking :: () -> 
 fn{Js} mapWriteBuffer "alan_std.mapWriteBufferType" <- RootBacking :: () -> BufferUsages;
 fn{Rs} storageBuffer "alan_std::storage_buffer_type" <- RootBacking :: () -> BufferUsages;
 fn{Js} storageBuffer "alan_std.storageBufferType" <- RootBacking :: () -> BufferUsages;
-fn{Rs} GBuffer{T}(bu: BufferUsages, arr: T[]) = GBuffer{T}({"alan_std::create_buffer_init" <- RootBacking :: (BufferUsages, T[], i8) -> GBufferRaw}(bu, arr, {Size{T}}().i8));
-fn{Js} GBuffer{T}(bu: BufferUsages, arr: T[]) = GBuffer{T}({"alan_std.createBufferInit" <- RootBacking :: (BufferUsages, T[]) -> GBufferRaw}(bu, arr));
-fn{Rs} GBuffer{T}(bu: BufferUsages, size: i64) = GBuffer{T}({"alan_std::create_empty_buffer" <- RootBacking :: (BufferUsages, i64, i8) -> GBufferRaw}(bu, size, {Size{T}}().i8));
-fn{Js} GBuffer{T}(bu: BufferUsages, size: i64) = GBuffer{T}({"alan_std.createEmptyBuffer" <- RootBacking :: (BufferUsages, i32) -> GBufferRaw}(bu, size.i32));
+fn{Rs} GBuffer{T}(bu: BufferUsages, arr: T[]) {
+  let fallibleRawBuffer = {"alan_std::create_buffer_init" <- RootBacking :: (BufferUsages, T[], i8) -> Fallible{GBufferRaw}}(bu, arr, {Size{T}}().i8);
+  return if(fallibleRawBuffer.exists,
+    fn = Fallible{GBuffer{T}}(GBuffer{T}(fallibleRawBuffer.getOrExit)),
+    fn = Error{GBuffer{T}}(fallibleRawBuffer.Error.getOrExit.string));
+}
+fn{Js} GBuffer{T}(bu: BufferUsages, arr: T[]) {
+  let fallibleRawBuffer = {"alan_std.createBufferInit" <- RootBacking :: (BufferUsages, T[]) -> Fallible{GBufferRaw}}(bu, arr);
+  return if(fallibleRawBuffer.exists,
+    fn = Fallible{GBuffer{T}}(GBuffer{T}(fallibleRawBuffer.getOrExit)),
+    fn = Error{GBuffer{T}}(fallibleRawBuffer.Error.getOrExit.string));
+}
+fn{Rs} GBuffer{T}(bu: BufferUsages, size: i64) {
+  let fallibleRawBuffer = {"alan_std::create_empty_buffer" <- RootBacking :: (BufferUsages, i64, i8) -> GBufferRaw!}(bu, size, {Size{T}}().i8);
+  return if(fallibleRawBuffer.exists,
+    fn = Fallible{GBuffer{T}}(GBuffer{T}(fallibleRawBuffer.getOrExit)),
+    fn = Error{GBuffer{T}}(fallibleRawBuffer.Error.getOrExit.string));
+}
+fn{Js} GBuffer{T}(bu: BufferUsages, size: i64) {
+  let fallibleRawBuffer = {"alan_std.createEmptyBuffer" <- RootBacking :: (BufferUsages, i32) -> GBufferRaw!}(bu, size.i32);
+  return if(fallibleRawBuffer.exists,
+    fn = Fallible{GBuffer{T}}(GBuffer{T}(fallibleRawBuffer.getOrExit)),
+    fn = Error{GBuffer{T}}(fallibleRawBuffer.Error.getOrExit.string));
+}
 fn GBuffer{T}(vals: T[]) = GBuffer{T}(storageBuffer(), vals);
 fn GBuffer{T}(size: i64) = GBuffer{T}(storageBuffer(), size);
 fn{Rs} cpulen{T}(b: GBuffer{T}) = {"alan_std::bufferlen" <- RootBacking :: GBufferRaw -> i64}(b.rawBuffer);
@@ -5014,7 +5036,7 @@ fn storageBarrier() = WgpuType{"storageBarrier"}(
 fn map{G, G2}(gb: GBuffer{G}, f: Prop{WgpuTypeMap, String{G}} -> Prop{WgpuTypeMap, String{G2}}) {
   let idx = gFor(gb.cpulen);
   let val = gb[idx];
-  let out = GBuffer{G2}(gb.cpulen);
+  let out = GBuffer{G2}(gb.cpulen)!!;
   let compute = out[idx].store(f(val));
   compute.build.run;
   return out;
@@ -5022,7 +5044,7 @@ fn map{G, G2}(gb: GBuffer{G}, f: Prop{WgpuTypeMap, String{G}} -> Prop{WgpuTypeMa
 fn map{G, G2}(gb: GBuffer{G}, f: (Prop{WgpuTypeMap, String{G}}, gu32) -> Prop{WgpuTypeMap, String{G2}}) {
   let idx = gFor(gb.cpulen);
   let val = gb[idx];
-  let out = GBuffer{G2}(gb.cpulen);
+  let out = GBuffer{G2}(gb.cpulen)!!;
   let compute = out[idx].store(f(val, idx));
   compute.build.run;
   return out;

--- a/alan_std.js
+++ b/alan_std.js
@@ -798,9 +798,13 @@ export async function gpu() {
 
 export async function createBufferInit(usage, vals) {
   let g = await gpu();
+  let size = vals.length * (vals[0]?.bits ?? 32) / 8;
+  if (g.device.limits.maxBufferSize < size) {
+    return new AlanError(`Cannot load the array into the GPU, as it is it oo large. GBuffer on your GPU only supports up to ${g.device.limits.maxBufferSize} bytes per buffer`);
+  }
   let b = await g.device.createBuffer({
     mappedAtCreation: true,
-    size: vals.length * (vals[0]?.bits ?? 32) / 8,
+    size,
     usage,
     label: `buffer_${uuidv4().replaceAll('-', '_')}`,
   });
@@ -816,6 +820,9 @@ export async function createBufferInit(usage, vals) {
 
 export async function createEmptyBuffer(usage, size, ValKind) {
   let g = await gpu();
+  if (g.device.limits.maxBufferSize < size) {
+    return new AlanError(`Cannot load the array into the GPU, as it is it oo large. GBuffer on your GPU only supports up to ${g.device.limits.maxBufferSize} bytes per buffer`);
+  }
   let b = await g.device.createBuffer({
     size: size.valueOf() * (ValKind?.bits ?? 32) / 8,
     usage,

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -1180,7 +1180,7 @@ pub fn replace_buffer<T>(b: &GBuffer, v: &Vec<T>) -> Result<(), AlanError> {
         Err("The input array is not the same size as the buffer".into())
     } else {
         let g = gpu();
-        let gb = create_buffer_init(&map_write_buffer_type(), &v, &b.element_size)
+        let gb = create_buffer_init(&map_write_buffer_type(), v, &b.element_size)
             .expect("The buffer already exists so a new one the same size should always work");
         let mut encoder = g
             .device

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -948,7 +948,11 @@ pub fn create_buffer_init<T>(
     })
 }
 
-pub fn create_empty_buffer(usage: &wgpu::BufferUsages, size: &i64, element_size: &i8) -> Result<GBuffer, AlanError> {
+pub fn create_empty_buffer(
+    usage: &wgpu::BufferUsages,
+    size: &i64,
+    element_size: &i8,
+) -> Result<GBuffer, AlanError> {
     let g = gpu();
     let limits = g.device.limits();
     if limits.max_buffer_size < *size as u64 {
@@ -1144,7 +1148,8 @@ pub fn gpu_run_list(ggs: &mut Vec<GPGPU>) {
 
 pub fn read_buffer<T: std::clone::Clone>(b: &GBuffer) -> Vec<T> {
     let g = gpu();
-    let temp_buffer = create_empty_buffer(&map_read_buffer_type(), &bufferlen(b), &b.element_size).expect("The buffer already exists so a new one the same size should always work");
+    let temp_buffer = create_empty_buffer(&map_read_buffer_type(), &bufferlen(b), &b.element_size)
+        .expect("The buffer already exists so a new one the same size should always work");
     let mut encoder = g
         .device
         .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
@@ -1175,7 +1180,8 @@ pub fn replace_buffer<T>(b: &GBuffer, v: &Vec<T>) -> Result<(), AlanError> {
         Err("The input array is not the same size as the buffer".into())
     } else {
         let g = gpu();
-        let gb = create_buffer_init(&map_write_buffer_type(), &v, &b.element_size).expect("The buffer already exists so a new one the same size should always work");
+        let gb = create_buffer_init(&map_write_buffer_type(), &v, &b.element_size)
+            .expect("The buffer already exists so a new one the same size should always work");
         let mut encoder = g
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });

--- a/alan_std/src/lib.rs
+++ b/alan_std/src/lib.rs
@@ -924,13 +924,17 @@ pub fn create_buffer_init<T>(
     usage: &wgpu::BufferUsages,
     vals: &Vec<T>,
     element_size: &i8,
-) -> GBuffer {
+) -> Result<GBuffer, AlanError> {
     let g = gpu();
     let val_slice = &vals[..];
     let val_ptr = val_slice.as_ptr();
     let val_u8_len = vals.len() * (*element_size as usize);
+    let limits = g.device.limits();
+    if limits.max_buffer_size < val_u8_len as u64 {
+        return Err(AlanError { message: format!("Cannot load the array into the GPU, as it is too large. GBuffer on your GPU only supports up to {} bytes per buffer", limits.max_buffer_size), });
+    }
     let val_u8: &[u8] = unsafe { std::slice::from_raw_parts(val_ptr as *const u8, val_u8_len) };
-    GBuffer {
+    Ok(GBuffer {
         buffer: Rc::new(wgpu::util::DeviceExt::create_buffer_init(
             &g.device,
             &wgpu::util::BufferInitDescriptor {
@@ -941,12 +945,16 @@ pub fn create_buffer_init<T>(
         )),
         id: format!("buffer_{}", format!("{}", Uuid::new_v4()).replace("-", "_")),
         element_size: *element_size,
-    }
+    })
 }
 
-pub fn create_empty_buffer(usage: &wgpu::BufferUsages, size: &i64, element_size: &i8) -> GBuffer {
+pub fn create_empty_buffer(usage: &wgpu::BufferUsages, size: &i64, element_size: &i8) -> Result<GBuffer, AlanError> {
     let g = gpu();
-    GBuffer {
+    let limits = g.device.limits();
+    if limits.max_buffer_size < *size as u64 {
+        return Err(AlanError { message: format!("Cannot load the array into the GPU, as it is too large. GBuffer on your GPU only supports up to {} bytes per buffer", limits.max_buffer_size), });
+    }
+    Ok(GBuffer {
         buffer: Rc::new(g.device.create_buffer(&wgpu::BufferDescriptor {
             label: None, // TODO: Add a label for easier debugging?
             size: (*size as u64) * (*element_size as u64),
@@ -955,7 +963,7 @@ pub fn create_empty_buffer(usage: &wgpu::BufferUsages, size: &i64, element_size:
         })),
         id: format!("buffer_{}", format!("{}", Uuid::new_v4()).replace("-", "_")),
         element_size: *element_size,
-    }
+    })
 }
 
 // TODO: Either add the ability to bind to const values, or come up with a better solution. For
@@ -1136,7 +1144,7 @@ pub fn gpu_run_list(ggs: &mut Vec<GPGPU>) {
 
 pub fn read_buffer<T: std::clone::Clone>(b: &GBuffer) -> Vec<T> {
     let g = gpu();
-    let temp_buffer = create_empty_buffer(&map_read_buffer_type(), &bufferlen(b), &b.element_size);
+    let temp_buffer = create_empty_buffer(&map_read_buffer_type(), &bufferlen(b), &b.element_size).expect("The buffer already exists so a new one the same size should always work");
     let mut encoder = g
         .device
         .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
@@ -1167,7 +1175,7 @@ pub fn replace_buffer<T>(b: &GBuffer, v: &Vec<T>) -> Result<(), AlanError> {
         Err("The input array is not the same size as the buffer".into())
     } else {
         let g = gpu();
-        let gb = create_buffer_init(&map_write_buffer_type(), &v, &b.element_size);
+        let gb = create_buffer_init(&map_write_buffer_type(), &v, &b.element_size).expect("The buffer already exists so a new one the same size should always work");
         let mut encoder = g
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });


### PR DESCRIPTION
The `GBuffer` constructor functions are now `Fallible` in case you try to allocate too much memory for a single buffer. Technically this should apply to all memory allocations, but GPU buffers have a much lower limit than "all of the RAM on the GPU", while crazy trickery in modern operating systems means you can allocate more memory than should be physically possible and the OS will swap memory around under the hood for you.

This means that you actually *do* need to pay attention to over-allocating for the GPU but don't really need to for the CPU.

In the process of doing this change, I ran into compiler bugs with Fallible being used with `Tuple` types, especially in the JS path, but also a couple on the RS path and one during the constructor function generation for any `Either`-based type, which have also been fixed.

Resolves #690