### PR TITLE
Create `Exclude{T, N}`, `First{T}`, and `Rest{T}` types

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -1957,94 +1957,54 @@ test!(either_dedup_single_unwrap => r#"
     stdout "8\n";
 );
 
-// First/Rest pattern matching for recursive Either processing
+// Exclude constructor tests
 
-test!(first_matches_first_variant => r#"
-    export fn main {
-      let v = Either{string, i64, bool}("hello");
-      first(v).print;
-    }"#;
-    stdout "hello\n";
+test!(exclude_tuple_by_index => r#"
+  type MyTuple = a: i64, b: string, c: bool;
+  type MyFiltered = Exclude{MyTuple, 1};
+  export fn main {
+    let v: MyTuple = MyTuple(42, "hello", true);
+    let res: MyFiltered = MyFiltered(v.a, v.c);
+    res.a.print;
+    res.c.print;
+  }"#;
+  stdout "42\ntrue\n";
 );
 
-test!(first_no_match_returns_void => r#"
-    export fn main {
-      let v = Either{string, i64, bool}(42);
-      first(v).print;
-    }"#;
-    stdout "void\n";
+test!(exclude_tuple_by_index_first => r#"
+  type MyTuple2 = a: i64, b: string, c: bool;
+  type MyFiltered = Exclude{MyTuple2, 0};
+  export fn main {
+    let v: MyTuple2 = MyTuple2(42, "hello", true);
+    let res: MyFiltered = MyFiltered(v.b, v.c);
+    res.b.print;
+    res.c.print;
+  }"#;
+  stdout "hello\ntrue\n";
 );
 
-test!(first_with_two_variants => r#"
-    export fn main {
-      let v = Either{string, i64}("world");
-      first(v).print;
-    }"#;
-    stdout "world\n";
+test!(exclude_tuple_parent_constructor => r#"
+  type MyTuple = a: i64, b: string, c: bool;
+  type MyFiltered = Exclude{MyTuple, 1};
+  export fn main {
+    let v: MyTuple = MyTuple(42, "hello", true);
+    let res: MyFiltered = MyFiltered(v);
+    res.a.print;
+    res.c.print;
+  }"#;
+  stdout "42\ntrue\n";
 );
 
-test!(first_with_two_variants_no_match => r#"
-    export fn main {
-      let v = Either{string, i64}(99);
-      first(v).print;
-    }"#;
-    stdout "void\n";
-);
-
-test!(rest_discards_first_variant => r#"
-    export fn main {
-      let v = Either{string, i64, bool}("hello");
-      rest(v);
-    }"#;
-    stdout "";
-);
-
-test!(rest_preserves_second_variant => r#"
-    export fn main {
-      let v = Either{string, i64, bool}(42);
-      first(rest(v)).print;
-    }"#;
-    stdout "42\n";
-);
-
-test!(rest_preserves_third_variant => r#"
-    export fn main {
-      let v = Either{string, i64, bool}(true);
-      first(rest(v)).print;
-    }"#;
-    stdout "void\n";
-);
-
-test!(rest_with_two_variants_discarded => r#"
-    export fn main {
-      let v = Either{string, i64}("hello");
-      rest(v).print;
-    }"#;
-    stdout "void\n";
-);
-
-test!(rest_with_two_variants_preserved => r#"
-    export fn main {
-      let v = Either{string, i64}(42);
-      rest(v).print;
-    }"#;
-    stdout "42\n";
-);
-
-test!(first_rest_chain => r#"
-    export fn main {
-      let v = Either{string, i64, bool}("hello");
-      first(v).print;
-      first(rest(v)).print;
-    }"#;
-    stdout "hello\nvoid\n";
-);
-
-test!(first_rest_chain_second => r#"
-    export fn main {
-      let v = Either{string, i64, bool}(42);
-      first(v).print;
-      first(rest(v)).print;
-    }"#;
-    stdout "void\n42\n";
+test!(exclude_tuple_parent_constructor_recursive => r#"
+  type Grandparent = a: i64, b: string, c: bool, d: f64;
+  type Parent = Exclude{Grandparent, 3};
+  type Child = Exclude{Parent, 1};
+  export fn main {
+    let gp: Grandparent = Grandparent(42, "hello", true, 3.14);
+    let p: Parent = Parent(gp);
+    let c: Child = Child(p);
+    c.a.print;
+    c.c.print;
+  }"#;
+  stdout "42\ntrue\n";
 );

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -2169,3 +2169,16 @@ test!(exclude_either_parent_constructor_recursive => r#"
   }"#;
   stdout "42\n";
 );
+
+// -.(dot-dash) Exclude operator syntax tests
+
+test!(exclude_tuple_dotdash_chained => r#"
+  type MyTuple = a: i64, b: string, c: bool;
+  type MySingle = MyTuple-.a-.c;
+  export fn main {
+    let v: MyTuple = MyTuple(42, "hello", true);
+    let res: MySingle = MySingle(v);
+    res.b.print;
+  }"#;
+  stdout "hello\n";
+);

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -1943,8 +1943,100 @@ test!(either_dedup_explicit => r#"
     fn takeEither(x: NormalEither) = x.print;
     export fn main {
       takeEither(42.DupEither);
-    }"#;
-    stdout "42\n";
+ }"#;
+  stdout "42\n";
+);
+
+// Rest{T} wrapper type tests for parent constructors
+
+test!(rest_tuple_parent_constructor => r#"
+  type MyTuple = a: i64, b: string, c: bool;
+  type MyFiltered = Rest{MyTuple};
+  export fn main {
+    let v: MyTuple = MyTuple(42, "hello", true);
+    let res: MyFiltered = MyFiltered(v);
+    res.b.print;
+    res.c.print;
+  }"#;
+  stdout "hello\ntrue\n";
+);
+
+test!(rest_tuple_parent_constructor_recursive => r#"
+  type Grandparent = a: i64, b: string, c: bool, d: f64;
+  type Parent = Rest{Grandparent};
+  type Child = Rest{Parent};
+  export fn main {
+    let gp: Grandparent = Grandparent(42, "hello", true, 3.14);
+    let p: Parent = Parent(gp);
+    let c: Child = Child(p);
+    c.c.print;
+    c.d.print;
+  }"#;
+  stdout "true\n3.14\n";
+);
+
+test!(rest_either_parent_constructor => r#"
+  type MyEither = i64 | string | bool;
+  type MyFiltered = Rest{MyEither};
+  export fn main {
+    let v: MyEither = "hello".MyEither;
+    let res: Maybe{MyFiltered} = MyFiltered(v);
+    if(res.exists,
+      fn { res.getOrExit.print; },
+      fn { 'void'.print; });
+  }"#;
+  stdout "hello\n";
+);
+
+test!(rest_either_parent_constructor_none => r#"
+  type MyEither = i64 | string | bool;
+  type MyFiltered = Rest{MyEither};
+  export fn main {
+    let v: MyEither = 42.MyEither;
+    let res: Maybe{MyFiltered} = MyFiltered(v);
+    if(res.exists,
+      fn { res.getOrExit.print; },
+      fn { 'void'.print; });
+  }"#;
+  stdout "void\n";
+);
+
+test!(rest_either_parent_constructor_recursive => r#"
+  type Grandparent = i64 | string | bool | f64;
+  type Parent = Rest{Grandparent};
+  type Child = Rest{Parent};
+  export fn main {
+    let gp: Grandparent = true.Grandparent;
+    let p: Maybe{Parent} = Parent(gp);
+    if(p.exists,
+      fn {
+        let c: Maybe{Child} = Child(p.getOrExit);
+        if(c.exists,
+          fn { c.getOrExit.print; },
+          fn { 'void'.print; });
+      },
+      fn { 'void'.print; });
+  }"#;
+  stdout "true\n";
+);
+
+test!(rest_either_parent_constructor_recursive_none => r#"
+  type Grandparent = i64 | string | bool | f64;
+  type Parent = Rest{Grandparent};
+  type Child = Rest{Parent};
+  export fn main {
+    let gp: Grandparent = "hello".Grandparent;
+    let p: Maybe{Parent} = Parent(gp);
+    if(p.exists,
+      fn {
+        let c: Maybe{Child} = Child(p.getOrExit);
+        if(c.exists,
+          fn { c.getOrExit.print; },
+          fn { 'void'.print; });
+      },
+      fn { 'void'.print; });
+  }"#;
+  stdout "void\n";
 );
 
 test!(either_dedup_single_unwrap => r#"

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -1956,3 +1956,95 @@ test!(either_dedup_single_unwrap => r#"
     }"#;
     stdout "8\n";
 );
+
+// First/Rest pattern matching for recursive Either processing
+
+test!(first_matches_first_variant => r#"
+    export fn main {
+      let v = Either{string, i64, bool}("hello");
+      first(v).print;
+    }"#;
+    stdout "hello\n";
+);
+
+test!(first_no_match_returns_void => r#"
+    export fn main {
+      let v = Either{string, i64, bool}(42);
+      first(v).print;
+    }"#;
+    stdout "void\n";
+);
+
+test!(first_with_two_variants => r#"
+    export fn main {
+      let v = Either{string, i64}("world");
+      first(v).print;
+    }"#;
+    stdout "world\n";
+);
+
+test!(first_with_two_variants_no_match => r#"
+    export fn main {
+      let v = Either{string, i64}(99);
+      first(v).print;
+    }"#;
+    stdout "void\n";
+);
+
+test!(rest_discards_first_variant => r#"
+    export fn main {
+      let v = Either{string, i64, bool}("hello");
+      rest(v);
+    }"#;
+    stdout "";
+);
+
+test!(rest_preserves_second_variant => r#"
+    export fn main {
+      let v = Either{string, i64, bool}(42);
+      first(rest(v)).print;
+    }"#;
+    stdout "42\n";
+);
+
+test!(rest_preserves_third_variant => r#"
+    export fn main {
+      let v = Either{string, i64, bool}(true);
+      first(rest(v)).print;
+    }"#;
+    stdout "void\n";
+);
+
+test!(rest_with_two_variants_discarded => r#"
+    export fn main {
+      let v = Either{string, i64}("hello");
+      rest(v).print;
+    }"#;
+    stdout "void\n";
+);
+
+test!(rest_with_two_variants_preserved => r#"
+    export fn main {
+      let v = Either{string, i64}(42);
+      rest(v).print;
+    }"#;
+    stdout "42\n";
+);
+
+test!(first_rest_chain => r#"
+    export fn main {
+      let v = Either{string, i64, bool}("hello");
+      first(v).print;
+      first(rest(v)).print;
+    }"#;
+    stdout "hello\nvoid\n";
+);
+
+test!(first_rest_chain_second => r#"
+    export fn main {
+      let v = Either{string, i64, bool}(42);
+      first(v).print;
+      first(rest(v)).print;
+    }"#;
+    stdout "void\n42\n";
+);

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -2008,3 +2008,72 @@ test!(exclude_tuple_parent_constructor_recursive => r#"
   }"#;
   stdout "42\ntrue\n";
 );
+
+// Exclude Either tests
+
+test!(exclude_either_by_index => r#"
+  type MyEither = i64 | string | bool;
+  type MyFiltered = Exclude{MyEither, 1};
+  export fn main {
+    let v: MyEither = 42.MyEither;
+    let res: MyFiltered = 42.MyFiltered;
+    res.print;
+  }"#;
+  stdout "42\n";
+);
+
+test!(exclude_either_by_index_first => r#"
+  type MyEither2 = i64 | string | bool;
+  type MyFiltered2 = Exclude{MyEither2, 0};
+  export fn main {
+    let v: MyEither2 = true.MyEither2;
+    let res: MyFiltered2 = true.MyFiltered2;
+    res.print;
+  }"#;
+  stdout "true\n";
+);
+
+test!(exclude_either_parent_constructor => r#"
+  type MyEither = i64 | string | bool;
+  type MyFiltered = Exclude{MyEither, 1};
+  export fn main {
+    let v: MyEither = 42.MyEither;
+    let res: Maybe{MyFiltered} = MyFiltered(v);
+    if(res.exists,
+      fn { res.getOrExit.print; },
+      fn { 'void'.print; });
+  }"#;
+  stdout "42\n";
+);
+
+test!(exclude_either_parent_constructor_none => r#"
+  type MyEither = i64 | string | bool;
+  type MyFiltered = Exclude{MyEither, 1};
+  export fn main {
+    let v: MyEither = "hello".MyEither;
+    let res: Maybe{MyFiltered} = MyFiltered(v);
+    if(res.exists,
+      fn { res.getOrExit.print; },
+      fn { 'void'.print; });
+  }"#;
+  stdout "void\n";
+);
+
+test!(exclude_either_parent_constructor_recursive => r#"
+  type Grandparent = i64 | string | bool | f64;
+  type Parent = Exclude{Grandparent, 3};
+  type Child = Exclude{Parent, 1};
+  export fn main {
+    let gp: Grandparent = 42.Grandparent;
+    let p: Maybe{Parent} = Parent(gp);
+    if(p.exists,
+      fn {
+        let c: Maybe{Child} = Child(p.getOrExit);
+        if(c.exists,
+          fn { c.getOrExit.print; },
+          fn { 'void'.print; });
+      },
+      fn { 'void'.print; });
+  }"#;
+  stdout "42\n";
+);

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -2170,9 +2170,104 @@ test!(exclude_either_parent_constructor_recursive => r#"
   stdout "42\n";
 );
 
-// -.(dot-dash) Exclude operator syntax tests
+// Transitive parent constructor tests: constructing Child directly from Grandparent
 
-test!(exclude_tuple_dotdash_chained => r#"
+test!(exclude_either_parent_constructor_direct_from_grandparent => r#"
+  type Grandparent = i64 | string | bool | f64;
+  type Parent = Exclude{Grandparent, 3};
+  type Child = Exclude{Parent, 1};
+  export fn main {
+    let gp: Grandparent = 42.Grandparent;
+    let c: Maybe{Child} = Child(gp);
+    if(c.exists,
+      fn { c.getOrExit.print; },
+      fn { 'void'.print; });
+  }"#;
+  stdout "42\n";
+);
+
+test!(exclude_either_parent_constructor_direct_none => r#"
+  type Grandparent = i64 | string | bool | f64;
+  type Parent = Exclude{Grandparent, 3};
+  type Child = Exclude{Parent, 1};
+  export fn main {
+    let gp: Grandparent = "hello".Grandparent;
+    let c: Maybe{Child} = Child(gp);
+    if(c.exists,
+      fn { c.getOrExit.print; },
+      fn { 'void'.print; });
+  }"#;
+  stdout "void\n";
+);
+
+test!(exclude_tuple_parent_constructor_direct_from_grandparent => r#"
+  type Grandparent = a: i64, b: string, c: bool, d: f64;
+  type Parent = Exclude{Grandparent, 3};
+  type Child = Exclude{Parent, 1};
+  export fn main {
+    let gp: Grandparent = Grandparent(42, "hello", true, 3.14);
+    let c: Child = Child(gp);
+    c.a.print;
+    c.c.print;
+  }"#;
+  stdout "42\ntrue\n";
+);
+
+// Single-element and void reduction tests
+
+test!(exclude_tuple_single_element_remains_tuple => r#"
+  type MyTuple = a: i64, b: string;
+  type MySingle = Exclude{MyTuple, 1};
+  export fn main {
+    let v: MyTuple = MyTuple(42, "hello");
+    let res: MySingle = MySingle(v);
+    res.a.print;
+  }"#;
+  stdout "42\n";
+);
+
+test!(exclude_either_single_element_remains_either => r#"
+  type MyEither = i64 | string | bool;
+  type MySingle = Exclude{MyEither, 1};
+  export fn main {
+    let v: MyEither = 42.MyEither;
+    let res: Maybe{MySingle} = MySingle(v);
+    if(res.exists,
+      fn { res.getOrExit.i64.print; },
+      fn { 'void'.print; });
+  }"#;
+  stdout "42\n";
+);
+
+test!(exclude_tuple_to_void => r#"
+  type MyTuple = a: i64, b: string;
+  type MyPartial = Exclude{MyTuple, 1};
+  type MyVoid = Exclude{MyPartial, 0};
+  export fn main {
+    let v: MyTuple = MyTuple(42, "hello");
+    let p: MyPartial = MyPartial(v);
+    let res: MyVoid = MyVoid(p);
+    res.print;
+  }"#;
+  stdout "void\n";
+);
+
+test!(exclude_either_to_void => r#"
+  type MyEither = i64 | string;
+  type MySingle = Exclude{MyEither, 1};
+  type MyVoid = Exclude{MySingle, 0};
+  export fn main {
+    let v: MyEither = 42.MyEither;
+    let s: Maybe{MySingle} = MySingle(v);
+    let res: MyVoid = MyVoid(s.getOrExit);
+    res.print;
+  }"#;
+  stdout "void\n";
+);
+
+// -.(dash-dot) "subtract property" Exclude operator syntax tests
+
+test!(exclude_tuple_dashdot_chained => r#"
   type MyTuple = a: i64, b: string, c: bool;
   type MySingle = MyTuple-.a-.c;
   export fn main {

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -335,6 +335,52 @@ pub fn from_microstatement(
                     Err("Generic functions should have been resolved before reaching here".into())
                 }
                 FnKind::Normal | FnKind::External(_) => {
+                    // Special handling for first_either and rest_either
+                    if function.name == "first_either" || function.name == "rest_either" {
+                        if args.len() == 1 {
+                            let arg_type = args[0].get_type().degroup();
+                            if let CType::Either(ts) = &*arg_type.clone() {
+                                let (a, o, d) = from_microstatement(&args[0], scope, parent_fn, out, deps)?;
+                                out = o;
+                                deps = d;
+                                let get_check = |t: &Arc<CType>| -> String {
+                                    let cls = match &**t {
+                                        CType::Int(_) | CType::Float(_) => return format!("(typeof {} !== 'undefined')", a),
+                                        CType::TString(_) => "alan_std.Str",
+                                        CType::Type(n, _) if matches!(n.as_str(), "string" | "String") => "alan_std.Str",
+                                        CType::Type(n, _) if n == "i64" => "alan_std.I64",
+                                        CType::Type(n, _) if n == "f32" => "alan_std.F32",
+                                        CType::Type(n, _) if n == "f64" => "alan_std.F64",
+                                        CType::Type(n, _) if n == "i8" => "alan_std.I8",
+                                        CType::Type(n, _) if n == "i16" => "alan_std.I16",
+                                        CType::Type(n, _) if n == "i32" => "alan_std.I32",
+                                        CType::Type(n, _) if n == "u8" => "alan_std.U8",
+                                        CType::Type(n, _) if n == "u16" => "alan_std.U16",
+                                        CType::Type(n, _) if n == "u32" => "alan_std.U32",
+                                        CType::Type(n, _) if n == "u64" => "alan_std.U64",
+                                        CType::Type(n, _) if n == "bool" => "alan_std.Bool",
+                                        CType::Type(n, _) => n,
+                                        CType::Field(n, _) => n,
+                                        _ => &t.clone().to_callable_string(),
+                                    };
+                                    format!("({} instanceof {})", a, cls)
+                                };
+                                if function.name == "first_either" {
+                                    if ts.is_empty() {
+                                        return Ok(("null".to_string(), out, deps));
+                                    }
+                                    let check = get_check(&ts[0]);
+                                    return Ok((format!("({} ? {} : null)", check, a), out, deps));
+                                } else if function.name == "rest_either" {
+                                    if ts.len() <= 1 {
+                                        return Ok(("null".to_string(), out, deps));
+                                    }
+                                    let check = get_check(&ts[0]);
+                                    return Ok((format!("(!({}) ? {} : null)", check, a), out, deps));
+                                }
+                            }
+                        }
+                    }
                     let (_, o, d) = typen::generate(function.rettype(), out, deps)?;
                     out = o;
                     deps = d;
@@ -409,6 +455,52 @@ pub fn from_microstatement(
                     ))
                 }
                 FnKind::Bind(jsname) | FnKind::ExternalBind(jsname, _) => {
+                    // Special handling for first_either and rest_either
+                    if jsname == "first_either" || jsname == "rest_either" {
+                        if args.len() == 1 {
+                            let arg_type = args[0].get_type().degroup();
+                            if let CType::Either(ts) = &*arg_type.clone() {
+                                let (a, o, d) = from_microstatement(&args[0], scope, parent_fn, out, deps)?;
+                                out = o;
+                                deps = d;
+                                let get_check = |t: &Arc<CType>| -> String {
+                                    let cls = match &**t {
+                                        CType::Int(_) | CType::Float(_) => return format!("(typeof {} !== 'undefined')", a),
+                                        CType::TString(_) => "alan_std.Str",
+                                        CType::Type(n, _) if matches!(n.as_str(), "string" | "String") => "alan_std.Str",
+                                        CType::Type(n, _) if n == "i64" => "alan_std.I64",
+                                        CType::Type(n, _) if n == "f32" => "alan_std.F32",
+                                        CType::Type(n, _) if n == "f64" => "alan_std.F64",
+                                        CType::Type(n, _) if n == "i8" => "alan_std.I8",
+                                        CType::Type(n, _) if n == "i16" => "alan_std.I16",
+                                        CType::Type(n, _) if n == "i32" => "alan_std.I32",
+                                        CType::Type(n, _) if n == "u8" => "alan_std.U8",
+                                        CType::Type(n, _) if n == "u16" => "alan_std.U16",
+                                        CType::Type(n, _) if n == "u32" => "alan_std.U32",
+                                        CType::Type(n, _) if n == "u64" => "alan_std.U64",
+                                        CType::Type(n, _) if n == "bool" => "alan_std.Bool",
+                                        CType::Type(n, _) => n,
+                                        CType::Field(n, _) => n,
+                                        _ => &t.clone().to_callable_string(),
+                                    };
+                                    format!("({} instanceof {})", a, cls)
+                                };
+                                if jsname == "first_either" {
+                                    if ts.is_empty() {
+                                        return Ok(("null".to_string(), out, deps));
+                                    }
+                                    let check = get_check(&ts[0]);
+                                    return Ok((format!("({} ? {} : null)", check, a), out, deps));
+                                } else {
+                                    if ts.len() <= 1 {
+                                        return Ok(("null".to_string(), out, deps));
+                                    }
+                                    let check = get_check(&ts[0]);
+                                    return Ok((format!("(!({}) ? {} : null)", check, a), out, deps));
+                                }
+                            }
+                        }
+                    }
                     let mut argstrs = Vec::new();
                     for arg in args {
                         let (a, o, d) = from_microstatement(arg, scope, parent_fn, out, deps)?;
@@ -641,6 +733,60 @@ pub fn from_microstatement(
                                 return Ok((format!("{}.arg0", argstrs[0]), out, deps));
                             }
                             CType::Either(ts) => {
+                                // Helper to get JS class name for a type
+                                let get_js_class = |t: &Arc<CType>| -> String {
+                                    match &**t {
+                                        CType::TString(_) => "alan_std.Str".to_string(),
+                                        CType::Type(n, _) => match n.as_str() {
+                                            "string" | "String" => "alan_std.Str".to_string(),
+                                            "f32" => "alan_std.F32".to_string(),
+                                            "f64" => "alan_std.F64".to_string(),
+                                            "i8" => "alan_std.I8".to_string(),
+                                            "i16" => "alan_std.I16".to_string(),
+                                            "i32" => "alan_std.I32".to_string(),
+                                            "i64" => "alan_std.I64".to_string(),
+                                            "u8" => "alan_std.U8".to_string(),
+                                            "u16" => "alan_std.U16".to_string(),
+                                            "u32" => "alan_std.U32".to_string(),
+                                            "u64" => "alan_std.U64".to_string(),
+                                            "bool" => "alan_std.Bool".to_string(),
+                                            _ => n.clone(),
+                                        },
+                                        CType::Field(n, _) => n.clone(),
+                                        _ => t.clone().to_callable_string(),
+                                    }
+                                };
+                                // Helper to get instanceof check for a type
+                                let get_instanceof = |t: &Arc<CType>, var: &str| -> String {
+                                    match &**t {
+                                        CType::Int(_) | CType::Float(_) => format!("(typeof {} !== 'undefined')", var),
+                                        _ => format!("({} instanceof {})", var, get_js_class(t)),
+                                    }
+                                };
+                                // Special handling for first{T} function
+                                if function.name == "first" {
+                                    if ts.is_empty() {
+                                        return Ok(("null".to_string(), out, deps));
+                                    }
+                                    let check = get_instanceof(&ts[0], &argstrs[0]);
+                                    return Ok((
+                                        format!("({} ? {} : null)", check, argstrs[0]),
+                                        out,
+                                        deps,
+                                    ));
+                                }
+                                // Special handling for rest{T} function
+                                if function.name == "rest" {
+                                    if ts.len() <= 1 {
+                                        return Ok(("null".to_string(), out, deps));
+                                    }
+                                    let check = get_instanceof(&ts[0], &argstrs[0]);
+                                    return Ok((
+                                        format!("(!({}) ? {} : null)", check, argstrs[0]),
+                                        out,
+                                        deps,
+                                    ));
+                                }
                                 // The kinds of types allowed here are `Type`, `Bound`, and
                                 // `ResolvedBoundGeneric`, and `Field`. Other types don't have
                                 // a string name we can match against the function name

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -1540,6 +1540,10 @@ pub fn from_microstatement(
                             CType::Binds(..) => {
                                 return Ok((argstrs.join(", "), out, deps));
                             }
+                            CType::Void | CType::DerivedVoid(..) => {
+                                // DerivedVoid parent constructor: takes parent, returns void
+                                return Ok(("undefined".to_string(), out, deps));
+                            }
                             otherwise => {
                                 return Err(format!("How did you get here? Trying to create a constructor function {function:?} for {otherwise:?}").into());
                             }
@@ -1717,7 +1721,7 @@ pub fn generate(
     }
     let ret = function.rettype().degroup();
     match &*ret {
-        CType::Void => { /* Do nothing */ }
+        CType::Void | CType::DerivedVoid(..) => { /* Do nothing */ }
         CType::Type(n, _) if n == "void" => { /* Do nothing */ }
         _otherwise => {
             let (_, o, d) = typen::generate(ret, out, deps)?;

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -1281,6 +1281,49 @@ pub fn from_microstatement(
                                         _ => {}
                                     }
                                 }
+                                // Check for parent constructor: single argument whose type is an
+                                // Either containing a superset of the child's variants
+                                if argstrs.len() == 1 {
+                                    let single_arg_type = match &function.args().first() {
+                                        Some(t) => t.2.clone().degroup(),
+                                        None => Arc::new(CType::Void),
+                                    };
+                                    if let CType::Either(parent_variants, _) = &*single_arg_type {
+                                        // Find which parent variants match child variants
+                                        let mut matched_types: Vec<String> = Vec::new();
+                                        for pv in parent_variants.iter() {
+                                            let parent_key = pv.clone().degroup().to_callable_string();
+                                            for cv in ts {
+                                                if cv.clone().degroup().to_callable_string() == parent_key {
+                                                    matched_types.push(parent_key);
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        if !matched_types.is_empty() && matched_types.len() < parent_variants.len() {
+                                            let parent_arg = match argstrs[0].strip_prefix("&mut ")
+                                            {
+                                                Some(s) => s.to_string(),
+                                                None => argstrs[0].clone(),
+                                            };
+                                            // Generate type check: if (typeof arg === 'type') return arg; else return null;
+                                            let type_checks: Vec<String> = matched_types.iter().map(|t| {
+                                                match t.as_str() {
+                                                    "i64" | "u64" | "f64" => format!("typeof {} === 'number'", parent_arg),
+                                                    "string" => format!("typeof {} === 'string'", parent_arg),
+                                                    "bool" => format!("typeof {} === 'boolean'", parent_arg),
+                                                    _ => format!("{}.type === '{}'", parent_arg, t),
+                                                }
+                                            }).collect();
+                                            let condition = type_checks.join(" || ");
+                                            return Ok((
+                                                format!("({} ? {} : null)", condition, parent_arg),
+                                                out,
+                                                deps,
+                                            ));
+                                        }
+                                    }
+                                }
                                 return Err(format!("Cannot generate a constructor function for {} type as it is not part of the {} type", enum_name, function.name).into());
                             }
                             CType::Tuple(ts, _) => {
@@ -1448,6 +1491,75 @@ pub fn from_microstatement(
                             }
                             otherwise => {
                                 return Err(format!("How did you get here? Trying to create a constructor function {function:?} for {otherwise:?}").into());
+                            }
+                        }
+                    } else if function.args().len() == 1 {
+                        // Check for parent constructor: return type is Maybe{Child} and arg is a superset Either
+                        let ret_inner = match &*ret_type {
+                            CType::Either(ts, _) if ts.len() == 2 => {
+                                if let CType::Void = &*ts[1] {
+                                    Some(ts[0].clone())
+                                } else {
+                                    None
+                                }
+                            }
+                            _ => None,
+                        };
+                        if let Some(child_type_raw) = ret_inner {
+                            let mut child_type = child_type_raw.clone().degroup();
+                            loop {
+                                child_type = match &*child_type {
+                                    CType::Type(_, t) => t.clone(),
+                                    CType::Group(t) => t.clone(),
+                                    _ => break,
+                                };
+                            }
+                            let child_name = child_type.clone().to_callable_string();
+                            if function.name == child_name {
+                                let arg_type = function.args()[0].2.clone().degroup();
+                                if let CType::Either(parent_variants, _) = &*arg_type {
+                                    if let CType::Either(child_variants, _) = &*child_type {
+                                        let mut matched_types: Vec<String> = Vec::new();
+                                        for pv in parent_variants.iter() {
+                                            let parent_key = pv.clone().degroup().to_callable_string();
+                                            for cv in child_variants {
+                                                if cv.clone().degroup().to_callable_string() == parent_key {
+                                                    matched_types.push(parent_key);
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        if !matched_types.is_empty() && matched_types.len() < parent_variants.len() {
+                                            let parent_arg = match argstrs[0].strip_prefix("&mut ") {
+                                                Some(s) => s.to_string(),
+                                                None => argstrs[0].clone(),
+                                            };
+                                            let type_checks: Vec<String> = matched_types.iter().map(|t| {
+                                                match t.as_str() {
+                                                    "i64" => format!("{} instanceof alan_std.I64", parent_arg),
+                                                    "u64" => format!("{} instanceof alan_std.U64", parent_arg),
+                                                    "f64" => format!("{} instanceof alan_std.F64", parent_arg),
+                                                    "i32" => format!("{} instanceof alan_std.I32", parent_arg),
+                                                    "u32" => format!("{} instanceof alan_std.U32", parent_arg),
+                                                    "i16" => format!("{} instanceof alan_std.I16", parent_arg),
+                                                    "u16" => format!("{} instanceof alan_std.U16", parent_arg),
+                                                    "i8" => format!("{} instanceof alan_std.I8", parent_arg),
+                                                    "u8" => format!("{} instanceof alan_std.U8", parent_arg),
+                                                    "f32" => format!("{} instanceof alan_std.F32", parent_arg),
+                                                    "string" => format!("typeof {} === 'string'", parent_arg),
+                                                    "bool" => format!("{} instanceof alan_std.Bool", parent_arg),
+                                                    _ => format!("{}.type === '{}'", parent_arg, t),
+                                                }
+                                            }).collect();
+                                            let condition = type_checks.join(" || ");
+                                            return Ok((
+                                                format!("({} ? {} : null)", condition, parent_arg),
+                                                out,
+                                                deps,
+                                            ));
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -1292,29 +1292,80 @@ pub fn from_microstatement(
                                         // Find which parent variants match child variants
                                         let mut matched_types: Vec<String> = Vec::new();
                                         for pv in parent_variants.iter() {
-                                            let parent_key = pv.clone().degroup().to_callable_string();
+                                            let parent_key =
+                                                pv.clone().degroup().to_callable_string();
                                             for cv in ts {
-                                                if cv.clone().degroup().to_callable_string() == parent_key {
+                                                if cv.clone().degroup().to_callable_string()
+                                                    == parent_key
+                                                {
                                                     matched_types.push(parent_key);
                                                     break;
                                                 }
                                             }
                                         }
-                                        if !matched_types.is_empty() && matched_types.len() < parent_variants.len() {
+                                        if !matched_types.is_empty()
+                                            && matched_types.len() < parent_variants.len()
+                                        {
                                             let parent_arg = match argstrs[0].strip_prefix("&mut ")
                                             {
                                                 Some(s) => s.to_string(),
                                                 None => argstrs[0].clone(),
                                             };
                                             // Generate type check: if (typeof arg === 'type') return arg; else return null;
-                                            let type_checks: Vec<String> = matched_types.iter().map(|t| {
-                                                match t.as_str() {
-                                                    "i64" | "u64" | "f64" => format!("typeof {} === 'number'", parent_arg),
-                                                    "string" => format!("typeof {} === 'string'", parent_arg),
-                                                    "bool" => format!("typeof {} === 'boolean'", parent_arg),
+                                            let type_checks: Vec<String> = matched_types
+                                                .iter()
+                                                .map(|t| match t.as_str() {
+                                                    "i64" => format!(
+                                                        "{} instanceof alan_std.I64",
+                                                        parent_arg
+                                                    ),
+                                                    "u64" => format!(
+                                                        "{} instanceof alan_std.U64",
+                                                        parent_arg
+                                                    ),
+                                                    "f64" => format!(
+                                                        "{} instanceof alan_std.F64",
+                                                        parent_arg
+                                                    ),
+                                                    "i32" => format!(
+                                                        "{} instanceof alan_std.I32",
+                                                        parent_arg
+                                                    ),
+                                                    "u32" => format!(
+                                                        "{} instanceof alan_std.U32",
+                                                        parent_arg
+                                                    ),
+                                                    "i16" => format!(
+                                                        "{} instanceof alan_std.I16",
+                                                        parent_arg
+                                                    ),
+                                                    "u16" => format!(
+                                                        "{} instanceof alan_std.U16",
+                                                        parent_arg
+                                                    ),
+                                                    "i8" => format!(
+                                                        "{} instanceof alan_std.I8",
+                                                        parent_arg
+                                                    ),
+                                                    "u8" => format!(
+                                                        "{} instanceof alan_std.U8",
+                                                        parent_arg
+                                                    ),
+                                                    "f32" => format!(
+                                                        "{} instanceof alan_std.F32",
+                                                        parent_arg
+                                                    ),
+                                                    "string" => format!(
+                                                        "{} instanceof alan_std.Str",
+                                                        parent_arg
+                                                    ),
+                                                    "bool" => format!(
+                                                        "{} instanceof alan_std.Bool",
+                                                        parent_arg
+                                                    ),
                                                     _ => format!("{}.type === '{}'", parent_arg, t),
-                                                }
-                                            }).collect();
+                                                })
+                                                .collect();
                                             let condition = type_checks.join(" || ");
                                             return Ok((
                                                 format!("({} ? {} : null)", condition, parent_arg),
@@ -1521,36 +1572,79 @@ pub fn from_microstatement(
                                     if let CType::Either(child_variants, _) = &*child_type {
                                         let mut matched_types: Vec<String> = Vec::new();
                                         for pv in parent_variants.iter() {
-                                            let parent_key = pv.clone().degroup().to_callable_string();
+                                            let parent_key =
+                                                pv.clone().degroup().to_callable_string();
                                             for cv in child_variants {
-                                                if cv.clone().degroup().to_callable_string() == parent_key {
+                                                if cv.clone().degroup().to_callable_string()
+                                                    == parent_key
+                                                {
                                                     matched_types.push(parent_key);
                                                     break;
                                                 }
                                             }
                                         }
-                                        if !matched_types.is_empty() && matched_types.len() < parent_variants.len() {
-                                            let parent_arg = match argstrs[0].strip_prefix("&mut ") {
+                                        if !matched_types.is_empty()
+                                            && matched_types.len() < parent_variants.len()
+                                        {
+                                            let parent_arg = match argstrs[0].strip_prefix("&mut ")
+                                            {
                                                 Some(s) => s.to_string(),
                                                 None => argstrs[0].clone(),
                                             };
-                                            let type_checks: Vec<String> = matched_types.iter().map(|t| {
-                                                match t.as_str() {
-                                                    "i64" => format!("{} instanceof alan_std.I64", parent_arg),
-                                                    "u64" => format!("{} instanceof alan_std.U64", parent_arg),
-                                                    "f64" => format!("{} instanceof alan_std.F64", parent_arg),
-                                                    "i32" => format!("{} instanceof alan_std.I32", parent_arg),
-                                                    "u32" => format!("{} instanceof alan_std.U32", parent_arg),
-                                                    "i16" => format!("{} instanceof alan_std.I16", parent_arg),
-                                                    "u16" => format!("{} instanceof alan_std.U16", parent_arg),
-                                                    "i8" => format!("{} instanceof alan_std.I8", parent_arg),
-                                                    "u8" => format!("{} instanceof alan_std.U8", parent_arg),
-                                                    "f32" => format!("{} instanceof alan_std.F32", parent_arg),
-                                                    "string" => format!("typeof {} === 'string'", parent_arg),
-                                                    "bool" => format!("{} instanceof alan_std.Bool", parent_arg),
+                                            let type_checks: Vec<String> = matched_types
+                                                .iter()
+                                                .map(|t| match t.as_str() {
+                                                    "i64" => format!(
+                                                        "{} instanceof alan_std.I64",
+                                                        parent_arg
+                                                    ),
+                                                    "u64" => format!(
+                                                        "{} instanceof alan_std.U64",
+                                                        parent_arg
+                                                    ),
+                                                    "f64" => format!(
+                                                        "{} instanceof alan_std.F64",
+                                                        parent_arg
+                                                    ),
+                                                    "i32" => format!(
+                                                        "{} instanceof alan_std.I32",
+                                                        parent_arg
+                                                    ),
+                                                    "u32" => format!(
+                                                        "{} instanceof alan_std.U32",
+                                                        parent_arg
+                                                    ),
+                                                    "i16" => format!(
+                                                        "{} instanceof alan_std.I16",
+                                                        parent_arg
+                                                    ),
+                                                    "u16" => format!(
+                                                        "{} instanceof alan_std.U16",
+                                                        parent_arg
+                                                    ),
+                                                    "i8" => format!(
+                                                        "{} instanceof alan_std.I8",
+                                                        parent_arg
+                                                    ),
+                                                    "u8" => format!(
+                                                        "{} instanceof alan_std.U8",
+                                                        parent_arg
+                                                    ),
+                                                    "f32" => format!(
+                                                        "{} instanceof alan_std.F32",
+                                                        parent_arg
+                                                    ),
+                                                    "string" => format!(
+                                                        "{} instanceof alan_std.Str",
+                                                        parent_arg
+                                                    ),
+                                                    "bool" => format!(
+                                                        "{} instanceof alan_std.Bool",
+                                                        parent_arg
+                                                    ),
                                                     _ => format!("{}.type === '{}'", parent_arg, t),
-                                                }
-                                            }).collect();
+                                                })
+                                                .collect();
                                             let condition = type_checks.join(" || ");
                                             return Ok((
                                                 format!("({} ? {} : null)", condition, parent_arg),

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -335,52 +335,6 @@ pub fn from_microstatement(
                     Err("Generic functions should have been resolved before reaching here".into())
                 }
                 FnKind::Normal | FnKind::External(_) => {
-                    // Special handling for first_either and rest_either
-                    if function.name == "first_either" || function.name == "rest_either" {
-                        if args.len() == 1 {
-                            let arg_type = args[0].get_type().degroup();
-                            if let CType::Either(ts) = &*arg_type.clone() {
-                                let (a, o, d) = from_microstatement(&args[0], scope, parent_fn, out, deps)?;
-                                out = o;
-                                deps = d;
-                                let get_check = |t: &Arc<CType>| -> String {
-                                    let cls = match &**t {
-                                        CType::Int(_) | CType::Float(_) => return format!("(typeof {} !== 'undefined')", a),
-                                        CType::TString(_) => "alan_std.Str",
-                                        CType::Type(n, _) if matches!(n.as_str(), "string" | "String") => "alan_std.Str",
-                                        CType::Type(n, _) if n == "i64" => "alan_std.I64",
-                                        CType::Type(n, _) if n == "f32" => "alan_std.F32",
-                                        CType::Type(n, _) if n == "f64" => "alan_std.F64",
-                                        CType::Type(n, _) if n == "i8" => "alan_std.I8",
-                                        CType::Type(n, _) if n == "i16" => "alan_std.I16",
-                                        CType::Type(n, _) if n == "i32" => "alan_std.I32",
-                                        CType::Type(n, _) if n == "u8" => "alan_std.U8",
-                                        CType::Type(n, _) if n == "u16" => "alan_std.U16",
-                                        CType::Type(n, _) if n == "u32" => "alan_std.U32",
-                                        CType::Type(n, _) if n == "u64" => "alan_std.U64",
-                                        CType::Type(n, _) if n == "bool" => "alan_std.Bool",
-                                        CType::Type(n, _) => n,
-                                        CType::Field(n, _) => n,
-                                        _ => &t.clone().to_callable_string(),
-                                    };
-                                    format!("({} instanceof {})", a, cls)
-                                };
-                                if function.name == "first_either" {
-                                    if ts.is_empty() {
-                                        return Ok(("null".to_string(), out, deps));
-                                    }
-                                    let check = get_check(&ts[0]);
-                                    return Ok((format!("({} ? {} : null)", check, a), out, deps));
-                                } else if function.name == "rest_either" {
-                                    if ts.len() <= 1 {
-                                        return Ok(("null".to_string(), out, deps));
-                                    }
-                                    let check = get_check(&ts[0]);
-                                    return Ok((format!("(!({}) ? {} : null)", check, a), out, deps));
-                                }
-                            }
-                        }
-                    }
                     let (_, o, d) = typen::generate(function.rettype(), out, deps)?;
                     out = o;
                     deps = d;
@@ -455,52 +409,6 @@ pub fn from_microstatement(
                     ))
                 }
                 FnKind::Bind(jsname) | FnKind::ExternalBind(jsname, _) => {
-                    // Special handling for first_either and rest_either
-                    if jsname == "first_either" || jsname == "rest_either" {
-                        if args.len() == 1 {
-                            let arg_type = args[0].get_type().degroup();
-                            if let CType::Either(ts) = &*arg_type.clone() {
-                                let (a, o, d) = from_microstatement(&args[0], scope, parent_fn, out, deps)?;
-                                out = o;
-                                deps = d;
-                                let get_check = |t: &Arc<CType>| -> String {
-                                    let cls = match &**t {
-                                        CType::Int(_) | CType::Float(_) => return format!("(typeof {} !== 'undefined')", a),
-                                        CType::TString(_) => "alan_std.Str",
-                                        CType::Type(n, _) if matches!(n.as_str(), "string" | "String") => "alan_std.Str",
-                                        CType::Type(n, _) if n == "i64" => "alan_std.I64",
-                                        CType::Type(n, _) if n == "f32" => "alan_std.F32",
-                                        CType::Type(n, _) if n == "f64" => "alan_std.F64",
-                                        CType::Type(n, _) if n == "i8" => "alan_std.I8",
-                                        CType::Type(n, _) if n == "i16" => "alan_std.I16",
-                                        CType::Type(n, _) if n == "i32" => "alan_std.I32",
-                                        CType::Type(n, _) if n == "u8" => "alan_std.U8",
-                                        CType::Type(n, _) if n == "u16" => "alan_std.U16",
-                                        CType::Type(n, _) if n == "u32" => "alan_std.U32",
-                                        CType::Type(n, _) if n == "u64" => "alan_std.U64",
-                                        CType::Type(n, _) if n == "bool" => "alan_std.Bool",
-                                        CType::Type(n, _) => n,
-                                        CType::Field(n, _) => n,
-                                        _ => &t.clone().to_callable_string(),
-                                    };
-                                    format!("({} instanceof {})", a, cls)
-                                };
-                                if jsname == "first_either" {
-                                    if ts.is_empty() {
-                                        return Ok(("null".to_string(), out, deps));
-                                    }
-                                    let check = get_check(&ts[0]);
-                                    return Ok((format!("({} ? {} : null)", check, a), out, deps));
-                                } else {
-                                    if ts.len() <= 1 {
-                                        return Ok(("null".to_string(), out, deps));
-                                    }
-                                    let check = get_check(&ts[0]);
-                                    return Ok((format!("(!({}) ? {} : null)", check, a), out, deps));
-                                }
-                            }
-                        }
-                    }
                     let mut argstrs = Vec::new();
                     for arg in args {
                         let (a, o, d) = from_microstatement(arg, scope, parent_fn, out, deps)?;
@@ -686,7 +594,7 @@ pub fn from_microstatement(
                             };
                         }
                         match &*input_type {
-                            CType::Tuple(ts) => {
+                            CType::Tuple(ts, _) => {
                                 // Short-circuit for direct `<N>` function calls (which can only be
                                 // generated by the internals of the compiler)
                                 if let Ok(i) = function.name.parse::<i64>() {
@@ -732,61 +640,7 @@ pub fn from_microstatement(
                             CType::Field(..) => {
                                 return Ok((format!("{}.arg0", argstrs[0]), out, deps));
                             }
-                            CType::Either(ts) => {
-                                // Helper to get JS class name for a type
-                                let get_js_class = |t: &Arc<CType>| -> String {
-                                    match &**t {
-                                        CType::TString(_) => "alan_std.Str".to_string(),
-                                        CType::Type(n, _) => match n.as_str() {
-                                            "string" | "String" => "alan_std.Str".to_string(),
-                                            "f32" => "alan_std.F32".to_string(),
-                                            "f64" => "alan_std.F64".to_string(),
-                                            "i8" => "alan_std.I8".to_string(),
-                                            "i16" => "alan_std.I16".to_string(),
-                                            "i32" => "alan_std.I32".to_string(),
-                                            "i64" => "alan_std.I64".to_string(),
-                                            "u8" => "alan_std.U8".to_string(),
-                                            "u16" => "alan_std.U16".to_string(),
-                                            "u32" => "alan_std.U32".to_string(),
-                                            "u64" => "alan_std.U64".to_string(),
-                                            "bool" => "alan_std.Bool".to_string(),
-                                            _ => n.clone(),
-                                        },
-                                        CType::Field(n, _) => n.clone(),
-                                        _ => t.clone().to_callable_string(),
-                                    }
-                                };
-                                // Helper to get instanceof check for a type
-                                let get_instanceof = |t: &Arc<CType>, var: &str| -> String {
-                                    match &**t {
-                                        CType::Int(_) | CType::Float(_) => format!("(typeof {} !== 'undefined')", var),
-                                        _ => format!("({} instanceof {})", var, get_js_class(t)),
-                                    }
-                                };
-                                // Special handling for first{T} function
-                                if function.name == "first" {
-                                    if ts.is_empty() {
-                                        return Ok(("null".to_string(), out, deps));
-                                    }
-                                    let check = get_instanceof(&ts[0], &argstrs[0]);
-                                    return Ok((
-                                        format!("({} ? {} : null)", check, argstrs[0]),
-                                        out,
-                                        deps,
-                                    ));
-                                }
-                                // Special handling for rest{T} function
-                                if function.name == "rest" {
-                                    if ts.len() <= 1 {
-                                        return Ok(("null".to_string(), out, deps));
-                                    }
-                                    let check = get_instanceof(&ts[0], &argstrs[0]);
-                                    return Ok((
-                                        format!("(!({}) ? {} : null)", check, argstrs[0]),
-                                        out,
-                                        deps,
-                                    ));
-                                }
+                            CType::Either(ts, _) => {
                                 // The kinds of types allowed here are `Type`, `Bound`, and
                                 // `ResolvedBoundGeneric`, and `Field`. Other types don't have
                                 // a string name we can match against the function name
@@ -901,7 +755,7 @@ pub fn from_microstatement(
                             CType::Type(_, t) => t.clone(),
                             _ => inner_ret_type,
                         };
-                        if let CType::Either(_) = &*inner_ret_type {
+                        if let CType::Either(_, _) = &*inner_ret_type {
                             return Ok(("null".to_string(), out, deps));
                         }
                     }
@@ -914,7 +768,7 @@ pub fn from_microstatement(
                             _ => ret_type,
                         };
                         match &*inner_ret_type {
-                            CType::Either(ts) => {
+                            CType::Either(ts, _) => {
                                 if argstrs.len() != 2 {
                                     return Err(format!("Invalid arguments {} provided for Either re-assignment function, must be two arguments", argstrs.join(", ")).into());
                                 }
@@ -1088,7 +942,7 @@ pub fn from_microstatement(
                             CType::Array(_) => {
                                 return Ok((format!("[{}]", argstrs.join(", ")), out, deps));
                             }
-                            CType::Either(ts) => {
+                            CType::Either(ts, _) => {
                                 if argstrs.len() > 1 {
                                     return Err(format!("Invalid arguments {} provided for Either constructor function, must be zero or one argument", argstrs.join(", ")).into());
                                 }
@@ -1101,7 +955,7 @@ pub fn from_microstatement(
                                     CType::Type(n, _) => Ok(n.clone()),
                                     CType::Array(_) => Ok(enum_type.clone().to_callable_string()),
                                     CType::Binds(..) => Ok(enum_type.clone().to_callable_string()),
-                                    CType::Tuple(_) => Ok(enum_type.clone().to_callable_string()),
+                                    CType::Tuple(_, _) => Ok(enum_type.clone().to_callable_string()),
                                     otherwise => Err(format!("Cannot generate an constructor function for {} type as the input type has no name?, {:?}", function.name, otherwise)),
                                 }?;
                                 for t in ts {
@@ -1110,7 +964,7 @@ pub fn from_microstatement(
                                         CType::Array(_) => {
                                             return Ok((argstrs[0].clone(), out, deps));
                                         }
-                                        CType::Tuple(ts)
+                                        CType::Tuple(ts, _)
                                             if inner_type.clone().to_callable_string()
                                                 == enum_name =>
                                         {
@@ -1429,9 +1283,99 @@ pub fn from_microstatement(
                                 }
                                 return Err(format!("Cannot generate a constructor function for {} type as it is not part of the {} type", enum_name, function.name).into());
                             }
-                            CType::Tuple(ts) => {
+                            CType::Tuple(ts, _) => {
                                 // TODO: Better type checking here, but it's *probably* being
                                 // done at a higher layer
+                                // Check for parent constructor: single argument whose type is a
+                                // Tuple/Either containing a superset of the child's fields
+                                if argstrs.len() == 1 {
+                                    let single_arg_type = match &function.args().first() {
+                                        Some(t) => t.2.clone().degroup(),
+                                        None => Arc::new(CType::Void),
+                                    };
+                                    if let Some(parent_fields) = match &*single_arg_type {
+                                        CType::Tuple(pf, _) => Some(pf.clone()),
+                                        CType::Either(pf, _) => Some(pf.clone()),
+                                        _ => None,
+                                    } {
+                                        let child_fields: Vec<&Arc<CType>> = ts
+                                            .iter()
+                                            .filter(|t| match &***t {
+                                                CType::Field(_, t) => !matches!(
+                                                    &**t,
+                                                    CType::Int(_)
+                                                        | CType::Float(_)
+                                                        | CType::Bool(_)
+                                                        | CType::TString(_),
+                                                ),
+                                                CType::Int(_)
+                                                | CType::Float(_)
+                                                | CType::Bool(_)
+                                                | CType::TString(_) => false,
+                                                _ => true,
+                                            })
+                                            .collect();
+                                        let mut parent_indices: Vec<usize> = Vec::new();
+                                        let mut all_matched = true;
+                                        for child_field in &child_fields {
+                                            let child_key = (*child_field)
+                                                .clone()
+                                                .degroup()
+                                                .to_callable_string();
+                                            let mut found = false;
+                                            for (idx, pf) in parent_fields.iter().enumerate() {
+                                                if pf.clone().degroup().to_callable_string()
+                                                    == child_key
+                                                {
+                                                    parent_indices.push(idx);
+                                                    found = true;
+                                                    break;
+                                                }
+                                            }
+                                            if !found {
+                                                all_matched = false;
+                                                break;
+                                            }
+                                        }
+                                        if all_matched && !parent_indices.is_empty() {
+                                            let parent_arg = match argstrs[0].strip_prefix("&mut ")
+                                            {
+                                                Some(s) => s.to_string(),
+                                                None => argstrs[0].clone(),
+                                            };
+                                            // Build { childField: parent.childField, ... }
+                                            let field_assigns: Vec<String> = child_fields
+                                                .iter()
+                                                .zip(parent_indices.iter())
+                                                .map(|(cf, pi)| {
+                                                    let child_name = match &***cf {
+                                                        CType::Field(n, _) => n.clone(),
+                                                        _ => format!(
+                                                            "arg{}",
+                                                            (**cf)
+                                                                .clone()
+                                                                .to_callable_string()
+                                                                .len()
+                                                        ),
+                                                    };
+                                                    let parent_name = match &*parent_fields[*pi] {
+                                                        CType::Field(n, _) => n.clone(),
+                                                        _ => format!("arg{}", pi),
+                                                    };
+                                                    format!(
+                                                        "{}: {}.{}",
+                                                        child_name, parent_arg, parent_name
+                                                    )
+                                                })
+                                                .collect();
+                                            return Ok((
+                                                format!("{{\n{}\n}}", field_assigns.join(",\n")),
+                                                out,
+                                                deps,
+                                            ));
+                                        }
+                                    }
+                                }
                                 let filtered_ts = ts
                                     .iter()
                                     .filter(|t| match &***t {

--- a/alan_compiler/src/lntojs/typen.rs
+++ b/alan_compiler/src/lntojs/typen.rs
@@ -10,7 +10,7 @@ pub fn ctype_to_jtype(
 ) -> Result<(String, OrderedHashMap<String, String>), Box<dyn std::error::Error>> {
     match &*ctype {
         CType::Mut(t) => ctype_to_jtype(t.clone(), deps),
-        CType::Void => Ok(("".to_string(), deps)),
+        CType::Void | CType::DerivedVoid(..) => Ok(("".to_string(), deps)),
         CType::Infer(s, _) => Err(format!(
             "Inferred type matching {s} was not realized before code generation"
         )
@@ -34,7 +34,7 @@ pub fn ctype_to_jtype(
                             let res = ctype_to_jtype(g.clone(), deps)?;
                             deps = res.1;
                         }
-                        CType::Void => { /* Do nothing */ }
+                        CType::Void | CType::DerivedVoid(..) => { /* Do nothing */ }
                         CType::Tuple(ts, _) => {
                             for t in ts {
                                 let res = ctype_to_jtype(t.clone(), deps)?;

--- a/alan_compiler/src/lntojs/typen.rs
+++ b/alan_compiler/src/lntojs/typen.rs
@@ -16,7 +16,7 @@ pub fn ctype_to_jtype(
         )
         .into()),
         CType::Type(n, t) => match &**t {
-            CType::Either(ts) => {
+        CType::Either(ts, _) => {
                 if ts.len() == 2 && (matches!(*ts[1], CType::Void) || matches!(&*ts[1], CType::Type(n, _) if n == "Error")) {
                     return Ok(("".to_string(), deps));
                 }
@@ -35,7 +35,7 @@ pub fn ctype_to_jtype(
                             deps = res.1;
                         }
                         CType::Void => { /* Do nothing */ }
-                        CType::Tuple(ts) => {
+                        CType::Tuple(ts, _) => {
                             for t in ts {
                                 let res = ctype_to_jtype(t.clone(), deps)?;
                                 deps = res.1;
@@ -56,7 +56,7 @@ pub fn ctype_to_jtype(
                 }
                 Ok(("".to_string(), deps))
             }
-            CType::Tuple(ts) => {
+            CType::Tuple(ts, _) => {
                 let mut out = Vec::new();
                 for (i, t) in ts.iter().enumerate() {
                     match &**t {
@@ -228,7 +228,7 @@ pub fn ctype_to_jtype(
             deps = res.1;
             Ok(("".to_string(), deps)) // TODO: What do we even do with this?
         }
-        CType::Tuple(ts) => {
+        CType::Tuple(ts, _) => {
             for t in ts {
                 let res = ctype_to_jtype(t.clone(), deps)?;
                 deps = res.1;
@@ -240,7 +240,7 @@ pub fn ctype_to_jtype(
             deps = res.1;
             Ok(("".to_string(), deps))
         }
-        CType::Either(ts) => {
+        CType::Either(ts, _) => {
             for t in ts {
                 let res = ctype_to_jtype(t.clone(), deps)?;
                 deps = res.1;

--- a/alan_compiler/src/lntors/function.rs
+++ b/alan_compiler/src/lntors/function.rs
@@ -1740,9 +1740,14 @@ pub fn from_microstatement(
                                                 .iter()
                                                 .map(|i| format!("{}.{}", parent_arg, i))
                                                 .collect();
-                                            // Tuples in Rust use (a, b, ...) syntax directly
+                                            // Tuples in Rust use (a, b, ...) syntax directly.
+                                            // Single-element tuples need a trailing comma: (v.1,)
                                             return Ok((
-                                                format!("({})", field_accesses.join(", ")),
+                                                if field_accesses.len() == 1 {
+                                                    format!("({},)", field_accesses[0])
+                                                } else {
+                                                    format!("({})", field_accesses.join(", "))
+                                                },
                                                 out,
                                                 deps,
                                             ));

--- a/alan_compiler/src/lntors/function.rs
+++ b/alan_compiler/src/lntors/function.rs
@@ -1829,6 +1829,10 @@ pub fn from_microstatement(
                             CType::Binds(..) => {
                                 return Ok((argstrs.join(", "), out, deps));
                             }
+                            CType::Void | CType::DerivedVoid(..) => {
+                                // DerivedVoid parent constructor: takes parent, returns void
+                                return Ok(("()".to_string(), out, deps));
+                            }
                             otherwise => {
                                 return Err(format!("How did you get here? Trying to create a constructor function {function:?} for {otherwise:?}").into());
                             }
@@ -2020,7 +2024,7 @@ pub fn generate(
     }
     let ret = function.rettype().degroup();
     let opt_ret_str = match &*ret {
-        CType::Void => None,
+        CType::Void | CType::DerivedVoid(..) => None,
         CType::Type(n, _) if n == "void" => None,
         _otherwise => {
             let (t_str, o, d) = typen::generate(ret, out, deps)?;

--- a/alan_compiler/src/lntors/function.rs
+++ b/alan_compiler/src/lntors/function.rs
@@ -1131,20 +1131,26 @@ pub fn from_microstatement(
                                         Some(t) => t.2.clone().degroup(),
                                         None => Arc::new(CType::Void),
                                     };
-                                    let parent_type_name = single_arg_type.clone().to_callable_string();
+                                    let parent_type_name =
+                                        single_arg_type.clone().to_callable_string();
                                     if let CType::Either(parent_variants, _) = &*single_arg_type {
                                         // Find which parent variants match child variants
                                         let mut matched_indices: Vec<usize> = Vec::new();
                                         for (idx, pv) in parent_variants.iter().enumerate() {
-                                            let parent_key = pv.clone().degroup().to_callable_string();
+                                            let parent_key =
+                                                pv.clone().degroup().to_callable_string();
                                             for cv in ts {
-                                                if cv.clone().degroup().to_callable_string() == parent_key {
+                                                if cv.clone().degroup().to_callable_string()
+                                                    == parent_key
+                                                {
                                                     matched_indices.push(idx);
                                                     break;
                                                 }
                                             }
                                         }
-                                        if !matched_indices.is_empty() && matched_indices.len() < parent_variants.len() {
+                                        if !matched_indices.is_empty()
+                                            && matched_indices.len() < parent_variants.len()
+                                        {
                                             let parent_arg = match argstrs[0].strip_prefix("&mut ")
                                             {
                                                 Some(s) => s.to_string(),
@@ -1153,7 +1159,8 @@ pub fn from_microstatement(
                                             // Generate match expression: Some(Child::Variant(v)) for matched, None for excluded
                                             let mut arms = Vec::new();
                                             for (idx, pv) in parent_variants.iter().enumerate() {
-                                                let variant_name = pv.clone().degroup().to_callable_string();
+                                                let variant_name =
+                                                    pv.clone().degroup().to_callable_string();
                                                 if matched_indices.contains(&idx) {
                                                     arms.push(format!(
                                                         "{}::{}(v) => Some({}::{}(v))",
@@ -1165,13 +1172,16 @@ pub fn from_microstatement(
                                                 } else {
                                                     arms.push(format!(
                                                         "{}::{}(_) => None",
-                                                        parent_type_name,
-                                                        variant_name
+                                                        parent_type_name, variant_name
                                                     ));
                                                 }
                                             }
                                             return Ok((
-                                                format!("match {} {{\n    {}\n}}", parent_arg, arms.join(",\n    ")),
+                                                format!(
+                                                    "match {} {{\n    {}\n}}",
+                                                    parent_arg,
+                                                    arms.join(",\n    ")
+                                                ),
                                                 out,
                                                 deps,
                                             ));
@@ -1660,8 +1670,8 @@ pub fn from_microstatement(
                                                 deps,
                                             ));
                                         }
-                                     }
-                                 }
+                                    }
+                                }
                                 return Err(format!("Cannot generate a constructor function for {} type as it is not part of the {} type", enum_name, function.name).into());
                             }
                             CType::Tuple(ts, _) => {
@@ -1848,22 +1858,29 @@ pub fn from_microstatement(
                                     if let CType::Either(child_variants, _) = &*child_type {
                                         let mut matched_indices: Vec<usize> = Vec::new();
                                         for (idx, pv) in parent_variants.iter().enumerate() {
-                                            let parent_key = pv.clone().degroup().to_callable_string();
+                                            let parent_key =
+                                                pv.clone().degroup().to_callable_string();
                                             for cv in child_variants {
-                                                if cv.clone().degroup().to_callable_string() == parent_key {
+                                                if cv.clone().degroup().to_callable_string()
+                                                    == parent_key
+                                                {
                                                     matched_indices.push(idx);
                                                     break;
                                                 }
                                             }
                                         }
-                                        if !matched_indices.is_empty() && matched_indices.len() < parent_variants.len() {
-                                            let parent_arg = match argstrs[0].strip_prefix("&mut ") {
+                                        if !matched_indices.is_empty()
+                                            && matched_indices.len() < parent_variants.len()
+                                        {
+                                            let parent_arg = match argstrs[0].strip_prefix("&mut ")
+                                            {
                                                 Some(s) => s.to_string(),
                                                 None => argstrs[0].clone(),
                                             };
                                             let mut arms = Vec::new();
                                             for (idx, pv) in parent_variants.iter().enumerate() {
-                                                let variant_name = pv.clone().degroup().to_callable_string();
+                                                let variant_name =
+                                                    pv.clone().degroup().to_callable_string();
                                                 if matched_indices.contains(&idx) {
                                                     arms.push(format!(
                                                         "{}::{}(v) => Some({}::{}(v))",
@@ -1875,13 +1892,16 @@ pub fn from_microstatement(
                                                 } else {
                                                     arms.push(format!(
                                                         "{}::{}(_) => None",
-                                                        parent_type_name,
-                                                        variant_name
+                                                        parent_type_name, variant_name
                                                     ));
                                                 }
                                             }
                                             return Ok((
-                                                format!("match {} {{\n    {}\n}}", parent_arg, arms.join(",\n    ")),
+                                                format!(
+                                                    "match {} {{\n    {}\n}}",
+                                                    parent_arg,
+                                                    arms.join(",\n    ")
+                                                ),
                                                 out,
                                                 deps,
                                             ));

--- a/alan_compiler/src/lntors/function.rs
+++ b/alan_compiler/src/lntors/function.rs
@@ -403,7 +403,7 @@ pub fn from_microstatement(
                     if args.len() == 1 {
                         let arg_type = args[0].get_type().degroup();
                         if let CType::Either(ts) = &*arg_type.clone() {
-                            let rest_type = CType::trest(arg_type.clone());
+                            let rest_type = CType::exclude(arg_type.clone(), Arc::new(CType::Int(0)));
                             if ts.len() <= 1 {
                                 return Ok(("void".to_string(), out, deps));
                             }
@@ -859,7 +859,7 @@ pub fn from_microstatement(
                                     ));
                                 }
                                 if function.name == "rest" {
-                                    let rest_type = CType::trest(function.args()[0].2.clone());
+                                    let rest_type = CType::exclude(function.args()[0].2.clone(), Arc::new(CType::Int(0)));
                                     let rest_enum_name = rest_type.clone().to_callable_string();
                                     let (_rest_rtype, new_deps) = typen::ctype_to_rtype(rest_type.clone(), deps)?;
                                     deps = new_deps;

--- a/alan_compiler/src/lntors/function.rs
+++ b/alan_compiler/src/lntors/function.rs
@@ -373,125 +373,6 @@ pub fn from_microstatement(
                         out,
                         deps,
                     ));
-                } else if fname == "first_either" {
-                    if args.len() == 1 {
-                        let arg_type = args[0].get_type().degroup();
-                        if let CType::Either(ts) = &*arg_type.clone() {
-                            if ts.is_empty() {
-                                return Ok(("None".to_string(), out, deps));
-                            }
-                            let enum_name = arg_type.to_callable_string();
-                            let first_variant_name = match &*ts[0] {
-                                CType::Field(n, _) => n.clone(),
-                                CType::Type(n, _) => n.clone(),
-                                _ => ts[0].clone().to_callable_string(),
-                            };
-                            let (a, o, d) = from_microstatement(&args[0], parent_fn, scope, out, deps)?;
-                            out = o;
-                            deps = d;
-                            return Ok((
-                                format!(
-                                    "(match &{} {{ {}::{}(v) => Some(v.clone()), _ => None }})",
-                                    a, enum_name, first_variant_name
-                                ),
-                                out,
-                                deps,
-                            ));
-                        }
-                    }
-                } else if fname == "rest_either" {
-                    if args.len() == 1 {
-                        let arg_type = args[0].get_type().degroup();
-                        if let CType::Either(ts) = &*arg_type.clone() {
-                            let rest_type = CType::exclude(arg_type.clone(), Arc::new(CType::Int(0)));
-                            if ts.len() <= 1 {
-                                return Ok(("void".to_string(), out, deps));
-                            }
-                            // Check if Rest type is a 2-variant Either{T, ()} -> Option<T>
-                            let is_option = matches!(&*rest_type, CType::Either(rest_ts) if rest_ts.len() == 2 && matches!(*rest_ts[1], CType::Void));
-                            if is_option {
-                                let enum_name = arg_type.to_callable_string();
-                                let mut match_arms = Vec::new();
-                                for (i, t) in ts.iter().enumerate() {
-                                    if i == 0 {
-                                        let first_variant_name = match &**t {
-                                            CType::Field(n, _) => n.clone(),
-                                            CType::Type(n, _) => n.clone(),
-                                            _ => t.clone().to_callable_string(),
-                                        };
-                                        match_arms.push(format!(
-                                            "{}::{}(_) => None",
-                                            enum_name, first_variant_name
-                                        ));
-                                    } else {
-                                        let variant_name = match &**t {
-                                            CType::Field(n, _) => n.clone(),
-                                            CType::Type(n, _) => n.clone(),
-                                            _ => t.clone().to_callable_string(),
-                                        };
-                                        match_arms.push(format!(
-                                            "{}::{}(v) => Some(v.clone())",
-                                            enum_name, variant_name
-                                        ));
-                                    }
-                                }
-                                let (a, o, d) = from_microstatement(&args[0], parent_fn, scope, out, deps)?;
-                                out = o;
-                                deps = d;
-                                return Ok((
-                                    format!(
-                                        "(match &{} {{ {} }})",
-                                        a,
-                                        match_arms.join(", ")
-                                    ),
-                                    out,
-                                    deps,
-                                ));
-                            }
-                            // Ensure the Rest enum type definition is generated
-                            let (_rest_key, new_out, new_deps) = typen::generate(rest_type.clone(), out, deps)?;
-                            out = new_out;
-                            deps = new_deps;
-                            let rest_enum_name = rest_type.clone().to_callable_string();
-                            let enum_name = arg_type.to_callable_string();
-                            let mut match_arms = Vec::new();
-                            for (i, t) in ts.iter().enumerate() {
-                                if i == 0 {
-                                    let first_variant_name = match &**t {
-                                        CType::Field(n, _) => n.clone(),
-                                        CType::Type(n, _) => n.clone(),
-                                        _ => t.clone().to_callable_string(),
-                                    };
-                                    match_arms.push(format!(
-                                        "{}::{}(_) => {}::void",
-                                        enum_name, first_variant_name, rest_enum_name
-                                    ));
-                                } else {
-                                    let variant_name = match &**t {
-                                        CType::Field(n, _) => n.clone(),
-                                        CType::Type(n, _) => n.clone(),
-                                        _ => t.clone().to_callable_string(),
-                                    };
-                                    match_arms.push(format!(
-                                        "{}::{}(v) => {}::{}(v.clone())",
-                                        enum_name, variant_name, rest_enum_name, variant_name
-                                    ));
-                                }
-                            }
-                            let (a, o, d) = from_microstatement(&args[0], parent_fn, scope, out, deps)?;
-                            out = o;
-                            deps = d;
-                            return Ok((
-                                format!(
-                                    "(match &{} {{ {} }})",
-                                    a,
-                                    match_arms.join(", ")
-                                ),
-                                out,
-                                deps,
-                            ));
-                        }
-                    }
                 }
             }
             match &function.kind {
@@ -788,7 +669,7 @@ pub fn from_microstatement(
                             };
                         }
                         match &**input_type {
-                            CType::Tuple(ts) => {
+                            CType::Tuple(ts, _) => {
                                 // Short-circuit for direct `<N>` function calls (which can only be
                                 // generated by the internals of the compiler)
                                 if let Ok(i) = function.name.parse::<i64>() {
@@ -836,59 +717,9 @@ pub fn from_microstatement(
                             CType::Field(..) => {
                                 return Ok((format!("{}.0", argstrs[0]), out, deps));
                             }
-                            CType::Either(ts) => {
+                            CType::Either(ts, _) => {
                                 let enum_type = function.args()[0].2.clone().degroup();
                                 let enum_name = enum_type.to_callable_string();
-                                // Special handling for first{T} and rest{T} functions
-                                if function.name == "first" {
-                                    if ts.is_empty() {
-                                        return Ok(("None".to_string(), out, deps));
-                                    }
-                                    let first_variant_name = match &*ts[0] {
-                                        CType::Field(n, _) => n.clone(),
-                                        CType::Type(n, _) => n.clone(),
-                                        _ => ts[0].clone().to_callable_string(),
-                                    };
-                                    return Ok((
-                                        format!(
-                                            "(match &{} {{ {}::{}(v) => Some(v.clone()), _ => None }})",
-                                            argstrs[0], enum_name, first_variant_name
-                                        ),
-                                        out,
-                                        deps,
-                                    ));
-                                }
-                                if function.name == "rest" {
-                                    let rest_type = CType::exclude(function.args()[0].2.clone(), Arc::new(CType::Int(0)));
-                                    let rest_enum_name = rest_type.clone().to_callable_string();
-                                    let (_rest_rtype, new_deps) = typen::ctype_to_rtype(rest_type.clone(), deps)?;
-                                    deps = new_deps;
-                                    if ts.len() <= 1 {
-                                        return Ok(("None".to_string(), out, deps));
-                                    }
-                                    let mut match_arms = Vec::new();
-                                    for (_i, t) in ts.iter().enumerate().skip(1) {
-                                        let variant_name = match &**t {
-                                            CType::Field(n, _) => n.clone(),
-                                            CType::Type(n, _) => n.clone(),
-                                            _ => t.clone().to_callable_string(),
-                                        };
-                                        match_arms.push(format!(
-                                            "{}::{}(v) => Some({}::{}(v.clone()))",
-                                            enum_name, variant_name, rest_enum_name, variant_name
-                                        ));
-                                    }
-                                    match_arms.push("_ => None".to_string());
-                                    return Ok((
-                                        format!(
-                                            "(match &{} {{ {} }})",
-                                            argstrs[0],
-                                            match_arms.join(", ")
-                                        ),
-                                        out,
-                                        deps,
-                                    ));
-                                }
                                 // The kinds of types allowed here are `Type`, `Bound`, and
                                 // `ResolvedBoundGeneric`, and `Field`. Other types don't have
                                 // a string name we can match against the function name
@@ -942,7 +773,7 @@ pub fn from_microstatement(
                             CType::Type(_, t) => t.clone(),
                             _ => inner_ret_type,
                         };
-                        if let CType::Either(_) = &*inner_ret_type {
+                        if let CType::Either(_, _) = &*inner_ret_type {
                             return Ok(("None".to_string(), out, deps));
                         }
                     }
@@ -955,7 +786,7 @@ pub fn from_microstatement(
                             _ => ret_type,
                         };
                         match &*inner_ret_type {
-                            CType::Either(ts) => {
+                            CType::Either(ts, _) => {
                                 if argstrs.len() != 2 {
                                     return Err(format!("Invalid arguments {} provided for Either re-assignment function, must be two arguments", argstrs.join(", ")).into());
                                 }
@@ -1280,7 +1111,7 @@ pub fn from_microstatement(
                                     deps,
                                 ));
                             }
-                            CType::Either(ts) => {
+                            CType::Either(ts, _) => {
                                 if argstrs.len() > 1 {
                                     return Err(format!("Invalid arguments {} provided for Either constructor function, must be zero or one argument", argstrs.join(", ")).into());
                                 }
@@ -1779,9 +1610,81 @@ pub fn from_microstatement(
                                 }
                                 return Err(format!("Cannot generate a constructor function for {} type as it is not part of the {} type", enum_name, function.name).into());
                             }
-                            CType::Tuple(ts) => {
+                            CType::Tuple(ts, _) => {
                                 // TODO: Better type checking here, but it's *probably* being
                                 // done at a higher layer
+                                // Check for parent constructor: single argument whose type is a
+                                // Tuple/Either containing a superset of the child's fields
+                                if argstrs.len() == 1 {
+                                    let single_arg_type = match &function.args().first() {
+                                        Some(t) => t.2.clone().degroup(),
+                                        None => Arc::new(CType::Void),
+                                    };
+                                    if let Some(parent_fields) = match &*single_arg_type {
+                                        CType::Tuple(pf, _) => Some(pf.clone()),
+                                        CType::Either(pf, _) => Some(pf.clone()),
+                                        _ => None,
+                                    } {
+                                        // Filter out static fields from the child's expected fields
+                                        let child_fields: Vec<&Arc<CType>> = ts
+                                            .iter()
+                                            .filter(|t| match &***t {
+                                                CType::Field(_, t) => !matches!(
+                                                    &**t,
+                                                    CType::Int(_)
+                                                        | CType::Float(_)
+                                                        | CType::Bool(_)
+                                                        | CType::TString(_),
+                                                ),
+                                                CType::Int(_)
+                                                | CType::Float(_)
+                                                | CType::Bool(_)
+                                                | CType::TString(_) => false,
+                                                _ => true,
+                                            })
+                                            .collect();
+                                        // Find matching field indices in the parent
+                                        let mut parent_indices: Vec<usize> = Vec::new();
+                                        let mut all_matched = true;
+                                        for child_field in &child_fields {
+                                            let child_key = (*child_field)
+                                                .clone()
+                                                .degroup()
+                                                .to_callable_string();
+                                            let mut found = false;
+                                            for (idx, pf) in parent_fields.iter().enumerate() {
+                                                if pf.clone().degroup().to_callable_string()
+                                                    == child_key
+                                                {
+                                                    parent_indices.push(idx);
+                                                    found = true;
+                                                    break;
+                                                }
+                                            }
+                                            if !found {
+                                                all_matched = false;
+                                                break;
+                                            }
+                                        }
+                                        if all_matched && !parent_indices.is_empty() {
+                                            let parent_arg = match argstrs[0].strip_prefix("&mut ")
+                                            {
+                                                Some(s) => s.to_string(),
+                                                None => argstrs[0].clone(),
+                                            };
+                                            let field_accesses: Vec<String> = parent_indices
+                                                .iter()
+                                                .map(|i| format!("{}.{}", parent_arg, i))
+                                                .collect();
+                                            // Tuples in Rust use (a, b, ...) syntax directly
+                                            return Ok((
+                                                format!("({})", field_accesses.join(", ")),
+                                                out,
+                                                deps,
+                                            ));
+                                        }
+                                    }
+                                }
                                 if argstrs.len()
                                     == ts
                                         .iter()

--- a/alan_compiler/src/lntors/function.rs
+++ b/alan_compiler/src/lntors/function.rs
@@ -1124,6 +1124,60 @@ pub fn from_microstatement(
                                     CType::Type(n, _) => n.clone(),
                                     _ => enum_type.clone().to_callable_string(),
                                 };
+                                // Check for parent constructor: single argument whose type is an
+                                // Either containing a superset of the child's variants
+                                if argstrs.len() == 1 {
+                                    let single_arg_type = match &function.args().first() {
+                                        Some(t) => t.2.clone().degroup(),
+                                        None => Arc::new(CType::Void),
+                                    };
+                                    let parent_type_name = single_arg_type.clone().to_callable_string();
+                                    if let CType::Either(parent_variants, _) = &*single_arg_type {
+                                        // Find which parent variants match child variants
+                                        let mut matched_indices: Vec<usize> = Vec::new();
+                                        for (idx, pv) in parent_variants.iter().enumerate() {
+                                            let parent_key = pv.clone().degroup().to_callable_string();
+                                            for cv in ts {
+                                                if cv.clone().degroup().to_callable_string() == parent_key {
+                                                    matched_indices.push(idx);
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        if !matched_indices.is_empty() && matched_indices.len() < parent_variants.len() {
+                                            let parent_arg = match argstrs[0].strip_prefix("&mut ")
+                                            {
+                                                Some(s) => s.to_string(),
+                                                None => argstrs[0].clone(),
+                                            };
+                                            // Generate match expression: Some(Child::Variant(v)) for matched, None for excluded
+                                            let mut arms = Vec::new();
+                                            for (idx, pv) in parent_variants.iter().enumerate() {
+                                                let variant_name = pv.clone().degroup().to_callable_string();
+                                                if matched_indices.contains(&idx) {
+                                                    arms.push(format!(
+                                                        "{}::{}(v) => Some({}::{}(v))",
+                                                        parent_type_name,
+                                                        variant_name,
+                                                        function.name,
+                                                        variant_name
+                                                    ));
+                                                } else {
+                                                    arms.push(format!(
+                                                        "{}::{}(_) => None",
+                                                        parent_type_name,
+                                                        variant_name
+                                                    ));
+                                                }
+                                            }
+                                            return Ok((
+                                                format!("match {} {{\n    {}\n}}", parent_arg, arms.join(",\n    ")),
+                                                out,
+                                                deps,
+                                            ));
+                                        }
+                                    }
+                                }
                                 for t in ts {
                                     let inner_type = t.clone().degroup();
                                     match &*inner_type {
@@ -1606,8 +1660,8 @@ pub fn from_microstatement(
                                                 deps,
                                             ));
                                         }
-                                    }
-                                }
+                                     }
+                                 }
                                 return Err(format!("Cannot generate a constructor function for {} type as it is not part of the {} type", enum_name, function.name).into());
                             }
                             CType::Tuple(ts, _) => {
@@ -1762,6 +1816,78 @@ pub fn from_microstatement(
                             }
                             otherwise => {
                                 return Err(format!("How did you get here? Trying to create a constructor function {function:?} for {otherwise:?}").into());
+                            }
+                        }
+                    } else if function.args().len() == 1 {
+                        // Check for parent constructor: return type is Maybe{Child} and arg is a superset Either
+                        let ret_inner = match &*ret_type {
+                            CType::Either(ts, _) if ts.len() == 2 => {
+                                if let CType::Void = &*ts[1] {
+                                    Some(ts[0].clone())
+                                } else {
+                                    None
+                                }
+                            }
+                            _ => None,
+                        };
+                        if let Some(child_type_raw) = ret_inner {
+                            // Unwrap Type and Group wrappers to get to the inner type
+                            let mut child_type = child_type_raw.clone().degroup();
+                            loop {
+                                child_type = match &*child_type {
+                                    CType::Type(_, t) => t.clone(),
+                                    CType::Group(t) => t.clone(),
+                                    _ => break,
+                                };
+                            }
+                            let child_name = child_type.clone().to_callable_string();
+                            if function.name == child_name {
+                                let arg_type = function.args()[0].2.clone().degroup();
+                                let parent_type_name = arg_type.clone().to_callable_string();
+                                if let CType::Either(parent_variants, _) = &*arg_type {
+                                    if let CType::Either(child_variants, _) = &*child_type {
+                                        let mut matched_indices: Vec<usize> = Vec::new();
+                                        for (idx, pv) in parent_variants.iter().enumerate() {
+                                            let parent_key = pv.clone().degroup().to_callable_string();
+                                            for cv in child_variants {
+                                                if cv.clone().degroup().to_callable_string() == parent_key {
+                                                    matched_indices.push(idx);
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        if !matched_indices.is_empty() && matched_indices.len() < parent_variants.len() {
+                                            let parent_arg = match argstrs[0].strip_prefix("&mut ") {
+                                                Some(s) => s.to_string(),
+                                                None => argstrs[0].clone(),
+                                            };
+                                            let mut arms = Vec::new();
+                                            for (idx, pv) in parent_variants.iter().enumerate() {
+                                                let variant_name = pv.clone().degroup().to_callable_string();
+                                                if matched_indices.contains(&idx) {
+                                                    arms.push(format!(
+                                                        "{}::{}(v) => Some({}::{}(v))",
+                                                        parent_type_name,
+                                                        variant_name,
+                                                        function.name,
+                                                        variant_name
+                                                    ));
+                                                } else {
+                                                    arms.push(format!(
+                                                        "{}::{}(_) => None",
+                                                        parent_type_name,
+                                                        variant_name
+                                                    ));
+                                                }
+                                            }
+                                            return Ok((
+                                                format!("match {} {{\n    {}\n}}", parent_arg, arms.join(",\n    ")),
+                                                out,
+                                                deps,
+                                            ));
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/alan_compiler/src/lntors/function.rs
+++ b/alan_compiler/src/lntors/function.rs
@@ -373,6 +373,125 @@ pub fn from_microstatement(
                         out,
                         deps,
                     ));
+                } else if fname == "first_either" {
+                    if args.len() == 1 {
+                        let arg_type = args[0].get_type().degroup();
+                        if let CType::Either(ts) = &*arg_type.clone() {
+                            if ts.is_empty() {
+                                return Ok(("None".to_string(), out, deps));
+                            }
+                            let enum_name = arg_type.to_callable_string();
+                            let first_variant_name = match &*ts[0] {
+                                CType::Field(n, _) => n.clone(),
+                                CType::Type(n, _) => n.clone(),
+                                _ => ts[0].clone().to_callable_string(),
+                            };
+                            let (a, o, d) = from_microstatement(&args[0], parent_fn, scope, out, deps)?;
+                            out = o;
+                            deps = d;
+                            return Ok((
+                                format!(
+                                    "(match &{} {{ {}::{}(v) => Some(v.clone()), _ => None }})",
+                                    a, enum_name, first_variant_name
+                                ),
+                                out,
+                                deps,
+                            ));
+                        }
+                    }
+                } else if fname == "rest_either" {
+                    if args.len() == 1 {
+                        let arg_type = args[0].get_type().degroup();
+                        if let CType::Either(ts) = &*arg_type.clone() {
+                            let rest_type = CType::trest(arg_type.clone());
+                            if ts.len() <= 1 {
+                                return Ok(("void".to_string(), out, deps));
+                            }
+                            // Check if Rest type is a 2-variant Either{T, ()} -> Option<T>
+                            let is_option = matches!(&*rest_type, CType::Either(rest_ts) if rest_ts.len() == 2 && matches!(*rest_ts[1], CType::Void));
+                            if is_option {
+                                let enum_name = arg_type.to_callable_string();
+                                let mut match_arms = Vec::new();
+                                for (i, t) in ts.iter().enumerate() {
+                                    if i == 0 {
+                                        let first_variant_name = match &**t {
+                                            CType::Field(n, _) => n.clone(),
+                                            CType::Type(n, _) => n.clone(),
+                                            _ => t.clone().to_callable_string(),
+                                        };
+                                        match_arms.push(format!(
+                                            "{}::{}(_) => None",
+                                            enum_name, first_variant_name
+                                        ));
+                                    } else {
+                                        let variant_name = match &**t {
+                                            CType::Field(n, _) => n.clone(),
+                                            CType::Type(n, _) => n.clone(),
+                                            _ => t.clone().to_callable_string(),
+                                        };
+                                        match_arms.push(format!(
+                                            "{}::{}(v) => Some(v.clone())",
+                                            enum_name, variant_name
+                                        ));
+                                    }
+                                }
+                                let (a, o, d) = from_microstatement(&args[0], parent_fn, scope, out, deps)?;
+                                out = o;
+                                deps = d;
+                                return Ok((
+                                    format!(
+                                        "(match &{} {{ {} }})",
+                                        a,
+                                        match_arms.join(", ")
+                                    ),
+                                    out,
+                                    deps,
+                                ));
+                            }
+                            // Ensure the Rest enum type definition is generated
+                            let (_rest_key, new_out, new_deps) = typen::generate(rest_type.clone(), out, deps)?;
+                            out = new_out;
+                            deps = new_deps;
+                            let rest_enum_name = rest_type.clone().to_callable_string();
+                            let enum_name = arg_type.to_callable_string();
+                            let mut match_arms = Vec::new();
+                            for (i, t) in ts.iter().enumerate() {
+                                if i == 0 {
+                                    let first_variant_name = match &**t {
+                                        CType::Field(n, _) => n.clone(),
+                                        CType::Type(n, _) => n.clone(),
+                                        _ => t.clone().to_callable_string(),
+                                    };
+                                    match_arms.push(format!(
+                                        "{}::{}(_) => {}::void",
+                                        enum_name, first_variant_name, rest_enum_name
+                                    ));
+                                } else {
+                                    let variant_name = match &**t {
+                                        CType::Field(n, _) => n.clone(),
+                                        CType::Type(n, _) => n.clone(),
+                                        _ => t.clone().to_callable_string(),
+                                    };
+                                    match_arms.push(format!(
+                                        "{}::{}(v) => {}::{}(v.clone())",
+                                        enum_name, variant_name, rest_enum_name, variant_name
+                                    ));
+                                }
+                            }
+                            let (a, o, d) = from_microstatement(&args[0], parent_fn, scope, out, deps)?;
+                            out = o;
+                            deps = d;
+                            return Ok((
+                                format!(
+                                    "(match &{} {{ {} }})",
+                                    a,
+                                    match_arms.join(", ")
+                                ),
+                                out,
+                                deps,
+                            ));
+                        }
+                    }
                 }
             }
             match &function.kind {
@@ -718,6 +837,58 @@ pub fn from_microstatement(
                                 return Ok((format!("{}.0", argstrs[0]), out, deps));
                             }
                             CType::Either(ts) => {
+                                let enum_type = function.args()[0].2.clone().degroup();
+                                let enum_name = enum_type.to_callable_string();
+                                // Special handling for first{T} and rest{T} functions
+                                if function.name == "first" {
+                                    if ts.is_empty() {
+                                        return Ok(("None".to_string(), out, deps));
+                                    }
+                                    let first_variant_name = match &*ts[0] {
+                                        CType::Field(n, _) => n.clone(),
+                                        CType::Type(n, _) => n.clone(),
+                                        _ => ts[0].clone().to_callable_string(),
+                                    };
+                                    return Ok((
+                                        format!(
+                                            "(match &{} {{ {}::{}(v) => Some(v.clone()), _ => None }})",
+                                            argstrs[0], enum_name, first_variant_name
+                                        ),
+                                        out,
+                                        deps,
+                                    ));
+                                }
+                                if function.name == "rest" {
+                                    let rest_type = CType::trest(function.args()[0].2.clone());
+                                    let rest_enum_name = rest_type.clone().to_callable_string();
+                                    let (_rest_rtype, new_deps) = typen::ctype_to_rtype(rest_type.clone(), deps)?;
+                                    deps = new_deps;
+                                    if ts.len() <= 1 {
+                                        return Ok(("None".to_string(), out, deps));
+                                    }
+                                    let mut match_arms = Vec::new();
+                                    for (_i, t) in ts.iter().enumerate().skip(1) {
+                                        let variant_name = match &**t {
+                                            CType::Field(n, _) => n.clone(),
+                                            CType::Type(n, _) => n.clone(),
+                                            _ => t.clone().to_callable_string(),
+                                        };
+                                        match_arms.push(format!(
+                                            "{}::{}(v) => Some({}::{}(v.clone()))",
+                                            enum_name, variant_name, rest_enum_name, variant_name
+                                        ));
+                                    }
+                                    match_arms.push("_ => None".to_string());
+                                    return Ok((
+                                        format!(
+                                            "(match &{} {{ {} }})",
+                                            argstrs[0],
+                                            match_arms.join(", ")
+                                        ),
+                                        out,
+                                        deps,
+                                    ));
+                                }
                                 // The kinds of types allowed here are `Type`, `Bound`, and
                                 // `ResolvedBoundGeneric`, and `Field`. Other types don't have
                                 // a string name we can match against the function name
@@ -734,8 +905,6 @@ pub fn from_microstatement(
                                 // function argument. We blow up here if the first argument is
                                 // *not* a Type we can get an enum name from (it *shouldn't* be
                                 // possible, but..)
-                                let enum_type = function.args()[0].2.clone().degroup();
-                                let enum_name = enum_type.to_callable_string();
                                 // We pass through to the main path if we can't find a matching
                                 // name
                                 if accessor_field.is_some() {

--- a/alan_compiler/src/lntors/typen.rs
+++ b/alan_compiler/src/lntors/typen.rs
@@ -22,7 +22,7 @@ pub fn ctype_to_rtype(
                     Ok((format!(
                         "impl FnMut(&{}) -> {}",
                         match &**i {
-                            CType::Tuple(ts) => {
+                            CType::Tuple(ts, _) => {
                                 let mut out = Vec::new();
                                 for t in ts {
                                     let res = ctype_to_rtype(t.clone(), deps)?;
@@ -65,7 +65,7 @@ pub fn ctype_to_rtype(
         )
         .into()),
         CType::Type(_, t) => match &**t {
-            CType::Either(ts) => {
+            CType::Either(ts, _) => {
                 if ts.len() == 2 && (matches!(*ts[1], CType::Void) || matches!(&*ts[1], CType::Type(n, _) if n == "Error")) {
                     return Ok(("".to_string(), deps));
                 }
@@ -91,7 +91,7 @@ pub fn ctype_to_rtype(
                             enum_type_strs.push(s);
                         }
                         CType::Void => enum_type_strs.push("void".to_string()),
-                        CType::Tuple(ts) => {
+                        CType::Tuple(ts, _) => {
                             let mut out = Vec::new();
                             for t in ts {
                                 let res = ctype_to_rtype(t.clone(), deps)?;
@@ -118,9 +118,9 @@ pub fn ctype_to_rtype(
                     enum_type_strs.join(", ")
                 ), deps))
             }
-            CType::Tuple(ts) => {
-                let mut out = Vec::new();
-                for t in ts {
+                CType::Tuple(ts, _) => {
+                            let mut out = Vec::new();
+                            for t in ts {
                     match &**t {
                         CType::Field(_, t2) => {
                             if !matches!(&**t2, CType::Int(_) | CType::Float(_) | CType::Bool(_) | CType::TString(_)) {
@@ -309,7 +309,7 @@ pub fn ctype_to_rtype(
                 Ok((format!(
                     "impl Fn(&{}) -> {}",
                     match &**i {
-                        CType::Tuple(ts) => {
+                        CType::Tuple(ts, _) => {
                             let mut out = Vec::new();
                             for t in ts {
                                 let res = ctype_to_rtype(t.clone(), deps)?;
@@ -334,9 +334,9 @@ pub fn ctype_to_rtype(
                 ), deps))
             }
         },
-        CType::Tuple(ts) => {
-            let mut out = Vec::new();
-            for t in ts {
+                   CType::Tuple(ts, _) => {
+                            let mut out = Vec::new();
+                            for t in ts {
                 match &**t {
                     CType::Field(_, t2) => {
                         if !matches!(&**t2, CType::Int(_) | CType::Float(_) | CType::Bool(_) | CType::TString(_)) {
@@ -364,9 +364,9 @@ pub fn ctype_to_rtype(
             let res = ctype_to_rtype(v.clone(), deps)?;
             let s = res.0;
             deps = res.1;
-            Ok((format!("/* {k} */ {s}"), deps))
+             Ok((format!("/* {k} */ {s}"), deps))
         }
-        CType::Either(ts) => {
+        CType::Either(ts, _) => {
             // Special handling to convert `Either{T, void}` to `Option<T>` and `Either{T, Error}`
             // to `Result<T, AlanError>`
             if ts.len() == 2 {
@@ -420,9 +420,9 @@ pub fn ctype_to_rtype(
                                 }
                                 Ok((format!("Result<{}, {}>", s, "alan_std::AlanError"), deps))
                             }
-                            _ => Ok((Arc::new(CType::Either(ts.clone())).to_callable_string(), deps)),
+                            _ => Ok((Arc::new(CType::Either(ts.clone(), Vec::new())).to_callable_string(), deps)),
                         }
-                        _ => Ok((Arc::new(CType::Either(ts.clone())).to_callable_string(), deps)),
+                        _ => Ok((Arc::new(CType::Either(ts.clone(), Vec::new())).to_callable_string(), deps)),
                     }
                     CType::Type(_, t) => match &**t {
                         CType::Binds(rustname, _) => match &**rustname {
@@ -467,13 +467,13 @@ pub fn ctype_to_rtype(
                                     }
                                     Ok((format!("Result<{}, {}>", s, "alan_std::AlanError"), deps))
                                 }
-                                _ => Ok((Arc::new(CType::Either(ts.clone())).to_callable_string(), deps)),
+                                _ => Ok((Arc::new(CType::Either(ts.clone(), Vec::new())).to_callable_string(), deps)),
                             }
-                            _ => Ok((Arc::new(CType::Either(ts.clone())).to_callable_string(), deps)),
+                            _ => Ok((Arc::new(CType::Either(ts.clone(), Vec::new())).to_callable_string(), deps)),
                         }
-                        _ => Ok((Arc::new(CType::Either(ts.clone())).to_callable_string(), deps)),
+                        _ => Ok((Arc::new(CType::Either(ts.clone(), Vec::new())).to_callable_string(), deps)),
                     }
-                    _ => Ok((Arc::new(CType::Either(ts.clone())).to_callable_string(), deps)),
+                    _ => Ok((Arc::new(CType::Either(ts.clone(), Vec::new())).to_callable_string(), deps)),
                 }
             } else {
                 for t in ts {
@@ -481,7 +481,7 @@ pub fn ctype_to_rtype(
                     let res = ctype_to_rtype(t.clone(), deps)?;
                     deps = res.1;
                 }
-                Ok((Arc::new(CType::Either(ts.clone())).to_callable_string(), deps))
+                Ok((Arc::new(CType::Either(ts.clone(), Vec::new())).to_callable_string(), deps))
             }
         }
         CType::AnyOf(_) => Ok(("".to_string(), deps)), // Does this make any sense in Rust?
@@ -600,7 +600,7 @@ pub fn generate(
         // TODO: The complexity of this function indicates more fundamental issues in the type
         // generation. This needs a rethink and rewrite.
         CType::Type(_name, t) => match &**t {
-            CType::Either(_) => {
+            CType::Either(_, _) => {
                 let res = generate(t.clone(), out, deps)?;
                 out = res.1;
                 deps = res.2;
@@ -619,7 +619,7 @@ pub fn generate(
                 Ok((s, out, deps))
             }
         },
-        CType::Tuple(_) => {
+        CType::Tuple(_, _) => {
             let res = ctype_to_rtype(typen, deps)?;
             let s = res.0;
             deps = res.1;
@@ -629,7 +629,7 @@ pub fn generate(
             out.insert("void".to_string(), "type void = ();".to_string());
             Ok(("()".to_string(), out, deps))
         }
-        CType::Either(ts) => {
+        CType::Either(ts, _) => {
             // Make sure every sub-type exists
             for t in ts {
                 let res = generate(t.clone(), out, deps)?;

--- a/alan_compiler/src/lntors/typen.rs
+++ b/alan_compiler/src/lntors/typen.rs
@@ -59,7 +59,7 @@ pub fn ctype_to_rtype(
         CType::Mut(t) => {
             ctype_to_rtype(t.clone(), deps)
         }
-        CType::Void => Ok(("void".to_string(), deps)),
+        CType::Void | CType::DerivedVoid(..) => Ok(("void".to_string(), deps)),
         CType::Infer(s, _) => Err(format!(
             "Inferred type matching {s} was not realized before code generation"
         )
@@ -90,7 +90,7 @@ pub fn ctype_to_rtype(
                             deps = res.1;
                             enum_type_strs.push(s);
                         }
-                        CType::Void => enum_type_strs.push("void".to_string()),
+                        CType::Void | CType::DerivedVoid(..) => enum_type_strs.push("void".to_string()),
                         CType::Tuple(ts, _) => {
                             let mut out = Vec::new();
                             for t in ts {
@@ -372,7 +372,7 @@ pub fn ctype_to_rtype(
             if ts.len() == 2 {
                 let alan_error = "alan_std::AlanError".to_string();
                 match &*ts[1] {
-                    CType::Void => {
+                    CType::Void | CType::DerivedVoid(..) => {
                         let res = ctype_to_rtype(ts[0].clone(), deps)?;
                         let s = res.0;
                         deps = res.1;
@@ -625,7 +625,7 @@ pub fn generate(
             deps = res.1;
             Ok((s, out, deps))
         }
-        CType::Void => {
+        CType::Void | CType::DerivedVoid(..) => {
             out.insert("void".to_string(), "type void = ();".to_string());
             Ok(("()".to_string(), out, deps))
         }
@@ -661,7 +661,7 @@ pub fn generate(
                             deps = res.1;
                             enum_type_strs.push(format!("{}({})", n, res.0));
                         }
-                        CType::Void => enum_type_strs.push("void".to_string()),
+                        CType::Void | CType::DerivedVoid(..) => enum_type_strs.push("void".to_string()),
                         _otherwise => {
                             let res = ctype_to_rtype(t.clone(), deps)?;
                             deps = res.1;

--- a/alan_compiler/src/lntors/typen.rs
+++ b/alan_compiler/src/lntors/typen.rs
@@ -60,10 +60,6 @@ pub fn ctype_to_rtype(
             ctype_to_rtype(t.clone(), deps)
         }
         CType::Void => Ok(("void".to_string(), deps)),
-        CType::Rest(t) => {
-            let rest_type = CType::trest(t.clone());
-            ctype_to_rtype(rest_type, deps)
-        }
         CType::Infer(s, _) => Err(format!(
             "Inferred type matching {s} was not realized before code generation"
         )
@@ -646,6 +642,10 @@ pub fn generate(
                 let res = ctype_to_rtype(ts[0].clone(), deps)?;
                 deps = res.1;
                 Ok((format!("Option<{}>", res.0), out, deps))
+            } else if ts.len() == 2 && matches!(&*ts[1], CType::Type(n, _) if n == "Error") {
+                let res = ctype_to_rtype(ts[0].clone(), deps)?;
+                deps = res.1;
+                Ok((format!("Result<{}, alan_std::AlanError>", res.0), out, deps))
             } else {
                 // Build the enum definition for 3+ variant Either
                 let mut enum_type_strs = Vec::new();
@@ -685,10 +685,6 @@ pub fn generate(
             out = res.1;
             deps = res.2;
             Ok(("".to_string(), out, deps))
-        }
-        CType::Rest(t) => {
-            let rest_type = CType::trest(t.clone());
-            generate(rest_type, out, deps)
         }
         _otherwise => {
             let res = ctype_to_rtype(typen, deps)?;

--- a/alan_compiler/src/lntors/typen.rs
+++ b/alan_compiler/src/lntors/typen.rs
@@ -661,7 +661,9 @@ pub fn generate(
                             deps = res.1;
                             enum_type_strs.push(format!("{}({})", n, res.0));
                         }
-                        CType::Void | CType::DerivedVoid(..) => enum_type_strs.push("void".to_string()),
+                        CType::Void | CType::DerivedVoid(..) => {
+                            enum_type_strs.push("void".to_string())
+                        }
                         _otherwise => {
                             let res = ctype_to_rtype(t.clone(), deps)?;
                             deps = res.1;

--- a/alan_compiler/src/lntors/typen.rs
+++ b/alan_compiler/src/lntors/typen.rs
@@ -60,6 +60,10 @@ pub fn ctype_to_rtype(
             ctype_to_rtype(t.clone(), deps)
         }
         CType::Void => Ok(("void".to_string(), deps)),
+        CType::Rest(t) => {
+            let rest_type = CType::trest(t.clone());
+            ctype_to_rtype(rest_type, deps)
+        }
         CType::Infer(s, _) => Err(format!(
             "Inferred type matching {s} was not realized before code generation"
         )
@@ -637,16 +641,54 @@ pub fn generate(
                 deps = res.2;
             }
 
-            let res = ctype_to_rtype(typen, deps)?;
-            let out_str = res.0;
-            deps = res.1;
-            Ok((out_str, out, deps)) // TODO: Put something into out?
+            // Check if this is a 2-variant Either that maps to Option/Result
+            if ts.len() == 2 && matches!(*ts[1], CType::Void) {
+                let res = ctype_to_rtype(ts[0].clone(), deps)?;
+                deps = res.1;
+                Ok((format!("Option<{}>", res.0), out, deps))
+            } else {
+                // Build the enum definition for 3+ variant Either
+                let mut enum_type_strs = Vec::new();
+                for t in ts {
+                    match &**t {
+                        CType::Field(k, v) => {
+                            let res = ctype_to_rtype(v.clone(), deps)?;
+                            deps = res.1;
+                            enum_type_strs.push(format!("{}({})", k, res.0));
+                        }
+                        CType::Type(n, t) => {
+                            let res = ctype_to_rtype(t.clone(), deps)?;
+                            deps = res.1;
+                            enum_type_strs.push(format!("{}({})", n, res.0));
+                        }
+                        CType::Void => enum_type_strs.push("void".to_string()),
+                        _otherwise => {
+                            let res = ctype_to_rtype(t.clone(), deps)?;
+                            deps = res.1;
+                            let name = t.clone().to_callable_string();
+                            enum_type_strs.push(format!("{}({})", name, res.0));
+                        }
+                    }
+                }
+                let enum_key = typen.to_callable_string();
+                let enum_def = format!(
+                    "#[derive(Clone)]\nenum {} {{ {} }}",
+                    enum_key,
+                    enum_type_strs.join(", ")
+                );
+                out.insert(enum_key.clone(), enum_def);
+                Ok((enum_key, out, deps))
+            }
         }
         CType::Group(g) => {
             let res = generate(g.clone(), out, deps)?;
             out = res.1;
             deps = res.2;
             Ok(("".to_string(), out, deps))
+        }
+        CType::Rest(t) => {
+            let rest_type = CType::trest(t.clone());
+            generate(rest_type, out, deps)
         }
         _otherwise => {
             let res = ctype_to_rtype(typen, deps)?;

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -51,6 +51,7 @@ pub enum CType {
     Field(String, Arc<CType>),
     Either(Vec<Arc<CType>>),
     Prop(Arc<CType>, Arc<CType>),
+    Exclude(Arc<CType>, Arc<CType>),
     AnyOf(Vec<Arc<CType>>),
     Buffer(Arc<CType>, Arc<CType>),
     Array(Arc<CType>),
@@ -65,7 +66,7 @@ pub enum CType {
     Max(Vec<Arc<CType>>),
     Neg(Arc<CType>),
     Len(Arc<CType>),
-    Rest(Arc<CType>),
+ 
     Size(Arc<CType>),
     FileStr(Arc<CType>),
     Concat(Arc<CType>, Arc<CType>),
@@ -426,6 +427,13 @@ impl CType {
                     ctype_stack.push(dot);
                     ctype_stack.push(t);
                 }
+                CType::Exclude(t, p) => {
+                    str_parts.push("Exclude{");
+                    ctype_stack.push(close_brace);
+                    ctype_stack.push(p);
+                    ctype_stack.push(comma);
+                    ctype_stack.push(t);
+                }
                 CType::AnyOf(ts) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
@@ -524,11 +532,6 @@ impl CType {
                 }
                 CType::Len(t) => {
                     str_parts.push("Len{");
-                    ctype_stack.push(close_brace);
-                    ctype_stack.push(t);
-                }
-                CType::Rest(t) => {
-                    str_parts.push("Rest{");
                     ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
@@ -925,6 +928,13 @@ impl CType {
                     ctype_stack.push(comma);
                     ctype_stack.push(t);
                 }
+                CType::Exclude(t, p) => {
+                    str_parts.push("Exclude{");
+                    ctype_stack.push(close_brace);
+                    ctype_stack.push(p);
+                    ctype_stack.push(comma);
+                    ctype_stack.push(t);
+                }
                 CType::AnyOf(ts) => {
                     str_parts.push("AnyOf{");
                     ctype_stack.push(close_brace);
@@ -1039,11 +1049,6 @@ impl CType {
                 }
                 CType::Len(t) => {
                     str_parts.push("Len{");
-                    ctype_stack.push(close_brace);
-                    ctype_stack.push(t);
-                }
-                CType::Rest(t) => {
-                    str_parts.push("Rest{");
                     ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
@@ -1291,7 +1296,6 @@ impl CType {
             | CType::Field(_, t)
             | CType::Neg(t)
             | CType::Len(t)
-            | CType::Rest(t)
             | CType::Size(t)
             | CType::FileStr(t)
             | CType::EnvExists(t)
@@ -1304,6 +1308,7 @@ impl CType {
             | CType::Dependency(a, b)
             | CType::Import(a, b)
             | CType::Prop(a, b)
+            | CType::Exclude(a, b)
             | CType::Buffer(a, b)
             | CType::Concat(a, b) => a.clone().has_infer() || b.clone().has_infer(),
             CType::Tuple(ts)
@@ -1389,6 +1394,7 @@ impl CType {
                     .collect::<Vec<Arc<CType>>>(),
             )),
             CType::Prop(t, p) => Arc::new(CType::Prop(t.clone().degroup(), p.clone().degroup())),
+            CType::Exclude(t, p) => Arc::new(CType::Exclude(t.clone().degroup(), p.clone().degroup())),
             CType::AnyOf(ts) => Arc::new(CType::AnyOf(
                 ts.iter()
                     .map(|t| t.clone().degroup())
@@ -1441,7 +1447,6 @@ impl CType {
             )),
             CType::Neg(t) => Arc::new(CType::Neg(t.clone().degroup())),
             CType::Len(t) => Arc::new(CType::Len(t.clone().degroup())),
-            CType::Rest(t) => Arc::new(CType::Rest(t.clone().degroup())),
             CType::Size(t) => Arc::new(CType::Size(t.clone().degroup())),
             CType::FileStr(t) => Arc::new(CType::FileStr(t.clone().degroup())),
             CType::Concat(a, b) => {
@@ -1794,6 +1799,12 @@ impl CType {
                         input.push(t2.clone());
                         input.push(p2.clone());
                     }
+                    (CType::Exclude(t1, p1), CType::Exclude(t2, p2)) => {
+                        arg.push(t1.clone());
+                        arg.push(p1.clone());
+                        input.push(t2.clone());
+                        input.push(p2.clone());
+                    }
                     (a, CType::Prop(t, p)) => {
                         // TODO: There's probably a generalized way to handle things like this, but
                         // for now, just hardwire this particular generic resolution used for the
@@ -2074,7 +2085,6 @@ impl CType {
                         | CType::Max(_)
                         | CType::Neg(_)
                         | CType::Len(_)
-                        | CType::Rest(_)
                         | CType::Size(_),
                     ) => {
                         // TODO: This should allow us to constrain which generic values are
@@ -2223,10 +2233,6 @@ impl CType {
                         input.push(t2.clone());
                     }
                     (CType::Len(t1), CType::Len(t2)) => {
-                        arg.push(t1.clone());
-                        input.push(t2.clone());
-                    }
-                    (CType::Rest(t1), CType::Rest(t2)) => {
                         arg.push(t1.clone());
                         input.push(t2.clone());
                     }
@@ -3980,7 +3986,7 @@ impl CType {
                 .unwrap(),
             CType::Neg(t) => CType::neg(t.clone().swap_subtype(old_type, new_type)),
             CType::Len(t) => CType::len(t.clone().swap_subtype(old_type, new_type)),
-            CType::Rest(t) => CType::trest(t.clone().swap_subtype(old_type, new_type)),
+            CType::Exclude(t, p) => CType::exclude(t.clone().swap_subtype(old_type.clone(), new_type.clone()), p.clone().swap_subtype(old_type, new_type)),
             CType::Size(t) => CType::size(t.clone().swap_subtype(old_type, new_type)),
             CType::FileStr(t) => CType::filestr(t.clone().swap_subtype(old_type, new_type)),
             CType::Concat(a, b) => CType::concat(
@@ -4458,25 +4464,127 @@ impl CType {
             _ => Arc::new(CType::Int(1)),
         }
     }
-    pub fn trest(t: Arc<CType>) -> Arc<CType> {
+    pub fn exclude(t: Arc<CType>, n: Arc<CType>) -> Arc<CType> {
+        if t.clone().has_infer() || n.clone().has_infer() {
+            return Arc::new(CType::Exclude(t, n));
+        }
         match &*t {
+            CType::Infer(..) => unreachable!(),
+            CType::Type(_, inner) => CType::exclude(inner.clone(), n),
+            CType::Group(inner) => CType::exclude(inner.clone(), n),
             CType::Either(ts) => {
-                if ts.is_empty() {
+                let result = match &*n {
+                    CType::TString(s) => {
+                        let filtered: Vec<Arc<CType>> = ts.iter().filter(|t| {
+                            if let CType::Field(name, _) = &***t {
+                                name != s
+                            } else {
+                                true
+                            }
+                        }).cloned().collect();
+                        if filtered.len() == ts.len() {
+                            return Arc::new(CType::Fail(format!("Variant with name {s} not found in Either type")));
+                        }
+                        filtered
+                    }
+                    CType::Int(i) => {
+                        let idx = *i as usize;
+                        if idx >= ts.len() {
+                            return Arc::new(CType::Fail(format!("Index {idx} out of bounds for Either type with {} variants", ts.len())));
+                        }
+                        let mut filtered: Vec<Arc<CType>> = ts.iter().enumerate().filter(|(idx_in_either, _)| {
+                            *idx_in_either != idx
+                        }).map(|(_, t)| t.clone()).collect();
+                        if filtered.is_empty() {
+                            return Arc::new(CType::Void);
+                        }
+                        if !matches!(*filtered[filtered.len() - 1], CType::Void) {
+                            filtered.push(Arc::new(CType::Void));
+                        }
+                        filtered
+                    }
+                    otherwise => {
+                        CType::fail(&format!(
+                            "Exclude index must be a name or integer, not {otherwise:?}"
+                        ))
+                    }
+                };
+                if result.is_empty() {
                     return Arc::new(CType::Void);
                 }
-                let mut rest: Vec<Arc<CType>> = ts[1..].to_vec();
-                if rest.is_empty() {
-                    return Arc::new(CType::Void);
+                if result.len() == 1 {
+                    return result.into_iter().next().unwrap();
                 }
-                if !matches!(*rest[rest.len() - 1], CType::Void) {
-                    rest.push(Arc::new(CType::Void));
-                }
-                Arc::new(CType::Either(rest))
+                Arc::new(CType::Either(result))
             }
-            CType::Type(_, inner) => CType::trest(inner.clone()),
-            CType::Group(inner) => CType::trest(inner.clone()),
-            CType::Infer(..) => Arc::new(CType::Rest(t)),
-            _ => CType::fail("Rest can only be computed for Either types"),
+            CType::Tuple(ts) => {
+                let result = match &*n {
+                    CType::TString(s) => {
+                        let filtered: Vec<Arc<CType>> = ts.iter().filter(|t| {
+                            if let CType::Field(name, _) = &***t {
+                                name != s
+                            } else {
+                                true
+                            }
+                        }).cloned().collect();
+                        if filtered.len() == ts.len() {
+                            return Arc::new(CType::Fail(format!("Element with name {s} not found in Tuple type")));
+                        }
+                        filtered
+                    }
+                    CType::Int(i) => {
+                        let idx = *i as usize;
+                        if idx >= ts.len() {
+                            return Arc::new(CType::Fail(format!("Index {idx} out of bounds for Tuple type with {} elements", ts.len())));
+                        }
+                        let filtered: Vec<Arc<CType>> = ts.iter().enumerate().filter(|(idx_in_tup, _)| {
+                            *idx_in_tup != idx
+                        }).map(|(_, t)| t.clone()).collect();
+                        if filtered.is_empty() {
+                            return Arc::new(CType::Void);
+                        }
+                        if filtered.len() == 1 {
+                            return filtered.into_iter().next().unwrap();
+                        }
+                        return Arc::new(CType::Tuple(filtered));
+                    }
+                    otherwise => {
+                        CType::fail(&format!(
+                            "Exclude index must be a name or integer, not {otherwise:?}"
+                        ))
+                    }
+                };
+                if result.is_empty() {
+                    return Arc::new(CType::Void);
+                }
+                Arc::new(CType::Tuple(result))
+            }
+            CType::Field(name, _) => {
+                match &*n {
+                    CType::TString(s) => {
+                        if name == s {
+                            Arc::new(CType::Void)
+                        } else {
+                            Arc::new(CType::Fail(format!("Field name {s} does not match {name}")))
+                        }
+                    }
+                    CType::Int(i) => {
+                        if *i == 0 {
+                            Arc::new(CType::Void)
+                        } else {
+                            Arc::new(CType::Fail("Cannot exclude value (index 1) from Field type, only label (index 0)".to_string()))
+                        }
+                    }
+                    otherwise => {
+                        CType::fail(&format!(
+                            "Exclude index must be a name or integer, not {otherwise:?}"
+                        ))
+                    }
+                }
+            }
+            otherwise => CType::fail(&format!(
+                "Cannot exclude from type {otherwise:?}. Only Either, Tuple, and Field types are supported."
+            )),
         }
     }
     pub fn size(t: Arc<CType>) -> Arc<CType> {
@@ -5577,6 +5685,7 @@ pub fn typebaselist_to_ctype(
                                         "Field" => CType::field(args.clone()),
                                         "Either" => CType::either(args.clone()),
                                         "Prop" => CType::prop(args[0].clone(), args[1].clone()),
+                                        "Exclude" => CType::exclude(args[0].clone(), args[1].clone()),
                                         "AnyOf" => CType::anyof(args.clone()),
                                         "Buffer" => CType::buffer(args.clone()),
                                         "Array" => Arc::new(CType::Array(args[0].clone())),
@@ -5584,9 +5693,8 @@ pub fn typebaselist_to_ctype(
                                         "Min" => CType::min(args[0].clone(), args[1].clone()),
                                         "Max" => CType::max(args[0].clone(), args[1].clone()),
                                         "Neg" => CType::neg(args[0].clone()),
-                                        "Len" => CType::len(args[0].clone()),
-                                        "Rest" => CType::trest(args[0].clone()),
-                                        "Size" => CType::size(args[0].clone()),
+                                       "Len" => CType::len(args[0].clone()),
+                                         "Size" => CType::size(args[0].clone()),
                                         "FileStr" => CType::filestr(args[0].clone()),
                                         "Concat" => CType::concat(args[0].clone(), args[1].clone()),
                                         "Env" => CType::env(args[0].clone()),

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -5761,6 +5761,41 @@ pub fn typebaselist_to_ctype(
                                     }
                                 }
                             }
+                            CType::IntrinsicGeneric(e, 2) if e == "Exclude" => {
+                                match nexttypebase {
+                                    None => {},
+                                    Some(next) => match next {
+                                        parse::TypeBase::GnCall(g) => {
+                                            // Same as Prop: the second arg (the index/field to exclude)
+                                            // can be a bare identifier treated as a string
+                                            if g.typecalllist.len() != 3 {
+                                                CType::fail("The Exclude generic type accepts only two parameters");
+                                            }
+                                            args.push(withtypeoperatorslist_to_ctype(&vec![g.typecalllist[0].clone()], scope)?);
+                                            let second_arg_str = g.typecalllist[2].to_string();
+                                            match second_arg_str.parse::<i128>() {
+                                                Ok(i) => args.push(Arc::new(CType::Int(i))),
+                                                Err(_) => {
+                                                    if let parse::WithTypeOperators::TypeBaseList(tbl) = &g.typecalllist[2] {
+                                                        if tbl.len() > 1 {
+                                                            args.push(withtypeoperatorslist_to_ctype(&vec![g.typecalllist[2].clone()], scope)?);
+                                                        } else {
+                                                            match second_arg_str.as_str() {
+                                                                "true" => args.push(Arc::new(CType::Bool(true))),
+                                                                "false" => args.push(Arc::new(CType::Bool(false))),
+                                                                _ => args.push(Arc::new(CType::TString(second_arg_str)))
+                                                            }
+                                                        }
+                                                    } else {
+                                                        CType::fail("huh?")
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        _ => CType::fail("Cannot follow method style syntax without an operator in between"),
+                                    }
+                                }
+                            }
                             CType::IntrinsicGeneric(f, 2) if f == "Field" => {
                                 match nexttypebase {
                                     None => {},

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -18,7 +18,7 @@ use crate::parse;
 pub enum CType {
     Void,
     DerivedVoid(Vec<Arc<CType>>), // void with parent types for Exclude{...} constructors
-    Infer(String, String), // TODO: Switch to an Interface here once they exist
+    Infer(String, String),        // TODO: Switch to an Interface here once they exist
     Type(String, Arc<CType>),
     Generic(String, Vec<String>, Arc<CType>),
     Binds(Arc<CType>, Vec<Arc<CType>>),

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -3581,12 +3581,17 @@ impl CType {
                             }
                         }
                     }
-                    // Create the parent constructor: fn TypeName(arg: ParentType) -> TypeName
+                    // Create the parent constructor: fn TypeName(arg: ParentType) -> Maybe{TypeName}
+                    // Returns Maybe because the parent may hold the excluded variant
+                    let maybe_ret = Arc::new(CType::Either(
+                        vec![t.clone(), Arc::new(CType::Void)],
+                        Vec::new(),
+                    ));
                     fs.push(Arc::new(Function {
                         name: constructor_fn_name.clone(),
                         typen: Arc::new(CType::Function(
                             Arc::new(CType::Tuple(vec![parent.clone()], Vec::new())),
-                            t.clone(),
+                            maybe_ret,
                         )),
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -65,6 +65,7 @@ pub enum CType {
     Max(Vec<Arc<CType>>),
     Neg(Arc<CType>),
     Len(Arc<CType>),
+    Rest(Arc<CType>),
     Size(Arc<CType>),
     FileStr(Arc<CType>),
     Concat(Arc<CType>, Arc<CType>),
@@ -523,6 +524,11 @@ impl CType {
                 }
                 CType::Len(t) => {
                     str_parts.push("Len{");
+                    ctype_stack.push(close_brace);
+                    ctype_stack.push(t);
+                }
+                CType::Rest(t) => {
+                    str_parts.push("Rest{");
                     ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
@@ -1036,6 +1042,11 @@ impl CType {
                     ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
+                CType::Rest(t) => {
+                    str_parts.push("Rest{");
+                    ctype_stack.push(close_brace);
+                    ctype_stack.push(t);
+                }
                 CType::Size(t) => {
                     str_parts.push("Size{");
                     ctype_stack.push(close_brace);
@@ -1280,6 +1291,7 @@ impl CType {
             | CType::Field(_, t)
             | CType::Neg(t)
             | CType::Len(t)
+            | CType::Rest(t)
             | CType::Size(t)
             | CType::FileStr(t)
             | CType::EnvExists(t)
@@ -1429,6 +1441,7 @@ impl CType {
             )),
             CType::Neg(t) => Arc::new(CType::Neg(t.clone().degroup())),
             CType::Len(t) => Arc::new(CType::Len(t.clone().degroup())),
+            CType::Rest(t) => Arc::new(CType::Rest(t.clone().degroup())),
             CType::Size(t) => Arc::new(CType::Size(t.clone().degroup())),
             CType::FileStr(t) => Arc::new(CType::FileStr(t.clone().degroup())),
             CType::Concat(a, b) => {
@@ -2061,6 +2074,7 @@ impl CType {
                         | CType::Max(_)
                         | CType::Neg(_)
                         | CType::Len(_)
+                        | CType::Rest(_)
                         | CType::Size(_),
                     ) => {
                         // TODO: This should allow us to constrain which generic values are
@@ -2209,6 +2223,10 @@ impl CType {
                         input.push(t2.clone());
                     }
                     (CType::Len(t1), CType::Len(t2)) => {
+                        arg.push(t1.clone());
+                        input.push(t2.clone());
+                    }
+                    (CType::Rest(t1), CType::Rest(t2)) => {
                         arg.push(t1.clone());
                         input.push(t2.clone());
                     }
@@ -3962,6 +3980,7 @@ impl CType {
                 .unwrap(),
             CType::Neg(t) => CType::neg(t.clone().swap_subtype(old_type, new_type)),
             CType::Len(t) => CType::len(t.clone().swap_subtype(old_type, new_type)),
+            CType::Rest(t) => CType::trest(t.clone().swap_subtype(old_type, new_type)),
             CType::Size(t) => CType::size(t.clone().swap_subtype(old_type, new_type)),
             CType::FileStr(t) => CType::filestr(t.clone().swap_subtype(old_type, new_type)),
             CType::Concat(a, b) => CType::concat(
@@ -4287,6 +4306,13 @@ impl CType {
             },
             CType::Tuple(ts) | CType::Either(ts) => match &*p {
                 CType::TString(s) => {
+                    if let Ok(i) = s.parse::<i128>() {
+                        if (0..ts.len()).contains(&(i as usize)) {
+                            return ts[i as usize].clone();
+                        } else {
+                            return Arc::new(CType::Fail(format!("{i} is out of bounds for type {t:?}")));
+                        }
+                    }
                     for inner in ts {
                         if let CType::Field(n, f) = &**inner {
                             if n == s {
@@ -4430,6 +4456,27 @@ impl CType {
             }
             CType::Infer(..) => Arc::new(CType::Len(t)),
             _ => Arc::new(CType::Int(1)),
+        }
+    }
+    pub fn trest(t: Arc<CType>) -> Arc<CType> {
+        match &*t {
+            CType::Either(ts) => {
+                if ts.is_empty() {
+                    return Arc::new(CType::Void);
+                }
+                let mut rest: Vec<Arc<CType>> = ts[1..].to_vec();
+                if rest.is_empty() {
+                    return Arc::new(CType::Void);
+                }
+                if !matches!(*rest[rest.len() - 1], CType::Void) {
+                    rest.push(Arc::new(CType::Void));
+                }
+                Arc::new(CType::Either(rest))
+            }
+            CType::Type(_, inner) => CType::trest(inner.clone()),
+            CType::Group(inner) => CType::trest(inner.clone()),
+            CType::Infer(..) => Arc::new(CType::Rest(t)),
+            _ => CType::fail("Rest can only be computed for Either types"),
         }
     }
     pub fn size(t: Arc<CType>) -> Arc<CType> {
@@ -5538,6 +5585,7 @@ pub fn typebaselist_to_ctype(
                                         "Max" => CType::max(args[0].clone(), args[1].clone()),
                                         "Neg" => CType::neg(args[0].clone()),
                                         "Len" => CType::len(args[0].clone()),
+                                        "Rest" => CType::trest(args[0].clone()),
                                         "Size" => CType::size(args[0].clone()),
                                         "FileStr" => CType::filestr(args[0].clone()),
                                         "Concat" => CType::concat(args[0].clone(), args[1].clone()),

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -17,6 +17,7 @@ use crate::parse;
 #[derive(Clone, Debug, PartialEq)]
 pub enum CType {
     Void,
+    DerivedVoid(Vec<Arc<CType>>), // void with parent types for Exclude{...} constructors
     Infer(String, String), // TODO: Switch to an Interface here once they exist
     Type(String, Arc<CType>),
     Generic(String, Vec<String>, Arc<CType>),
@@ -195,7 +196,7 @@ impl CType {
             GTE.get_or_init(|| Arc::new(CType::Infer(" >= ".to_string(), " >= ".to_string())));
         while let Some(element) = ctype_stack.pop() {
             match &**element {
-                CType::Void => str_parts.push("()"),
+                CType::Void | CType::DerivedVoid(..) => str_parts.push("()"),
                 CType::Infer(s, _) => str_parts.push(s),
                 CType::Type(n, t) => match strict {
                     true => str_parts.push(n),
@@ -699,7 +700,7 @@ impl CType {
             COMMA.get_or_init(|| Arc::new(CType::Infer(", ".to_string(), ", ".to_string())));
         while let Some(element) = ctype_stack.pop() {
             match &**element {
-                CType::Void => str_parts.push("void"),
+                CType::Void | CType::DerivedVoid(..) => str_parts.push("void"),
                 CType::Infer(s, _) => str_parts.push(s),
                 CType::Type(_, t) => ctype_stack.push(t),
                 CType::Generic(n, gs, _) => {
@@ -1298,6 +1299,7 @@ impl CType {
     pub fn has_infer(self: Arc<CType>) -> bool {
         match &*self {
             CType::Void
+            | CType::DerivedVoid(..)
             | CType::IntrinsicGeneric(..)
             | CType::Int(_)
             | CType::Float(_)
@@ -1372,7 +1374,7 @@ impl CType {
 
     pub fn degroup(self: Arc<CType>) -> Arc<CType> {
         match &*self {
-            CType::Void => self,
+            CType::Void | CType::DerivedVoid(..) => self,
             CType::Infer(..) => self,
             CType::Type(n, t) => Arc::new(CType::Type(n.clone(), t.clone().degroup())),
             CType::Generic(..) => self,
@@ -3750,6 +3752,25 @@ impl CType {
                     }));
                 }
             }
+            CType::DerivedVoid(parents) => {
+                // Generate parent constructor functions that take parent type and return void
+                for parent in parents {
+                    let parent_unwrapped = parent.clone().degroup();
+                    if !matches!(&*parent_unwrapped, CType::Tuple(..) | CType::Either(..)) {
+                        continue;
+                    }
+                    fs.push(Arc::new(Function {
+                        name: constructor_fn_name.clone(),
+                        typen: Arc::new(CType::Function(
+                            Arc::new(CType::Tuple(vec![parent.clone()], Vec::new())),
+                            Arc::new(CType::Void),
+                        )),
+                        microstatements: Vec::new(),
+                        kind: FnKind::Derived,
+                        origin_scope_path: scope.path.clone(),
+                    }));
+                }
+            }
             _ => {} // Don't do anything for other types
         }
         (CType::clone(&t), fs)
@@ -3979,6 +4000,7 @@ impl CType {
         }
         match &*self {
             CType::Void
+            | CType::DerivedVoid(..)
             | CType::Infer(..)
             | CType::Generic(..)
             | CType::IntrinsicGeneric(..)
@@ -4646,11 +4668,11 @@ impl CType {
                         }
                         let filtered: Vec<Arc<CType>> = ts.iter().enumerate().filter(|(idx_in_either, _)| {
                             *idx_in_either != idx
-                        }).map(|(_, t)| t.clone()).collect();
-                        if filtered.is_empty() {
-                            return Arc::new(CType::Void);
-                        }
-                        filtered
+                         }).map(|(_, t)| t.clone()).collect();
+                         if filtered.is_empty() {
+                             return Arc::new(CType::DerivedVoid(parents));
+                         }
+                         filtered
                     }
                     otherwise => {
                         CType::fail(&format!(
@@ -4659,7 +4681,7 @@ impl CType {
                     }
                 };
                 if result.is_empty() {
-                    return Arc::new(CType::Void);
+                    return Arc::new(CType::DerivedVoid(parents));
                 }
                 if result.len() == 1 {
                     return Arc::new(CType::Either(result, parents));
@@ -4689,7 +4711,7 @@ impl CType {
                             *idx_in_tup != idx
                         }).map(|(_, t)| t.clone()).collect();
                         if filtered.is_empty() {
-                            return Arc::new(CType::Void);
+                            return Arc::new(CType::DerivedVoid(parents));
                         }
                         if filtered.len() == 1 {
                             return Arc::new(CType::Tuple(filtered, parents));
@@ -4703,7 +4725,7 @@ impl CType {
                     }
                 };
                 if result.is_empty() {
-                    return Arc::new(CType::Void);
+                    return Arc::new(CType::DerivedVoid(parents));
                 }
                 Arc::new(CType::Tuple(result, parents))
             }
@@ -4806,7 +4828,7 @@ impl CType {
         // particularly for writing to disk or interfacing with network protocols, etc, so I'd
         // prefer to keep it and have some compile-time guarantees we don't normally see.
         match &*t {
-            CType::Void => Arc::new(CType::Int(0)),
+            CType::Void | CType::DerivedVoid(..) => Arc::new(CType::Int(0)),
             CType::Infer(..) => Arc::new(CType::Size(t.clone())),
             CType::Type(_, t) => CType::size(t.clone()),
             CType::Generic(..) => CType::fail("Cannot determine the size of an unbound generic"),

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -47,9 +47,9 @@ pub enum CType {
     Nodejs(Arc<CType>),
     From(Arc<CType>),
     Import(Arc<CType>, Arc<CType>),
-    Tuple(Vec<Arc<CType>>),
+    Tuple(Vec<Arc<CType>>, Vec<Arc<CType>>),
     Field(String, Arc<CType>),
-    Either(Vec<Arc<CType>>),
+    Either(Vec<Arc<CType>>, Vec<Arc<CType>>),
     Prop(Arc<CType>, Arc<CType>),
     Exclude(Arc<CType>, Arc<CType>),
     AnyOf(Vec<Arc<CType>>),
@@ -66,7 +66,7 @@ pub enum CType {
     Max(Vec<Arc<CType>>),
     Neg(Arc<CType>),
     Len(Arc<CType>),
- 
+
     Size(Arc<CType>),
     FileStr(Arc<CType>),
     Concat(Arc<CType>, Arc<CType>),
@@ -398,7 +398,7 @@ impl CType {
                         ctype_stack.push(n);
                     }
                 },
-                CType::Tuple(ts) => {
+                CType::Tuple(ts, _) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
                             ctype_stack.push(comma);
@@ -414,7 +414,7 @@ impl CType {
                     }
                     false => ctype_stack.push(t),
                 },
-                CType::Either(ts) => {
+                CType::Either(ts, _) => {
                     for (i, t) in ts.iter().rev().enumerate() {
                         if i != 0 {
                             ctype_stack.push(or);
@@ -894,7 +894,7 @@ impl CType {
                     ctype_stack.push(comma);
                     ctype_stack.push(n);
                 }
-                CType::Tuple(ts) => {
+                CType::Tuple(ts, _) => {
                     str_parts.push("Tuple{");
                     ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
@@ -911,7 +911,7 @@ impl CType {
                     ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
-                CType::Either(ts) => {
+                CType::Either(ts, _) => {
                     str_parts.push("Either{");
                     ctype_stack.push(close_brace);
                     for (i, t) in ts.iter().rev().enumerate() {
@@ -1237,13 +1237,45 @@ impl CType {
             CType::TString(s) if s.starts_with(|c: char| c.is_ascii_digit()) => {
                 format!("_{}", self.clone().to_functional_string())
             }
-            CType::Type(n, t) => match **t {
+            CType::Type(n, t) => match &**t {
                 CType::Int(_) | CType::Float(_) => {
                     format!("_{}", self.clone().to_functional_string())
                 }
                 CType::Binds(..) => n.clone(),
+                CType::Exclude(et, ep) => {
+                    let resolved = CType::exclude(et.clone(), ep.clone());
+                    if matches!(&*resolved, CType::Exclude(..)) {
+                        self.clone().to_functional_string()
+                    } else {
+                        resolved.to_callable_string()
+                    }
+                }
+                CType::Type(_, inner) => {
+                    if matches!(&**inner, CType::Exclude(..)) {
+                        let (et, ep) = match &**inner {
+                            CType::Exclude(et, ep) => (et.clone(), ep.clone()),
+                            _ => unreachable!(),
+                        };
+                        let resolved = CType::exclude(et, ep);
+                        if matches!(&*resolved, CType::Exclude(..)) {
+                            self.clone().to_functional_string()
+                        } else {
+                            resolved.to_callable_string()
+                        }
+                    } else {
+                        self.clone().to_functional_string()
+                    }
+                }
                 _ => self.clone().to_functional_string(),
             },
+            CType::Exclude(t, p) => {
+                let resolved = CType::exclude(t.clone(), p.clone());
+                if matches!(&*resolved, CType::Exclude(..)) {
+                    self.clone().to_functional_string()
+                } else {
+                    resolved.to_callable_string()
+                }
+            }
             _ => self.clone().to_functional_string(),
         }
         .chars()
@@ -1311,8 +1343,8 @@ impl CType {
             | CType::Exclude(a, b)
             | CType::Buffer(a, b)
             | CType::Concat(a, b) => a.clone().has_infer() || b.clone().has_infer(),
-            CType::Tuple(ts)
-            | CType::Either(ts)
+            CType::Tuple(ts, _)
+            | CType::Either(ts, _)
             | CType::AnyOf(ts)
             | CType::Add(ts)
             | CType::Sub(ts)
@@ -1382,19 +1414,29 @@ impl CType {
             CType::Import(n, d) => {
                 Arc::new(CType::Import(n.clone().degroup(), d.clone().degroup()))
             }
-            CType::Tuple(ts) => Arc::new(CType::Tuple(
+            CType::Tuple(ts, parents) => Arc::new(CType::Tuple(
                 ts.iter()
+                    .map(|t| t.clone().degroup())
+                    .collect::<Vec<Arc<CType>>>(),
+                parents
+                    .iter()
                     .map(|t| t.clone().degroup())
                     .collect::<Vec<Arc<CType>>>(),
             )),
             CType::Field(l, t) => Arc::new(CType::Field(l.clone(), t.clone().degroup())),
-            CType::Either(ts) => Arc::new(CType::Either(
+            CType::Either(ts, parents) => Arc::new(CType::Either(
                 ts.iter()
+                    .map(|t| t.clone().degroup())
+                    .collect::<Vec<Arc<CType>>>(),
+                parents
+                    .iter()
                     .map(|t| t.clone().degroup())
                     .collect::<Vec<Arc<CType>>>(),
             )),
             CType::Prop(t, p) => Arc::new(CType::Prop(t.clone().degroup(), p.clone().degroup())),
-            CType::Exclude(t, p) => Arc::new(CType::Exclude(t.clone().degroup(), p.clone().degroup())),
+            CType::Exclude(t, p) => {
+                Arc::new(CType::Exclude(t.clone().degroup(), p.clone().degroup()))
+            }
             CType::AnyOf(ts) => Arc::new(CType::AnyOf(
                 ts.iter()
                     .map(|t| t.clone().degroup())
@@ -1700,14 +1742,14 @@ impl CType {
                     }
                     (CType::Function(i1, o1), CType::Function(i2, o2)) => {
                         match &**i1 {
-                            CType::Tuple(ts1) if ts1.len() == 1 => {
+                            CType::Tuple(ts1, _) if ts1.len() == 1 => {
                                 arg.push(ts1[0].clone());
                             }
                             _otherwise => arg.push(i1.clone()),
                         }
                         arg.push(o1.clone());
                         match &**i2 {
-                            CType::Tuple(ts2) if ts2.len() == 1 => {
+                            CType::Tuple(ts2, _) if ts2.len() == 1 => {
                                 input.push(ts2[0].clone());
                             }
                             _otherwise => input.push(i2.clone()),
@@ -1776,7 +1818,7 @@ impl CType {
                         input.push(n2.clone());
                         input.push(d2.clone());
                     }
-                    (CType::Tuple(ts1), CType::Tuple(ts2)) => {
+                    (CType::Tuple(ts1, _), CType::Tuple(ts2, _)) => {
                         if ts1.len() != ts2.len() {
                             return Err(format!(
                                 "Mismatched tuple types {} and {} found during inference",
@@ -1816,7 +1858,7 @@ impl CType {
                             CType::StringCast(sc) => match &**sc {
                                 CType::Infer(..) => match &**t {
                                     CType::Type(_, it) => match &**it {
-                                        CType::Tuple(tp) => {
+                                        CType::Tuple(tp, _) => {
                                             let mut found = false;
                                             for r in tp {
                                                 if let CType::Field(l, v) = &**r {
@@ -1845,7 +1887,7 @@ impl CType {
                                             return Err("Property extraction inference only possible on a tuple type".into());
                                         }
                                     },
-                                    CType::Tuple(tp) => {
+                                    CType::Tuple(tp, _) => {
                                         let mut found = false;
                                         for r in tp {
                                             if let CType::Field(l, v) = &**r {
@@ -1886,7 +1928,7 @@ impl CType {
                                                 match &**sc {
                                                     CType::Infer(..) => match &**t {
                                                         CType::Type(_, it) => match &**it {
-                                                            CType::Tuple(tp) => {
+                                                            CType::Tuple(tp, _) => {
                                                                 let mut found = false;
                                                                 for r in tp {
                                                                     if let CType::Field(l, v) = &**r
@@ -1912,7 +1954,7 @@ impl CType {
                                                                 return Err("Property extraction inference only possible on a tuple type".into());
                                                             }
                                                         },
-                                                        CType::Tuple(tp) => {
+                                                        CType::Tuple(tp, _) => {
                                                             let mut found = false;
                                                             for r in tp {
                                                                 if let CType::Field(l, v) = &**r {
@@ -1980,7 +2022,7 @@ impl CType {
                         arg.push(t1.clone());
                         input.push(i.clone());
                     }
-                    (CType::Either(ts1), CType::Either(ts2)) => {
+                    (CType::Either(ts1, _), CType::Either(ts2, _)) => {
                         if ts1.len() != ts2.len() {
                             return Err(format!(
                                 "Mismatched either types {} and {} found during inference",
@@ -2743,7 +2785,7 @@ impl CType {
                     // TODO: Do this the right way with `infer_generics`, but I need to refactor a
                     // lot to get the scope into this function. For now, let's just assume if the
                     // lengths of the input tuples are the same, we're fine, and if not, we're not.
-                    matches!((&**i1, &**i2), (CType::Tuple(ts1), CType::Tuple(ts2)) if ts1.len() == ts2.len())
+                    matches!((&**i1, &**i2), (CType::Tuple(ts1, _), CType::Tuple(ts2, _)) if ts1.len() == ts2.len())
                 } else {
                     // Should be impossible
                     false
@@ -3153,6 +3195,7 @@ impl CType {
                                         ))
                                     })
                                     .collect::<Vec<Arc<CType>>>(),
+                                Vec::new(),
                             )),
                             rettype,
                         ));
@@ -3179,7 +3222,7 @@ impl CType {
                     origin_scope_path: scope.path.clone(),
                 }));
             }
-            CType::Tuple(ts) => {
+            CType::Tuple(ts, parents) => {
                 // The constructor function needs to grab the types from all
                 // arguments to construct the desired product type. For any type
                 // that is marked as a field, we also want to create an accessor
@@ -3318,13 +3361,44 @@ impl CType {
                 fs.push(Arc::new(Function {
                     name: constructor_fn_name.clone(),
                     typen: Arc::new(CType::Function(
-                        Arc::new(CType::Tuple(actual_ts.clone())),
+                        Arc::new(CType::Tuple(actual_ts.clone(), Vec::new())),
                         t.clone(),
                     )),
                     microstatements: Vec::new(),
                     kind: FnKind::Derived,
                     origin_scope_path: scope.path.clone(),
                 }));
+                // Generate parent constructor functions for each parent type
+                for parent in parents {
+                    let parent_unwrapped = parent.clone().degroup();
+                    let parent_fields = match &*parent_unwrapped {
+                        CType::Tuple(pf, _) => pf.clone(),
+                        CType::Either(pf, _) => pf.clone(),
+                        _ => continue,
+                    };
+                    // Build the list of field indices in the parent that match our fields
+                    let mut indices = Vec::new();
+                    for child_field in &actual_ts {
+                        let child_key = child_field.clone().degroup().to_callable_string();
+                        for (idx, pf) in parent_fields.iter().enumerate() {
+                            if pf.clone().degroup().to_callable_string() == child_key {
+                                indices.push(idx);
+                                break;
+                            }
+                        }
+                    }
+                    // Create the parent constructor: fn TypeName(arg: ParentType) -> TypeName
+                    fs.push(Arc::new(Function {
+                        name: constructor_fn_name.clone(),
+                        typen: Arc::new(CType::Function(
+                            Arc::new(CType::Tuple(vec![parent.clone()], Vec::new())),
+                            t.clone(),
+                        )),
+                        microstatements: Vec::new(),
+                        kind: FnKind::Derived,
+                        origin_scope_path: scope.path.clone(),
+                    }));
+                }
             }
             CType::Field(n, f) => {
                 // This is a "baby tuple" of just one value. So we follow the Tuple logic, but
@@ -3416,7 +3490,8 @@ impl CType {
                     origin_scope_path: scope.path.clone(),
                 }));
             }
-            CType::Either(ts) => {
+
+            CType::Either(ts, parents) => {
                 // There are an equal number of constructor functions and accessor
                 // functions, one for each inner type of the sum type.
                 for e in ts {
@@ -3424,10 +3499,10 @@ impl CType {
                     fs.push(Arc::new(Function {
                         name: constructor_fn_name.clone(),
                         typen: Arc::new(CType::Function(
-                            Arc::new(CType::Tuple(vec![Arc::new(CType::Field(
-                                "arg0".to_string(),
-                                e.clone(),
-                            ))])),
+                            Arc::new(CType::Tuple(
+                                vec![Arc::new(CType::Field("arg0".to_string(), e.clone()))],
+                                Vec::new(),
+                            )),
                             t.clone(),
                         )),
                         microstatements: Vec::new(),
@@ -3438,7 +3513,7 @@ impl CType {
                     fs.push(Arc::new(Function {
                         name: "store".to_string(),
                         typen: Arc::new(CType::Function(
-                            Arc::new(CType::Tuple(vec![t.clone(), e.clone()])),
+                            Arc::new(CType::Tuple(vec![t.clone(), e.clone()], Vec::new())),
                             t.clone(),
                         )),
                         microstatements: Vec::new(),
@@ -3462,7 +3537,10 @@ impl CType {
                             name: n.clone(),
                             typen: Arc::new(CType::Function(
                                 t.clone(),
-                                Arc::new(CType::Either(vec![i.clone(), Arc::new(CType::Void)])),
+                                Arc::new(CType::Either(
+                                    vec![i.clone(), Arc::new(CType::Void)],
+                                    Vec::new(),
+                                )),
                             )),
                             microstatements: Vec::new(),
                             kind: FnKind::Derived,
@@ -3472,7 +3550,10 @@ impl CType {
                             name: n.clone(),
                             typen: Arc::new(CType::Function(
                                 t.clone(),
-                                Arc::new(CType::Either(vec![e.clone(), Arc::new(CType::Void)])),
+                                Arc::new(CType::Either(
+                                    vec![e.clone(), Arc::new(CType::Void)],
+                                    Vec::new(),
+                                )),
                             )),
                             microstatements: Vec::new(),
                             kind: FnKind::Derived,
@@ -3480,6 +3561,37 @@ impl CType {
                         })),
                         _ => {} // We can't make names for other types
                     }
+                }
+                // Generate parent constructor functions for each parent type
+                for parent in parents {
+                    let parent_unwrapped = parent.clone().degroup();
+                    let parent_fields = match &*parent_unwrapped {
+                        CType::Tuple(pf, _) => pf.clone(),
+                        CType::Either(pf, _) => pf.clone(),
+                        _ => continue,
+                    };
+                    // Build the list of field indices in the parent that match our fields
+                    let mut indices = Vec::new();
+                    for child_field in ts {
+                        let child_key = child_field.clone().degroup().to_callable_string();
+                        for (idx, pf) in parent_fields.iter().enumerate() {
+                            if pf.clone().degroup().to_callable_string() == child_key {
+                                indices.push(idx);
+                                break;
+                            }
+                        }
+                    }
+                    // Create the parent constructor: fn TypeName(arg: ParentType) -> TypeName
+                    fs.push(Arc::new(Function {
+                        name: constructor_fn_name.clone(),
+                        typen: Arc::new(CType::Function(
+                            Arc::new(CType::Tuple(vec![parent.clone()], Vec::new())),
+                            t.clone(),
+                        )),
+                        microstatements: Vec::new(),
+                        kind: FnKind::Derived,
+                        origin_scope_path: scope.path.clone(),
+                    }));
                 }
             }
             CType::Buffer(b, s) => {
@@ -3503,13 +3615,16 @@ impl CType {
                     fs.push(Arc::new(Function {
                         name: constructor_fn_name.clone(),
                         typen: Arc::new(CType::Function(
-                            Arc::new(CType::Tuple({
-                                let mut v = Vec::new();
-                                for _ in 0..size {
-                                    v.push(b.clone());
-                                }
-                                v
-                            })),
+                            Arc::new(CType::Tuple(
+                                {
+                                    let mut v = Vec::new();
+                                    for _ in 0..size {
+                                        v.push(b.clone());
+                                    }
+                                    v
+                                },
+                                Vec::new(),
+                            )),
                             t.clone(),
                         )),
                         microstatements: Vec::new(),
@@ -3698,7 +3813,7 @@ impl CType {
                 }
                 // Let's just avoid the "bare field" type definition and auto-wrap into a tuple
                 if let CType::Field(..) = &*inner_type {
-                    inner_type = Arc::new(CType::Tuple(vec![inner_type]));
+                    inner_type = Arc::new(CType::Tuple(vec![inner_type], Vec::new()));
                 }
                 // Magic hackery to convert a `From` type into an `Import` type if it's the top-level type
                 inner_type = match &*inner_type {
@@ -3914,8 +4029,12 @@ impl CType {
                 n.clone().swap_subtype(old_type.clone(), new_type.clone()),
                 d.clone().swap_subtype(old_type, new_type),
             )),
-            CType::Tuple(ts) => Arc::new(CType::Tuple(
+            CType::Tuple(ts, parents) => Arc::new(CType::Tuple(
                 ts.iter()
+                    .map(|t| t.clone().swap_subtype(old_type.clone(), new_type.clone()))
+                    .collect::<Vec<Arc<CType>>>(),
+                parents
+                    .iter()
                     .map(|t| t.clone().swap_subtype(old_type.clone(), new_type.clone()))
                     .collect::<Vec<Arc<CType>>>(),
             )),
@@ -3923,8 +4042,12 @@ impl CType {
                 name.clone(),
                 t.clone().swap_subtype(old_type, new_type),
             )),
-            CType::Either(ts) => Arc::new(CType::Either(
+            CType::Either(ts, parents) => Arc::new(CType::Either(
                 ts.iter()
+                    .map(|t| t.clone().swap_subtype(old_type.clone(), new_type.clone()))
+                    .collect::<Vec<Arc<CType>>>(),
+                parents
+                    .iter()
                     .map(|t| t.clone().swap_subtype(old_type.clone(), new_type.clone()))
                     .collect::<Vec<Arc<CType>>>(),
             )),
@@ -3986,7 +4109,10 @@ impl CType {
                 .unwrap(),
             CType::Neg(t) => CType::neg(t.clone().swap_subtype(old_type, new_type)),
             CType::Len(t) => CType::len(t.clone().swap_subtype(old_type, new_type)),
-            CType::Exclude(t, p) => CType::exclude(t.clone().swap_subtype(old_type.clone(), new_type.clone()), p.clone().swap_subtype(old_type, new_type)),
+            CType::Exclude(t, p) => CType::exclude(
+                t.clone().swap_subtype(old_type.clone(), new_type.clone()),
+                p.clone().swap_subtype(old_type, new_type),
+            ),
             CType::Size(t) => CType::size(t.clone().swap_subtype(old_type, new_type)),
             CType::FileStr(t) => CType::filestr(t.clone().swap_subtype(old_type, new_type)),
             CType::Concat(a, b) => CType::concat(
@@ -4241,7 +4367,7 @@ impl CType {
         let mut out_vec = Vec::new();
         for arg in args {
             match &*arg {
-                CType::Tuple(ts) => {
+                CType::Tuple(ts, _) => {
                     for t in ts {
                         out_vec.push(t.clone());
                     }
@@ -4249,13 +4375,13 @@ impl CType {
                 _other => out_vec.push(arg),
             }
         }
-        Arc::new(CType::Tuple(out_vec))
+        Arc::new(CType::Tuple(out_vec, Vec::new()))
     }
     pub fn either(args: Vec<Arc<CType>>) -> Arc<CType> {
         let mut out_vec = Vec::new();
         for arg in args {
             match &*arg {
-                CType::Either(ts) => {
+                CType::Either(ts, _) => {
                     for t in ts {
                         out_vec.push(t.clone());
                     }
@@ -4276,7 +4402,7 @@ impl CType {
         if deduped.len() == 1 {
             deduped.into_iter().next().unwrap()
         } else {
-            Arc::new(CType::Either(deduped))
+            Arc::new(CType::Either(deduped, Vec::new()))
         }
     }
     pub fn prop(t: Arc<CType>, p: Arc<CType>) -> Arc<CType> {
@@ -4310,13 +4436,15 @@ impl CType {
                     "Properties must be a name or integer location, not {otherwise:?}",
                 ))),
             },
-            CType::Tuple(ts) | CType::Either(ts) => match &*p {
+            CType::Tuple(ts, _) | CType::Either(ts, _) => match &*p {
                 CType::TString(s) => {
                     if let Ok(i) = s.parse::<i128>() {
                         if (0..ts.len()).contains(&(i as usize)) {
                             return ts[i as usize].clone();
                         } else {
-                            return Arc::new(CType::Fail(format!("{i} is out of bounds for type {t:?}")));
+                            return Arc::new(CType::Fail(format!(
+                                "{i} is out of bounds for type {t:?}"
+                            )));
                         }
                     }
                     for inner in ts {
@@ -4387,7 +4515,7 @@ impl CType {
                 _other => out_vec.push(arg),
             }
         }
-        Arc::new(CType::Either(out_vec))
+        Arc::new(CType::Either(out_vec, Vec::new()))
     }
     pub fn field(mut args: Vec<Arc<CType>>) -> Arc<CType> {
         if args.len() != 2 {
@@ -4449,14 +4577,14 @@ impl CType {
     }
     pub fn len(t: Arc<CType>) -> Arc<CType> {
         match &*t {
-            CType::Tuple(tup) => Arc::new(CType::Int(tup.len() as i128)),
+            CType::Tuple(tup, _) => Arc::new(CType::Int(tup.len() as i128)),
             CType::Buffer(_, l) => match **l {
                 CType::Int(l) => Arc::new(CType::Int(l)),
                 _ => {
                     CType::fail("Cannot get a compile time length for an invalid Buffer definition")
                 }
             },
-            CType::Either(eit) => Arc::new(CType::Int(eit.len() as i128)),
+            CType::Either(eit, _) => Arc::new(CType::Int(eit.len() as i128)),
             CType::Array(_) => {
                 CType::fail("Cannot get a compile time length for a variable-length array")
             }
@@ -4468,18 +4596,37 @@ impl CType {
         if t.clone().has_infer() || n.clone().has_infer() {
             return Arc::new(CType::Exclude(t, n));
         }
-        match &*t {
+        // Collect parent types from the original type, including transitive parents
+        let mut parents = Vec::new();
+        // Add the original type as the direct parent
+        parents.push(t.clone());
+        // Collect transitive parents from the unwrapped type
+        let unwrapped = t.clone().degroup();
+        match &*unwrapped {
+            CType::Type(_, inner) => {
+                match &**inner {
+                    CType::Tuple(_, inner_parents) => parents.extend(inner_parents.clone()),
+                    CType::Either(_, inner_parents) => parents.extend(inner_parents.clone()),
+                    _ => {}
+                }
+                return CType::exclude(inner.clone(), n);
+            }
+            CType::Group(inner) => {
+                return CType::exclude(inner.clone(), n);
+            }
+            CType::Tuple(_, inner_parents) => parents.extend(inner_parents.clone()),
+            CType::Either(_, inner_parents) => parents.extend(inner_parents.clone()),
+            _ => {}
+        }
+        match &*unwrapped {
             CType::Infer(..) => unreachable!(),
-            CType::Type(_, inner) => CType::exclude(inner.clone(), n),
-            CType::Group(inner) => CType::exclude(inner.clone(), n),
-            CType::Either(ts) => {
+            CType::Either(ts, _) => {
                 let result = match &*n {
                     CType::TString(s) => {
                         let filtered: Vec<Arc<CType>> = ts.iter().filter(|t| {
-                            if let CType::Field(name, _) = &***t {
-                                name != s
-                            } else {
-                                true
+                            match &***t {
+                                CType::Field(name, _) => name != s,
+                                _ => (**t).clone().to_callable_string() != *s,
                             }
                         }).cloned().collect();
                         if filtered.len() == ts.len() {
@@ -4492,14 +4639,11 @@ impl CType {
                         if idx >= ts.len() {
                             return Arc::new(CType::Fail(format!("Index {idx} out of bounds for Either type with {} variants", ts.len())));
                         }
-                        let mut filtered: Vec<Arc<CType>> = ts.iter().enumerate().filter(|(idx_in_either, _)| {
+                        let filtered: Vec<Arc<CType>> = ts.iter().enumerate().filter(|(idx_in_either, _)| {
                             *idx_in_either != idx
                         }).map(|(_, t)| t.clone()).collect();
                         if filtered.is_empty() {
                             return Arc::new(CType::Void);
-                        }
-                        if !matches!(*filtered[filtered.len() - 1], CType::Void) {
-                            filtered.push(Arc::new(CType::Void));
                         }
                         filtered
                     }
@@ -4513,18 +4657,17 @@ impl CType {
                     return Arc::new(CType::Void);
                 }
                 if result.len() == 1 {
-                    return result.into_iter().next().unwrap();
+                    return Arc::new(CType::Either(result, parents));
                 }
-                Arc::new(CType::Either(result))
+                Arc::new(CType::Either(result, parents))
             }
-            CType::Tuple(ts) => {
+            CType::Tuple(ts, _) => {
                 let result = match &*n {
                     CType::TString(s) => {
                         let filtered: Vec<Arc<CType>> = ts.iter().filter(|t| {
-                            if let CType::Field(name, _) = &***t {
-                                name != s
-                            } else {
-                                true
+                            match &***t {
+                                CType::Field(name, _) => name != s,
+                                _ => (**t).clone().to_callable_string() != *s,
                             }
                         }).cloned().collect();
                         if filtered.len() == ts.len() {
@@ -4544,9 +4687,9 @@ impl CType {
                             return Arc::new(CType::Void);
                         }
                         if filtered.len() == 1 {
-                            return filtered.into_iter().next().unwrap();
+                            return Arc::new(CType::Tuple(filtered, parents));
                         }
-                        return Arc::new(CType::Tuple(filtered));
+                        return Arc::new(CType::Tuple(filtered, parents));
                     }
                     otherwise => {
                         CType::fail(&format!(
@@ -4557,7 +4700,7 @@ impl CType {
                 if result.is_empty() {
                     return Arc::new(CType::Void);
                 }
-                Arc::new(CType::Tuple(result))
+                Arc::new(CType::Tuple(result, parents))
             }
             CType::Field(name, _) => {
                 match &*n {
@@ -4585,7 +4728,70 @@ impl CType {
             otherwise => CType::fail(&format!(
                 "Cannot exclude from type {otherwise:?}. Only Either, Tuple, and Field types are supported."
             )),
+         }
+    }
+    // After exclude produces a Tuple/Either with parents, check the scope for an existing type
+    // with matching field structure. If found, merge the parent lists and return the updated type.
+    pub fn merge_exclude_parents(result: Arc<CType>, scope: &Scope) -> Arc<CType> {
+        let (fields, parents) = match &*result {
+            CType::Tuple(fields, parents) => (fields.clone(), parents.clone()),
+            CType::Either(fields, parents) => (fields.clone(), parents.clone()),
+            _ => return result,
+        };
+        if parents.is_empty() {
+            return result;
         }
+        let result_fields_keys: Vec<String> = fields
+            .iter()
+            .map(|f| f.clone().degroup().to_callable_string())
+            .collect();
+        let result_key = result.clone().to_callable_string();
+        // Search scope for a type with matching structure but potentially different parents
+        if let Some(existing) = scope.types.get(&result_key) {
+            let existing_fields = match &**existing {
+                CType::Tuple(f, _) => f.clone(),
+                CType::Either(f, _) => f.clone(),
+                _ => return result,
+            };
+            // Compare field structure by callable string
+            let existing_fields_keys: Vec<String> = existing_fields
+                .iter()
+                .map(|f| f.clone().degroup().to_callable_string())
+                .collect();
+            if existing_fields_keys == result_fields_keys {
+                // Same field structure, merge parents
+                match &**existing {
+                    CType::Tuple(f, ep) => {
+                        let mut merged = ep.clone();
+                        for p in &parents {
+                            let pkey = p.clone().degroup().to_callable_string();
+                            if !merged
+                                .iter()
+                                .any(|mp| mp.clone().degroup().to_callable_string() == pkey)
+                            {
+                                merged.push(p.clone());
+                            }
+                        }
+                        return Arc::new(CType::Tuple(f.clone(), merged));
+                    }
+                    CType::Either(f, ep) => {
+                        let mut merged = ep.clone();
+                        for p in &parents {
+                            let pkey = p.clone().degroup().to_callable_string();
+                            if !merged
+                                .iter()
+                                .any(|mp| mp.clone().degroup().to_callable_string() == pkey)
+                            {
+                                merged.push(p.clone());
+                            }
+                        }
+                        return Arc::new(CType::Either(f.clone(), merged));
+                    }
+                    _ => {}
+                }
+            }
+        }
+        result
     }
     pub fn size(t: Arc<CType>) -> Arc<CType> {
         // TODO: Implementing this might require all types be made C-style structs under the hood,
@@ -4631,7 +4837,7 @@ impl CType {
             CType::Bool(_) => Arc::new(CType::Int(1)),
             CType::TString(s) => Arc::new(CType::Int(s.capacity() as i128)),
             CType::Group(t) | CType::Field(_, t) => CType::size(t.clone()),
-            CType::Tuple(ts) => {
+            CType::Tuple(ts, _) => {
                 let sizes = ts
                     .clone()
                     .into_iter()
@@ -4646,7 +4852,7 @@ impl CType {
                 }
                 Arc::new(CType::Int(out_size))
             }
-            CType::Either(ts) => {
+            CType::Either(ts, _) => {
                 let sizes = ts
                     .clone()
                     .into_iter()
@@ -4871,7 +5077,7 @@ impl CType {
         match &*c {
             CType::Bool(cond) => {
                 match &*t {
-                    CType::Tuple(tup) => {
+                    CType::Tuple(tup, _) => {
                         if tup.len() == 2 {
                             match cond {
                                 true => tup[0].clone(),
@@ -5439,7 +5645,7 @@ pub fn typebaselist_to_ctype(
                         }
                         parse::Constants::Strn(s) => {
                             prior_value = Some(match &*prior_value.unwrap() {
-                                CType::Tuple(ts) => {
+                                CType::Tuple(ts, _) => {
                                     let mut out = None;
                                     for t in ts {
                                         if let CType::Field(f, c) = &**t {
@@ -5472,13 +5678,13 @@ pub fn typebaselist_to_ctype(
                                     Err(_) => CType::fail("Indexing into a type must be done with positive integers"),
                                 };
                                     prior_value = Some(match &*prior_value.unwrap() {
-                                        CType::Tuple(ts) => match ts.get(idx) {
+                                        CType::Tuple(ts, _) => match ts.get(idx) {
                                             Some(t) => t.clone(),
                                             None => CType::fail(&format!(
                                                 "{idx} is larger than the size of {ts:?}"
                                             )),
                                         },
-                                        CType::Either(ts) => match ts.get(idx) {
+                                        CType::Either(ts, _) => match ts.get(idx) {
                                             Some(t) => t.clone(),
                                             None => CType::fail(&format!(
                                                 "{idx} is larger than the size of {ts:?}"
@@ -5685,7 +5891,11 @@ pub fn typebaselist_to_ctype(
                                         "Field" => CType::field(args.clone()),
                                         "Either" => CType::either(args.clone()),
                                         "Prop" => CType::prop(args[0].clone(), args[1].clone()),
-                                        "Exclude" => CType::exclude(args[0].clone(), args[1].clone()),
+                                        "Exclude" => {
+                                            let resolved =
+                                                CType::exclude(args[0].clone(), args[1].clone());
+                                            CType::merge_exclude_parents(resolved, scope)
+                                        }
                                         "AnyOf" => CType::anyof(args.clone()),
                                         "Buffer" => CType::buffer(args.clone()),
                                         "Array" => Arc::new(CType::Array(args[0].clone())),
@@ -5693,8 +5903,8 @@ pub fn typebaselist_to_ctype(
                                         "Min" => CType::min(args[0].clone(), args[1].clone()),
                                         "Max" => CType::max(args[0].clone(), args[1].clone()),
                                         "Neg" => CType::neg(args[0].clone()),
-                                       "Len" => CType::len(args[0].clone()),
-                                         "Size" => CType::size(args[0].clone()),
+                                        "Len" => CType::len(args[0].clone()),
+                                        "Size" => CType::size(args[0].clone()),
                                         "FileStr" => CType::filestr(args[0].clone()),
                                         "Concat" => CType::concat(args[0].clone(), args[1].clone()),
                                         "Env" => CType::env(args[0].clone()),

--- a/alan_compiler/src/program/function.rs
+++ b/alan_compiler/src/program/function.rs
@@ -544,7 +544,7 @@ impl Function {
         match &*typen {
             CType::Function(i, o) => {
                 match &**o {
-            CType::Void | CType::DerivedVoid(..) => { /* Do nothing */ }
+                    CType::Void | CType::DerivedVoid(..) => { /* Do nothing */ }
                     CType::Infer(t, _) if t == "unknown" && function_ast.optgenerics.is_none() => {
                         CType::fail(&format!(
                             "The return type for {}({}) could not be inferred.",

--- a/alan_compiler/src/program/function.rs
+++ b/alan_compiler/src/program/function.rs
@@ -45,7 +45,7 @@ pub fn type_to_args(t: Arc<CType>) -> Vec<(String, ArgKind, Arc<CType>)> {
                     CType::Mut(t) => args.push((argname.clone(), ArgKind::Mut, t.clone())),
                     _otherwise => args.push((argname.clone(), ArgKind::Ref, t.clone())),
                 },
-                CType::Void => { /* Do nothing */ }
+                CType::Void | CType::DerivedVoid(..) => { /* Do nothing */ }
                 CType::Own(t) => args.push(("arg0".to_string(), ArgKind::Own, t.clone())),
                 CType::Deref(t) => args.push(("arg0".to_string(), ArgKind::Deref, t.clone())),
                 CType::Mut(t) => args.push(("arg0".to_string(), ArgKind::Mut, t.clone())),
@@ -77,7 +77,7 @@ pub fn type_to_args(t: Arc<CType>) -> Vec<(String, ArgKind, Arc<CType>)> {
             CType::Mut(t) => vec![(argname.clone(), ArgKind::Mut, t.clone())],
             _otherwise => vec![(argname.clone(), ArgKind::Ref, t.clone())],
         },
-        CType::Void => Vec::new(),
+        CType::Void | CType::DerivedVoid(..) => Vec::new(),
         CType::Own(t) => vec![("arg0".to_string(), ArgKind::Own, t.clone())],
         CType::Deref(t) => vec![("arg0".to_string(), ArgKind::Deref, t.clone())],
         CType::Mut(t) => vec![("arg0".to_string(), ArgKind::Mut, t.clone())],
@@ -544,7 +544,7 @@ impl Function {
         match &*typen {
             CType::Function(i, o) => {
                 match &**o {
-                    CType::Void => { /* Do nothing */ }
+            CType::Void | CType::DerivedVoid(..) => { /* Do nothing */ }
                     CType::Infer(t, _) if t == "unknown" && function_ast.optgenerics.is_none() => {
                         CType::fail(&format!(
                             "The return type for {}({}) could not be inferred.",

--- a/alan_compiler/src/program/function.rs
+++ b/alan_compiler/src/program/function.rs
@@ -23,7 +23,7 @@ pub fn type_to_args(t: Arc<CType>) -> Vec<(String, ArgKind, Arc<CType>)> {
         CType::Function(i, _) => {
             let mut args = Vec::new();
             match &**i {
-                CType::Tuple(ts) => {
+                CType::Tuple(ts, _) => {
                     for (i, t) in ts.iter().enumerate() {
                         args.push(match &**t {
                             CType::Field(argname, t) => match &**t {
@@ -53,7 +53,7 @@ pub fn type_to_args(t: Arc<CType>) -> Vec<(String, ArgKind, Arc<CType>)> {
             }
             args
         }
-        CType::Tuple(ts) => {
+        CType::Tuple(ts, _) => {
             let mut args = Vec::new();
             for (i, t) in ts.iter().enumerate() {
                 args.push(match &**t {
@@ -115,6 +115,7 @@ pub fn args_and_rettype_to_type(
                         ))
                     })
                     .collect::<Vec<Arc<CType>>>(),
+                Vec::new(),
             )
         }),
         rettype,

--- a/alan_compiler/src/program/microstatement.rs
+++ b/alan_compiler/src/program/microstatement.rs
@@ -350,9 +350,9 @@ pub fn baseassignablelist_to_microstatements<'a>(
                             {
                                 let other_function_types = origin_scope.resolve_function_types(v);
                                 function_types = match (&*function_types, &*other_function_types) {
-                                    (CType::Void, CType::Void) => Arc::new(CType::Void),
-                                    (CType::Void, _) => other_function_types,
-                                    (_, CType::Void) => function_types,
+                                     (CType::Void | CType::DerivedVoid(..), CType::Void | CType::DerivedVoid(..)) => Arc::new(CType::Void),
+                                     (CType::Void | CType::DerivedVoid(..), _) => other_function_types,
+                                     (_, CType::Void | CType::DerivedVoid(..)) => function_types,
                                     (CType::AnyOf(t1), CType::AnyOf(t2)) => {
                                         Arc::new(CType::AnyOf({
                                             let mut v = Vec::new();
@@ -381,8 +381,8 @@ pub fn baseassignablelist_to_microstatements<'a>(
                             }
                             Program::return_program(program);
                         }
-                        match &*function_types {
-                            CType::Void => {
+                       match &*function_types {
+                             CType::Void | CType::DerivedVoid(..) => {
                                 // It could be a constant
                                 let maybe_c = scope.resolve_const(v);
                                 match maybe_c {
@@ -624,7 +624,7 @@ pub fn baseassignablelist_to_microstatements<'a>(
                 match &*typen {
                     CType::Function(i, o) => {
                         match &**o {
-                            CType::Void => { /* Do nothing */ }
+                            CType::Void | CType::DerivedVoid(..) => { /* Do nothing */ }
                             CType::Infer(t, _) if t == "unknown" => {
                                 CType::fail(&format!(
                                     "The return type for {}({}) could not be inferred.",
@@ -863,7 +863,7 @@ pub fn baseassignablelist_to_microstatements<'a>(
                                     // TODO: Really need to just have the Function use the Function
                                     // CType instead of this stuff
                                     let farg_types = match &**i {
-                                        CType::Void => Vec::new(),
+                                        CType::Void | CType::DerivedVoid(..) => Vec::new(),
                                         CType::Tuple(ts, _) => ts.clone(),
                                         _other => vec![i.clone()],
                                     };

--- a/alan_compiler/src/program/microstatement.rs
+++ b/alan_compiler/src/program/microstatement.rs
@@ -864,7 +864,7 @@ pub fn baseassignablelist_to_microstatements<'a>(
                                     // CType instead of this stuff
                                     let farg_types = match &**i {
                                         CType::Void => Vec::new(),
-                                        CType::Tuple(ts) => ts.clone(),
+                                        CType::Tuple(ts, _) => ts.clone(),
                                         _other => vec![i.clone()],
                                     };
                                     for (a, b) in farg_types.iter().zip(&arg_types) {

--- a/alan_compiler/src/program/microstatement.rs
+++ b/alan_compiler/src/program/microstatement.rs
@@ -350,9 +350,14 @@ pub fn baseassignablelist_to_microstatements<'a>(
                             {
                                 let other_function_types = origin_scope.resolve_function_types(v);
                                 function_types = match (&*function_types, &*other_function_types) {
-                                     (CType::Void | CType::DerivedVoid(..), CType::Void | CType::DerivedVoid(..)) => Arc::new(CType::Void),
-                                     (CType::Void | CType::DerivedVoid(..), _) => other_function_types,
-                                     (_, CType::Void | CType::DerivedVoid(..)) => function_types,
+                                    (
+                                        CType::Void | CType::DerivedVoid(..),
+                                        CType::Void | CType::DerivedVoid(..),
+                                    ) => Arc::new(CType::Void),
+                                    (CType::Void | CType::DerivedVoid(..), _) => {
+                                        other_function_types
+                                    }
+                                    (_, CType::Void | CType::DerivedVoid(..)) => function_types,
                                     (CType::AnyOf(t1), CType::AnyOf(t2)) => {
                                         Arc::new(CType::AnyOf({
                                             let mut v = Vec::new();
@@ -381,8 +386,8 @@ pub fn baseassignablelist_to_microstatements<'a>(
                             }
                             Program::return_program(program);
                         }
-                       match &*function_types {
-                             CType::Void | CType::DerivedVoid(..) => {
+                        match &*function_types {
+                            CType::Void | CType::DerivedVoid(..) => {
                                 // It could be a constant
                                 let maybe_c = scope.resolve_const(v);
                                 match maybe_c {

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -87,7 +87,7 @@ impl<'a> Scope<'a> {
                         g @ ("Int" | "Float" | "Bool" | "String" | "Group" | "Unwrap" | "Infix"
                         | "Prefix" | "Method" | "Property" | "Cast" | "Own" | "Deref" | "Mut"
                         | "Rust" | "Nodejs" | "From" | "Array" | "Fail" | "Neg" | "Len" | "Size"
-                        | "FileStr" | "Env" | "EnvExists" | "Not") => s = CType::from_generic(s, g, 1),
+                        | "FileStr" | "Env" | "EnvExists" | "Not" | "Rest") => s = CType::from_generic(s, g, 1),
                         g @ ("Function" | "Call" | "Dependency" | "Import" | "Field"
                         | "Prop" | "Buffer" | "Add" | "Sub" | "Mul" | "Div" | "Mod"
                         | "Pow" | "Min" | "Max" | "Concat" | "And" | "Or" | "Xor" | "Nand"

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -87,9 +87,9 @@ impl<'a> Scope<'a> {
                         g @ ("Int" | "Float" | "Bool" | "String" | "Group" | "Unwrap" | "Infix"
                         | "Prefix" | "Method" | "Property" | "Cast" | "Own" | "Deref" | "Mut"
                         | "Rust" | "Nodejs" | "From" | "Array" | "Fail" | "Neg" | "Len" | "Size"
-                        | "FileStr" | "Env" | "EnvExists" | "Not" | "Rest") => s = CType::from_generic(s, g, 1),
+                        | "FileStr" | "Env" | "EnvExists" | "Not") => s = CType::from_generic(s, g, 1),
                         g @ ("Function" | "Call" | "Dependency" | "Import" | "Field"
-                        | "Prop" | "Buffer" | "Add" | "Sub" | "Mul" | "Div" | "Mod"
+                        | "Prop" | "Exclude" | "Buffer" | "Add" | "Sub" | "Mul" | "Div" | "Mod"
                         | "Pow" | "Min" | "Max" | "Concat" | "And" | "Or" | "Xor" | "Nand"
                         | "Nor" | "Xnor" | "Eq" | "Neq" | "Lt" | "Lte" | "Gt" | "Gte") => s = CType::from_generic(s, g, 2),
                         g @ ("If" | "Binds" | "Tuple" | "Either" | "AnyOf") => {

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -318,11 +318,17 @@ impl<'a> Scope<'a> {
                     .collect::<Vec<Arc<CType>>>();
                 let output = f.rettype();
                 match generics {
-                    None => Arc::new(CType::Function(Arc::new(CType::Tuple(input)), output)),
+                    None => Arc::new(CType::Function(
+                        Arc::new(CType::Tuple(input, Vec::new())),
+                        output,
+                    )),
                     Some(gs) => Arc::new(CType::Generic(
                         f.name.clone(),
                         gs,
-                        Arc::new(CType::Function(Arc::new(CType::Tuple(input)), output)),
+                        Arc::new(CType::Function(
+                            Arc::new(CType::Tuple(input, Vec::new())),
+                            output,
+                        )),
                     )),
                 }
             })

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -88,6 +88,7 @@ type infix Tuple as , precedence 0; // A, B, C, ... The tuple type combines with
 type infix Field as : precedence 1; // Foo: Bar, let's you specify a property access label for the type, useful for syntactic sugar on a tuple type and the Either type (eventually).
 type infix Either as | precedence 0; // A | B, the type has a singular value from only one of the types at once.
 type infix Prop as . precedence 6; // A.B, returns the sub-type within A referenced by property B. Allows an inverse of a Tuple or Either type, accessed by either the Field name or an integer index
+type infix Exclude as -. precedence 6; // A-.B, removes the sub-type from A at the specified property B. Allows an inverse of a Tuple or Either type, removing by either the Field name or an integer index
 type infix AnyOf as & precedence 0; // A & B, which can be passed to a function that takes A or B as necessary.
 type infix Buffer as [ precedence 2; // Technically allows `Foo[3` by itself to be valid syntax, but...
 type postfix Self as ] precedence 11; // This one goes to eleven. Technically not necessary, but allows for `Foo[3]` to do the "right thing" and become a buffer of size 3

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -45,6 +45,7 @@ ctype Array{T}; // An array type, a variable-length array of the specified type 
 
 /// Compute types
 ctype Prop{T, P}; // Extracts the inner type from the outer type by the property name or number
+ctype Exclude{T, N}; // Returns the type with the specified property or index excluded, works with Either, Tuple, and Field
 ctype Len{A}; // Returns the length of the input type in terms of the number of elements it contains, which is most useful for Buffers, Tuples, and Either, causes a compiler failure for Arrays, and returns 1 for everything else
 ctype Size{T}; // Returns the size in bytes of the type in question, if possible, causing a compiler failure otherwise.
 ctype FileStr{F}; // Read a file and return a string constant, useful for including large strings from a separate, nearby file, or fails if it doesn't exist
@@ -77,8 +78,6 @@ ctype Lt{A, B}; // Returns true if A is less than B (and are an int or float)
 ctype Lte{A, B}; // Returns true if A is less than or equal to B
 ctype Gt{A, B}; // Returns true if A is greater than B
 ctype Gte{A, B}; // Returns true if A is greater than or equal to B
-ctype Rest{T}; // Returns all variants of an Either type except the first, appending () if not already the last variant
-
 // Defining the operators in the type system; they can be defined before the types themselves
 type infix Function as -> precedence 4; // I -> O, where I is the input and O is the output. With Tuples and Fields you can reconstruct arguments for functions.
 type infix Call as :: precedence 0; // N :: F, where N is the native function (or method) and F is the function type
@@ -143,6 +142,7 @@ type{Js} Error = Binds{"alan_std.AlanError" <- RootBacking};
 type Fallible{T} = T | Error;
 type Maybe{T} = T | ();
 type First{T} = Prop{T, 0};
+type Rest{T} = Exclude{T, 0};
 
 // Binding the float types
 type{Rs} f32 = Binds{"f32"};

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -269,12 +269,6 @@ fn{Js} exists{T} (m: T!) = {"((a) => new alan_std.Bool(!(a instanceof alan_std.A
 fn{Rs} string(e: Error) = {"format!" :: ("{}", Error) -> string}(e);
 fn{Js} string Property{"message"} :: Error -> string;
 
-/// First and Rest functions for Either type recursion
-fn{Rs} first{T}(v: T) -> Maybe{First{T}} = {"first_either" :: T -> Maybe{First{T}}}(v);
-fn{Js} first{T}(v: T) -> Maybe{First{T}} = {"first_either" :: T -> Maybe{First{T}}}(v);
-fn{Rs} rest{T}(v: T) -> Rest{T} = {"rest_either" :: T -> Rest{T}}(v);
-fn{Js} rest{T}(v: T) -> Rest{T} = {"rest_either" :: T -> Rest{T}}(v);
-
 /// Primitive type casting functions
 fn{Rs} f32 Cast{"f32"} :: Deref{i8} -> f32;
 fn{Js} f32 "new alan_std.F32" <- RootBacking :: i8 -> f32;

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -77,6 +77,7 @@ ctype Lt{A, B}; // Returns true if A is less than B (and are an int or float)
 ctype Lte{A, B}; // Returns true if A is less than or equal to B
 ctype Gt{A, B}; // Returns true if A is greater than B
 ctype Gte{A, B}; // Returns true if A is greater than or equal to B
+ctype Rest{T}; // Returns all variants of an Either type except the first, appending () if not already the last variant
 
 // Defining the operators in the type system; they can be defined before the types themselves
 type infix Function as -> precedence 4; // I -> O, where I is the input and O is the output. With Tuples and Fields you can reconstruct arguments for functions.
@@ -141,6 +142,7 @@ type{Rs} Error = Binds{"alan_std::AlanError" <- RootBacking};
 type{Js} Error = Binds{"alan_std.AlanError" <- RootBacking};
 type Fallible{T} = T | Error;
 type Maybe{T} = T | ();
+type First{T} = Prop{T, 0};
 
 // Binding the float types
 type{Rs} f32 = Binds{"f32"};
@@ -266,6 +268,12 @@ fn{Rs} exists{T} (m: T!) = {Method{"is_ok"} :: T! -> bool}(m);
 fn{Js} exists{T} (m: T!) = {"((a) => new alan_std.Bool(!(a instanceof alan_std.AlanError)))" <- RootBacking :: T! -> bool}(m);
 fn{Rs} string(e: Error) = {"format!" :: ("{}", Error) -> string}(e);
 fn{Js} string Property{"message"} :: Error -> string;
+
+/// First and Rest functions for Either type recursion
+fn{Rs} first{T}(v: T) -> Maybe{First{T}} = {"first_either" :: T -> Maybe{First{T}}}(v);
+fn{Js} first{T}(v: T) -> Maybe{First{T}} = {"first_either" :: T -> Maybe{First{T}}}(v);
+fn{Rs} rest{T}(v: T) -> Rest{T} = {"rest_either" :: T -> Rest{T}}(v);
+fn{Js} rest{T}(v: T) -> Rest{T} = {"rest_either" :: T -> Rest{T}}(v);
 
 /// Primitive type casting functions
 fn{Rs} f32 Cast{"f32"} :: Deref{i8} -> f32;


### PR DESCRIPTION
This provides more tools for programmatic manipulation of types similar to `Prop{T, N}` and will be useful for making compile-time-recursive functions that have a fixed depth at runtime.

- **Implement `First{T}`, `Rest{T}` and related functions**
- **Implement `Exclude{T, N}`**
- **Refactor to `Exclude{T, N}` to implement `Rest{T}` with**
- **Get `Exclude{T, N}` working for `Either{A, B, ...}` types**
- **Fix more issues spotted when testing the new `Rest{T}`**
