### PR TITLE
Dedupe types fed into `Either{A, B}`

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -1934,3 +1934,25 @@ test_ignore!(json_complex_construction => r#"
     }"#;
     stdout r#"{"mixed": "values", "work": true, "even": [4, "arrays"]}""#;
 );
+
+// Either deduplication
+
+test!(either_dedup_explicit => r#"
+    type DupEither = i64 | string | i64;
+    type NormalEither = i64 | string;
+    fn takeEither(x: NormalEither) = if(x.i64.exists, fn = x.i64.getOrExit.print, fn = x.string.getOrExit.print);
+    export fn main {
+      takeEither(42.DupEither);
+    }"#;
+    stdout "42\n";
+);
+
+test!(either_dedup_single_unwrap => r#"
+    type DupeI64 = i64 | i64;
+    export fn main {
+      let a: i64 = 3;
+      let b: DupeI64 = 5;
+      print(a.add(b));
+    }"#;
+    stdout "8\n";
+);

--- a/alan_compiler/src/lntors/typen.rs
+++ b/alan_compiler/src/lntors/typen.rs
@@ -599,7 +599,7 @@ pub fn generate(
         }
         // TODO: The complexity of this function indicates more fundamental issues in the type
         // generation. This needs a rethink and rewrite.
-        CType::Type(name, t) => match &**t {
+        CType::Type(_name, t) => match &**t {
             CType::Either(_) => {
                 let res = generate(t.clone(), out, deps)?;
                 out = res.1;
@@ -607,8 +607,9 @@ pub fn generate(
                 let res = ctype_to_rtype(typen.clone(), deps)?;
                 let s = res.0;
                 deps = res.1;
-                out.insert(t.clone().to_callable_string(), s);
-                Ok((name.clone(), out, deps))
+                let enum_key = t.clone().to_callable_string();
+                out.insert(enum_key.clone(), s);
+                Ok((enum_key, out, deps))
             }
             _ => {
                 let res = ctype_to_rtype(t.clone(), deps)?;

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -4238,7 +4238,21 @@ impl CType {
                 _other => out_vec.push(arg),
             }
         }
-        Arc::new(CType::Either(out_vec))
+        // Deduplicate by string representation
+        let mut seen = HashSet::new();
+        let deduped: Vec<Arc<CType>> = out_vec
+            .into_iter()
+            .filter(|t| {
+                let key = t.clone().degroup().to_callable_string();
+                seen.insert(key)
+            })
+            .collect();
+        // If deduplication leaves a single type, unwrap the Either
+        if deduped.len() == 1 {
+            deduped.into_iter().next().unwrap()
+        } else {
+            Arc::new(CType::Either(deduped))
+        }
     }
     pub fn prop(t: Arc<CType>, p: Arc<CType>) -> Arc<CType> {
         // Check the arguments first to see if they're to be inferred


### PR DESCRIPTION
This will help pave the way for supporting functions that return different values depending on the branch taken.
