### PR TITLE
Force an older version of bytemuck_derive so earlier Rust versions still work

### DIFF
--- a/alan/src/compile/mod.rs
+++ b/alan/src/compile/mod.rs
@@ -73,6 +73,10 @@ pub fn build(source_file: String) -> Result<String, Box<dyn std::error::Error>> 
 name = "alan_generated_bin"
 edition = "2021"
 
+# To continue supporting earlier versions of Rust
+[patch.crates-io]
+bytemuck_derive = { git = "https://github.com/Lokathor/bytemuck", tag = "bytemuck_derive-v1.8.1" }
+
 [dependencies]"#;
     let cargo_path = {
         let mut c = project_dir.clone();


### PR DESCRIPTION
This was discovered by a user in the Discord server. After some digging to make sure I had set `edition` correctly, I found [this issue](https://github.com/Lokathor/bytemuck/issues/306) where the conclusion is that there is a bug in earlier versions of `cargo` that are causing it to think the file is using 2024 edition, instead, when `rust-version` is declared.

So for now, the generated code will be hardwired to `bytemuck_derive` @ `1.8.1` as suggested by one of the users as a workaround. I may bump the minimum Rust version to one that doesn't have this bug later on, but this will unblock things for the time being.
