### PR TITLE
Faster compiler, fake interpreter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "dirs",
  "divan",
  "fs2",
+ "mimalloc",
 ]
 
 [[package]]
@@ -1028,6 +1029,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1094,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/alan/Cargo.toml
+++ b/alan/Cargo.toml
@@ -16,6 +16,7 @@ alan_compiler = { path = "../alan_compiler" }
 clap = { version = "4.6.1", features = ["derive"] }
 dirs = "6.0.0"
 fs2 = "0.4.3"
+mimalloc = "0.1.52"
 
 [dev-dependencies]
 divan = "0.1.21"

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -25,7 +25,7 @@ macro_rules! test {
                         return Err(format!("Unable to write {} to disk. {:?}", filename, e).into());
                     }
                 };
-                match crate::compile::build(filename.to_string()) {
+                match crate::compile::build(filename.to_string(), "release") {
                     Ok(_) => { /* Do nothing */ }
                     Err(e) => {
                         std::fs::remove_file(&filename)?;
@@ -85,7 +85,7 @@ macro_rules! test {
                         return Err(format!("Unable to write {} to disk. {:?}", $filename, e).into());
                     }
                 })+
-                match crate::compile::build(format!("{}.ln", $entryfile)) {
+                match crate::compile::build(format!("{}.ln", $entryfile), "release") {
                     Ok(_) => { /* Do nothing */ }
                     Err(e) => {
                         $( std::fs::remove_file($filename)?; )+
@@ -148,7 +148,7 @@ macro_rules! test_gpgpu {
                         return Err(format!("Unable to write {} to disk. {:?}", filename, e).into());
                     }
                 };
-                match crate::compile::build(filename.to_string()) {
+                match crate::compile::build(filename.to_string(), "release") {
                     Ok(_) => { /* Do nothing */ }
                     Err(e) => {
                         std::fs::remove_file(&filename)?;
@@ -258,7 +258,7 @@ macro_rules! test_ignore {
                         return Err(format!("Unable to write {} to disk. {:?}", filename, e).into());
                     }
                 };
-                match crate::compile::build(filename.to_string()) {
+                match crate::compile::build(filename.to_string(), "release") {
                     Ok(_) => { /* Do nothing */ }
                     Err(e) => {
                         std::fs::remove_file(&filename)?;

--- a/alan/src/compile/mod.rs
+++ b/alan/src/compile/mod.rs
@@ -64,23 +64,57 @@ fn acquire_file_lock(
     }
 }
 
-fn write_fast_linker_config(project_dir: &Path, find_cmd: &str) {
-    // The linker config is static for a given machine, so once it's written we can skip the
-    // (surprisingly expensive) detection work -- `which mold`/`which lld` plus a `rustc -vV` to
-    // find the host triple -- which would otherwise be paid on every single build.
-    let config_path = project_dir.join(".cargo").join("config.toml");
-    if config_path.exists() {
-        return;
-    }
-    let linker = if Command::new(find_cmd).arg("mold").output().is_ok() {
-        "mold"
-    } else if Command::new(find_cmd).arg("lld").output().is_ok() {
-        "lld"
-    } else {
-        return;
+fn write_fast_linker_config(project_dir: &Path, find_cmd: &str, bindir: &Option<PathBuf>) {
+    let dot_cargo = project_dir.join(".cargo");
+    let config_path = dot_cargo.join("config.toml");
+    // Only treat a linker as available if `which`/`where` actually *found* it. Note that
+    // `output()` returns `Ok` as long as the lookup command itself ran -- even when it reports
+    // "not found" via a non-zero exit code -- so we must inspect the exit status, not just `is_ok`.
+    // Otherwise we'd force `-fuse-ld=mold` on machines without mold and break linking entirely.
+    let is_available = |name: &str| {
+        Command::new(find_cmd)
+            .arg(name)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
     };
+    let linker = if is_available("mold") {
+        Some("mold")
+    } else if is_available("lld") {
+        Some("lld")
+    } else {
+        None
+    };
+    let linker = match linker {
+        Some(l) => l,
+        None => {
+            // No faster linker present: fall back to the default linker. Crucially, remove any
+            // config we (or an older, buggy version) may have left behind that forces a linker
+            // which isn't installed here -- otherwise every build would fail to link.
+            let _ = std::fs::remove_file(&config_path);
+            return;
+        }
+    };
+    // Fast path: if the existing config already forces the linker we found, it's correct, so we're
+    // done. This matters because it lets us skip the (relatively expensive) `rustc -vV` host-triple
+    // lookup on every build -- we only fall through to regenerating the config when it's missing or
+    // now points at a different linker (which is rare). The cheap `which` checks above are all we
+    // pay in the steady state.
+    let desired_flag = format!("-Clink-arg=-fuse-ld={linker}");
+    if let Ok(existing) = std::fs::read_to_string(&config_path) {
+        if existing.contains(&desired_flag) {
+            return;
+        }
+    }
+    // The config is missing or stale: (re)generate it. Resolve the host triple for the
+    // `[target.<triple>]` table, using the toolchain's `rustc` directly (via `bindir`) when we have
+    // it so we skip the rustup shim's overhead.
+    let rustc_path = bindir
+        .as_ref()
+        .map(|d| d.join("rustc"))
+        .unwrap_or_else(|| PathBuf::from("rustc"));
     let host = match (|| -> Option<String> {
-        let output = Command::new("rustc").arg("-vV").output().ok()?;
+        let output = Command::new(&rustc_path).arg("-vV").output().ok()?;
         let stdout = String::from_utf8(output.stdout).ok()?;
         stdout
             .lines()
@@ -91,16 +125,12 @@ fn write_fast_linker_config(project_dir: &Path, find_cmd: &str) {
         Some(h) => h,
         None => return,
     };
-    let dot_cargo = project_dir.join(".cargo");
     if std::fs::create_dir_all(&dot_cargo).is_err() {
         return;
     }
     let _ = std::fs::write(
-        dot_cargo.join("config.toml"),
-        format!(
-            "[target.{}]\nrustflags = [\"-Clink-arg=-fuse-ld={}\"]\n",
-            host, linker,
-        ),
+        &config_path,
+        format!("[target.{host}]\nrustflags = [\"{desired_flag}\"]\n"),
     );
 }
 
@@ -444,7 +474,7 @@ codegen-units = 256
             }?;
         }
     }
-    write_fast_linker_config(&project_dir, find_process);
+    write_fast_linker_config(&project_dir, find_process, &bindir);
     // We need to remove the prior binary, if it exists, to prevent a prior successful compilation
     // from accidentally being treated as the output of an unsuccessful compilation.
     if binary_path.exists() {

--- a/alan/src/compile/mod.rs
+++ b/alan/src/compile/mod.rs
@@ -1,7 +1,7 @@
 use std::env::current_dir;
 use std::fs::{create_dir_all, remove_file, write, File, OpenOptions};
 use std::io::{Read, Seek, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
@@ -61,7 +61,7 @@ fn acquire_file_lock(
     }
 }
 
-fn write_fast_linker_config(project_dir: &PathBuf, find_cmd: &str) {
+fn write_fast_linker_config(project_dir: &Path, find_cmd: &str) {
     let linker = if Command::new(find_cmd).arg("mold").output().is_ok() {
         "mold"
     } else if Command::new(find_cmd).arg("lld").output().is_ok() {
@@ -94,6 +94,61 @@ fn write_fast_linker_config(project_dir: &PathBuf, find_cmd: &str) {
     );
 }
 
+/// Resolve the directory containing the *real* toolchain `cargo`/`rustc` binaries, bypassing the
+/// `rustup` proxy shims. When Rust is installed via rustup (the recommended way), the `cargo` and
+/// `rustc` found on `PATH` are thin shim binaries that, on *every* invocation, parse rustup's TOML
+/// config to select a toolchain and then re-exec the real binary. For a fast `alan` run that just
+/// builds a tiny program, this shim overhead (a TOML parse plus an extra process exec) is a
+/// meaningful slice of wall-clock time, and it's paid once for `cargo` and again for every `rustc`
+/// invocation. Resolving the real toolchain `bin` directory once lets us invoke those binaries
+/// directly and skip the shims entirely.
+///
+/// Returns `None` when rustup is not in use (e.g. a distro-packaged toolchain), in which case the
+/// plain `cargo`/`rustc` on `PATH` are already the real binaries and need no special handling.
+fn rustup_bindir() -> Option<PathBuf> {
+    // Escape hatch: allow opting out of the bypass in case it misbehaves in an exotic toolchain
+    // setup.
+    if std::env::var_os("ALAN_DISABLE_RUSTUP_BYPASS").is_some() {
+        return None;
+    }
+    let output = Command::new("rustup")
+        .arg("which")
+        .arg("cargo")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let cargo_path = PathBuf::from(String::from_utf8(output.stdout).ok()?.trim());
+    cargo_path.parent().map(|p| p.to_path_buf())
+}
+
+/// Construct a `cargo` `Command` that bypasses the rustup shims when possible (see
+/// `rustup_bindir`). `bindir` should be the cached result of a single `rustup_bindir()` call for
+/// this build so the resolution cost is paid at most once.
+fn cargo_command(bindir: &Option<PathBuf>, project_dir: &Path) -> Command {
+    let mut cmd = match bindir {
+        Some(dir) => {
+            let mut cmd = Command::new(dir.join("cargo"));
+            // Point `cargo` at the real `rustc` so it doesn't reach for the rustc shim (which it
+            // would otherwise find via `PATH`), and prepend the toolchain `bin` dir to `PATH` so
+            // any other toolchain tools resolve directly too.
+            cmd.env("RUSTC", dir.join("rustc"));
+            if let Ok(path) = std::env::var("PATH") {
+                let mut paths = vec![dir.clone()];
+                paths.extend(std::env::split_paths(&path));
+                if let Ok(joined) = std::env::join_paths(paths) {
+                    cmd.env("PATH", joined);
+                }
+            }
+            cmd
+        }
+        None => Command::new("cargo"),
+    };
+    cmd.current_dir(project_dir);
+    cmd
+}
+
 /// The `build` function creates a temporary directory that is a Cargo project primarily consisting
 /// of a single source file, plus a Cargo.toml file including the 3rd party dependencies in the
 /// standard library and user source code.
@@ -113,6 +168,9 @@ pub fn build(source_file: String, profile: &str) -> Result<String, Box<dyn std::
             Err("cargo not found. Please make sure you have rust installed before using Alan!")
         }
     }?;
+    // Resolve the real toolchain binaries once so every `cargo`/`rustc` invocation below can skip
+    // the rustup proxy shims.
+    let bindir = rustup_bindir();
     // Because all Alan programs use the same Rust dependencies (for now), we can cut down a *lot*
     // of build time by re-using the `./target/release/build` and `./target/release/deps` directory
     // in subsequent builds. Since it takes over 30 seconds to make a release build on my laptop
@@ -284,8 +342,8 @@ codegen-units = 256
                 Err(e)
             }
         }?;
-        let mut first_build = Command::new("cargo");
-        first_build.current_dir(project_dir.clone()).arg("build");
+        let mut first_build = cargo_command(&bindir, &project_dir);
+        first_build.arg("build");
         if profile == "release" {
             first_build.arg("--release");
         } else {
@@ -303,9 +361,8 @@ codegen-units = 256
             }
         }?;
         if profile != "interp" {
-            let mut interp_warmup = Command::new("cargo");
+            let mut interp_warmup = cargo_command(&bindir, &project_dir);
             interp_warmup
-                .current_dir(project_dir.clone())
                 .arg("build")
                 .arg("--profile")
                 .arg("interp")
@@ -401,8 +458,7 @@ codegen-units = 256
     }?;
     // Update the cargo lockfile, if necessary
     if should_rebuild_deps {
-        match Command::new("cargo")
-            .current_dir(project_dir.clone())
+        match cargo_command(&bindir, &project_dir)
             .arg("update")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -424,8 +480,8 @@ codegen-units = 256
         )?;
     }
     // Build the executable
-    let mut build_cmd = Command::new("cargo");
-    build_cmd.current_dir(project_dir.clone()).arg("build");
+    let mut build_cmd = cargo_command(&bindir, &project_dir);
+    build_cmd.arg("build");
     if profile == "release" {
         build_cmd.arg("--release");
     } else {

--- a/alan/src/compile/mod.rs
+++ b/alan/src/compile/mod.rs
@@ -61,10 +61,43 @@ fn acquire_file_lock(
     }
 }
 
+fn write_fast_linker_config(project_dir: &PathBuf, find_cmd: &str) {
+    let linker = if Command::new(find_cmd).arg("mold").output().is_ok() {
+        "mold"
+    } else if Command::new(find_cmd).arg("lld").output().is_ok() {
+        "lld"
+    } else {
+        return;
+    };
+    let host = match (|| -> Option<String> {
+        let output = Command::new("rustc").arg("-vV").output().ok()?;
+        let stdout = String::from_utf8(output.stdout).ok()?;
+        stdout
+            .lines()
+            .find(|l| l.starts_with("host:"))
+            .and_then(|l| l.split_whitespace().nth(1))
+            .map(|s| s.to_string())
+    })() {
+        Some(h) => h,
+        None => return,
+    };
+    let dot_cargo = project_dir.join(".cargo");
+    if std::fs::create_dir_all(&dot_cargo).is_err() {
+        return;
+    }
+    let _ = std::fs::write(
+        dot_cargo.join("config.toml"),
+        format!(
+            "[target.{}]\nrustflags = [\"-Clink-arg=-fuse-ld={}\"]\n",
+            host, linker,
+        ),
+    );
+}
+
 /// The `build` function creates a temporary directory that is a Cargo project primarily consisting
 /// of a single source file, plus a Cargo.toml file including the 3rd party dependencies in the
 /// standard library and user source code.
-pub fn build(source_file: String) -> Result<String, Box<dyn std::error::Error>> {
+pub fn build(source_file: String, profile: &str) -> Result<String, Box<dyn std::error::Error>> {
     let find_process = if cfg!(windows) { "where" } else { "which" };
     // Fail if rustc is not present
     match Command::new(find_process).arg("rustc").output() {
@@ -110,10 +143,10 @@ pub fn build(source_file: String) -> Result<String, Box<dyn std::error::Error>> 
         p.push("alan_generated_bin");
         p
     };
-    let release_path = {
+    let binary_path = {
         let mut r = project_dir.clone();
         r.push("target");
-        r.push("release");
+        r.push(profile);
         r
     };
     let cargo_str = r#"[package]
@@ -123,6 +156,12 @@ edition = "2021"
 # To continue supporting earlier versions of Rust
 [patch.crates-io]
 bytemuck_derive = { git = "https://github.com/Lokathor/bytemuck", tag = "bytemuck_derive-v1.8.1" }
+
+[profile.interp]
+inherits = "dev"
+opt-level = 0
+debug = false
+codegen-units = 256
 
 [dependencies]"#;
     let cargo_path = {
@@ -245,10 +284,50 @@ bytemuck_derive = { git = "https://github.com/Lokathor/bytemuck", tag = "bytemuc
                 Err(e)
             }
         }?;
-        match Command::new("cargo")
-            .current_dir(project_dir.clone())
-            .arg("build")
-            .arg("--release")
+        let mut first_build = Command::new("cargo");
+        first_build.current_dir(project_dir.clone()).arg("build");
+        if profile == "release" {
+            first_build.arg("--release");
+        } else {
+            first_build.arg("--profile").arg(profile);
+        }
+        match first_build
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+        {
+            Ok(a) => Ok(a),
+            Err(e) => {
+                fs2::FileExt::unlock(&lockfile)?;
+                Err(e)
+            }
+        }?;
+        if profile != "interp" {
+            let mut interp_warmup = Command::new("cargo");
+            interp_warmup
+                .current_dir(project_dir.clone())
+                .arg("build")
+                .arg("--profile")
+                .arg("interp")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            match interp_warmup.output() {
+                Ok(a) => Ok(a),
+                Err(e) => {
+                    fs2::FileExt::unlock(&lockfile)?;
+                    Err(e)
+                }
+            }?;
+        }
+    }
+    write_fast_linker_config(&project_dir, find_process);
+    // We need to remove the prior binary, if it exists, to prevent a prior successful compilation
+    // from accidentally being treated as the output of an unsuccessful compilation.
+    if binary_path.exists() {
+        match Command::new("rm")
+            .current_dir(binary_path.clone())
+            .arg("-f")
+            .arg("alan_generated_bin")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output()
@@ -260,22 +339,6 @@ bytemuck_derive = { git = "https://github.com/Lokathor/bytemuck", tag = "bytemuc
             }
         }?;
     }
-    // We need to remove the prior binary, if it exists, to prevent a prior successful compilation
-    // from accidentally being treated as the output of an unsuccessful compilation.
-    match Command::new("rm")
-        .current_dir(release_path.clone())
-        .arg("-f")
-        .arg("alan_generated_bin")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-    {
-        Ok(a) => Ok(a),
-        Err(e) => {
-            fs2::FileExt::unlock(&lockfile)?;
-            Err(e)
-        }
-    }?;
     // Once we're here, the base hello world app we use as a build cache definitely exists, so
     // let's get to work! We can't use the `?` operator directly here, because we need to make sure
     // we remove the lockfile on any failure.
@@ -361,10 +424,14 @@ bytemuck_derive = { git = "https://github.com/Lokathor/bytemuck", tag = "bytemuc
         )?;
     }
     // Build the executable
-    match Command::new("cargo")
-        .current_dir(project_dir.clone())
-        .arg("build")
-        .arg("--release")
+    let mut build_cmd = Command::new("cargo");
+    build_cmd.current_dir(project_dir.clone()).arg("build");
+    if profile == "release" {
+        build_cmd.arg("--release");
+    } else {
+        build_cmd.arg("--profile").arg(profile);
+    }
+    match build_cmd
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -390,7 +457,7 @@ bytemuck_derive = { git = "https://github.com/Lokathor/bytemuck", tag = "bytemuc
         Some(n) => n.to_string_lossy().to_string(),
     };
     match Command::new("cp")
-        .current_dir(release_path)
+        .current_dir(binary_path)
         .arg("alan_generated_bin")
         .arg(format!(
             "{}/{}",
@@ -422,8 +489,36 @@ pub fn compile(source_file: String) -> Result<(), Box<dyn std::error::Error>> {
         .env
         .insert("ALAN_TARGET".to_string(), "release".to_string());
     Program::return_program(program);
-    build(source_file)?;
+    build(source_file, "release")?;
     println!("Done! Took {:.2}sec", start_time.elapsed().as_secs_f32());
+    Ok(())
+}
+
+/// The `interp` function builds the source file with minimal optimizations (like an interpreter),
+/// runs it, and deletes the binary.
+pub fn interp(source_file: String) -> Result<(), Box<dyn std::error::Error>> {
+    Program::set_target_lang_rs();
+    let mut program = Program::get_program();
+    program
+        .env
+        .insert("ALAN_TARGET".to_string(), "interp".to_string());
+    Program::return_program(program);
+    let binary = build(source_file, "interp")?;
+    let mut run = Command::new(format!("./{binary}"))
+        .current_dir(current_dir()?)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+    let ecode = run.wait()?;
+    Command::new("rm")
+        .current_dir(current_dir()?)
+        .arg(binary)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+    if !ecode.success() {
+        std::process::exit(ecode.code().unwrap());
+    }
     Ok(())
 }
 
@@ -459,7 +554,7 @@ pub fn test(source_file: String, js: bool) -> Result<(), Box<dyn std::error::Err
             std::process::exit(ecode.code().unwrap());
         }
     } else {
-        let binary = build(source_file)?;
+        let binary = build(source_file, "release")?;
         let mut run = Command::new(format!("./{binary}"))
             .current_dir(current_dir()?)
             .stdout(Stdio::inherit())

--- a/alan/src/compile/mod.rs
+++ b/alan/src/compile/mod.rs
@@ -115,13 +115,50 @@ fn write_fast_linker_config(project_dir: &Path, find_cmd: &str) {
 ///
 /// Returns `None` when rustup is not in use (e.g. a distro-packaged toolchain), in which case the
 /// plain `cargo`/`rustc` on `PATH` are already the real binaries and need no special handling.
-fn rustup_bindir() -> Option<PathBuf> {
+///
+/// The resolution itself costs ~40ms (it's a full `rustup which cargo` invocation), so we cache
+/// the result in `cache_dir` keyed on the things that determine which toolchain rustup would pick:
+/// the mtime of rustup's `settings.toml` (which rustup rewrites on `rustup default`/install/
+/// uninstall) and the `RUSTUP_TOOLCHAIN` override env var. A cache hit is two cheap `stat`s instead
+/// of spawning rustup, and a toolchain swap (`rustup default ...`) invalidates the cache
+/// automatically because it bumps `settings.toml`'s mtime.
+fn rustup_bindir(project_dir: &Path, cache_dir: &Path) -> Option<PathBuf> {
     // Escape hatch: allow opting out of the bypass in case it misbehaves in an exotic toolchain
     // setup.
     if std::env::var_os("ALAN_DISABLE_RUSTUP_BYPASS").is_some() {
         return None;
     }
+    // Build the cache key from rustup's toolchain-selection inputs.
+    let settings_mtime = rustup_settings_mtime();
+    let toolchain_env = std::env::var("RUSTUP_TOOLCHAIN").unwrap_or_default();
+    let key = format!(
+        "{}\n{}",
+        settings_mtime
+            .and_then(|m| m.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+        toolchain_env,
+    );
+    let cache_path = cache_dir.join(".toolchain_cache");
+    // Only trust the cache when we have a stable key (i.e. we could read settings.toml's mtime).
+    if settings_mtime.is_some() {
+        if let Ok(contents) = std::fs::read_to_string(&cache_path) {
+            if let Some((cached_key, cached_bindir)) = contents.split_once("\n::\n") {
+                if cached_key == key {
+                    let bindir = PathBuf::from(cached_bindir.trim());
+                    // Guard against a cached toolchain that has since been uninstalled.
+                    if bindir.join("cargo").exists() {
+                        return Some(bindir);
+                    }
+                }
+            }
+        }
+    }
+    // Cache miss (or no settings.toml): resolve via rustup. We run it in `project_dir` so any
+    // `rust-toolchain.toml` override resolution matches the directory where cargo will actually
+    // run.
     let output = Command::new("rustup")
+        .current_dir(project_dir)
         .arg("which")
         .arg("cargo")
         .output()
@@ -130,7 +167,26 @@ fn rustup_bindir() -> Option<PathBuf> {
         return None;
     }
     let cargo_path = PathBuf::from(String::from_utf8(output.stdout).ok()?.trim());
-    cargo_path.parent().map(|p| p.to_path_buf())
+    let bindir = cargo_path.parent()?.to_path_buf();
+    // Best-effort cache write (skipped when we lack a stable key).
+    if settings_mtime.is_some() {
+        let _ = std::fs::write(&cache_path, format!("{}\n::\n{}", key, bindir.display()));
+    }
+    Some(bindir)
+}
+
+/// Returns the modification time of rustup's `settings.toml`, which rustup rewrites whenever the
+/// active toolchain changes (`rustup default`, toolchain install/uninstall). Used as a cheap
+/// cache-invalidation signal for `rustup_bindir`.
+fn rustup_settings_mtime() -> Option<std::time::SystemTime> {
+    let rustup_home = match std::env::var_os("RUSTUP_HOME") {
+        Some(h) => PathBuf::from(h),
+        None => dirs::home_dir()?.join(".rustup"),
+    };
+    std::fs::metadata(rustup_home.join("settings.toml"))
+        .ok()?
+        .modified()
+        .ok()
 }
 
 /// Construct a `cargo` `Command` that bypasses the rustup shims when possible (see
@@ -178,9 +234,6 @@ pub fn build(source_file: String, profile: &str) -> Result<String, Box<dyn std::
             Err("cargo not found. Please make sure you have rust installed before using Alan!")
         }
     }?;
-    // Resolve the real toolchain binaries once so every `cargo`/`rustc` invocation below can skip
-    // the rustup proxy shims.
-    let bindir = rustup_bindir();
     // Because all Alan programs use the same Rust dependencies (for now), we can cut down a *lot*
     // of build time by re-using the `./target/release/build` and `./target/release/deps` directory
     // in subsequent builds. Since it takes over 30 seconds to make a release build on my laptop
@@ -242,6 +295,10 @@ codegen-units = 256
     if !alan_config.exists() {
         create_dir_all(alan_config.clone())?;
     }
+
+    // Resolve the real toolchain binaries (cached in the config dir) so every `cargo`/`rustc`
+    // invocation below can skip the rustup proxy shims.
+    let bindir = rustup_bindir(&project_dir, &alan_config);
 
     // Acquire the lock with a 3-minute timeout
     let mut lockfile = acquire_file_lock(&lockfile_path, 180)?;

--- a/alan/src/compile/mod.rs
+++ b/alan/src/compile/mod.rs
@@ -24,12 +24,15 @@ fn acquire_file_lock(
     let sleep_time = std::time::Duration::from_millis(50);
 
     loop {
-        // Try to open the file for exclusive access
+        // Try to open the file for exclusive access. NOTE: we must NOT truncate here -- this
+        // lockfile doubles as the store for the "last dependency update" timestamp, and truncating
+        // on every open would wipe that timestamp, making `should_rebuild_deps` always true and
+        // forcing a (often pointless) `cargo update` on every single invocation.
         match OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
-            .truncate(true)
+            .truncate(false)
             .open(lockfile_path)
         {
             Ok(file) => {
@@ -62,6 +65,13 @@ fn acquire_file_lock(
 }
 
 fn write_fast_linker_config(project_dir: &Path, find_cmd: &str) {
+    // The linker config is static for a given machine, so once it's written we can skip the
+    // (surprisingly expensive) detection work -- `which mold`/`which lld` plus a `rustc -vV` to
+    // find the host triple -- which would otherwise be paid on every single build.
+    let config_path = project_dir.join(".cargo").join("config.toml");
+    if config_path.exists() {
+        return;
+    }
     let linker = if Command::new(find_cmd).arg("mold").output().is_ok() {
         "mold"
     } else if Command::new(find_cmd).arg("lld").output().is_ok() {

--- a/alan/src/main.rs
+++ b/alan/src/main.rs
@@ -164,6 +164,18 @@ fn fmt_command(files: &[String], check: bool) -> Result<(), Box<dyn std::error::
             }
         };
         let formatted = fmt(&ast);
+        // The parser strips a leading shebang line (e.g. `#!/usr/bin/env alan`) so scripts can be
+        // run directly; re-attach it here so formatting an executable script doesn't delete its
+        // shebang.
+        let formatted = if src.starts_with("#!") {
+            match src.find('\n') {
+                Some(newline) => format!("{}{}", &src[..=newline], formatted),
+                // Shebang-only file with no body: leave the original untouched.
+                None => src.clone(),
+            }
+        } else {
+            formatted
+        };
 
         if check {
             if src != formatted {

--- a/alan/src/main.rs
+++ b/alan/src/main.rs
@@ -10,6 +10,12 @@ use alan_compiler::parse::get_ast;
 
 pub mod compile;
 
+// Alan's compilation is heavily allocation-bound (parsing the standard library and cloning AST /
+// type structures dominate the compiler's own CPU time). mimalloc handles the many small,
+// short-lived allocations far better than the default system allocator, cutting that overhead.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, propagate_version = true)]
 struct Cli {

--- a/alan/src/main.rs
+++ b/alan/src/main.rs
@@ -101,9 +101,8 @@ enum Commands {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Cli::parse();
-    if args.file.is_some() {
-        println!("TODO: Interpreter mode someday");
-        Ok(())
+    if let Some(file) = args.file {
+        compile::interp(file)
     } else {
         match &args.commands {
             Some(Commands::Bundle { file }) => Ok(compile::bundle(file.to_string())?),

--- a/alan_compiler/src/parse.rs
+++ b/alan_compiler/src/parse.rs
@@ -1388,6 +1388,18 @@ test!(ln =>
 );
 
 pub fn get_ast(input: &str) -> Result<Ln, nom::Err<nom::error::Error<&str>>> {
+    // Strip an optional leading "shebang" line (e.g. `#!/usr/bin/env alan`) so that an Alan source
+    // file can be marked executable and run directly as a script. A shebang is only recognized at
+    // the very start of the file; `#!` is unambiguous since Alan comments use `//` and `/* */`.
+    let input = match input.strip_prefix("#!") {
+        Some(rest) => match rest.find('\n') {
+            // Drop the shebang line and its trailing newline, keeping everything after it.
+            Some(newline) => &rest[newline + 1..],
+            // The shebang is the entire input (no newline) -- nothing left to parse.
+            None => "",
+        },
+        None => input,
+    };
     // We wrap the `ln` root parser in `all_consuming` to cause an error if there's unexpected
     // cruft at the end of the input, which we consider a syntax error at compile time. An LSP
     // would probably use `ln` directly, instead, so new lines/functions/etc the user is currently
@@ -1401,4 +1413,8 @@ test!(get_ast =>
     pass "";
     pass " ";
     pass "export fn main {\n  print('Hello, World!');\n}";
+    // A leading shebang line is stripped so files can be run as scripts.
+    pass "#!/usr/bin/env alan\nexport fn main {\n  print('Hello, World!');\n}";
+    pass "#!/usr/bin/alan\n";
+    pass "#!/usr/bin/env alan";
 );

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -2886,6 +2886,7 @@ impl CType {
                             _ => unreachable!(),
                         }),
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     }));
                 } else {
                     let mut microstatements = Vec::new();
@@ -3248,6 +3249,7 @@ impl CType {
                         microstatements,
                         kind,
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     }));
                 }
             }
@@ -3263,6 +3265,7 @@ impl CType {
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     }));
                 }
             }
@@ -3301,6 +3304,7 @@ impl CType {
                                         }],
                                         kind: FnKind::Static,
                                         origin_scope_path: scope.path.clone(),
+                                        lazy_body: None,
                                     }));
                                 }
                                 CType::Int(i) => {
@@ -3317,6 +3321,7 @@ impl CType {
                                         }],
                                         kind: FnKind::Static,
                                         origin_scope_path: scope.path.clone(),
+                                        lazy_body: None,
                                     }));
                                 }
                                 CType::Float(f) => {
@@ -3336,6 +3341,7 @@ impl CType {
                                         }],
                                         kind: FnKind::Static,
                                         origin_scope_path: scope.path.clone(),
+                                        lazy_body: None,
                                     }));
                                 }
                                 CType::Bool(b) => {
@@ -3355,6 +3361,7 @@ impl CType {
                                         }],
                                         kind: FnKind::Static,
                                         origin_scope_path: scope.path.clone(),
+                                        lazy_body: None,
                                     }));
                                 }
                                 _ => { /* Do nothing */ }
@@ -3387,6 +3394,7 @@ impl CType {
                                 microstatements: Vec::new(),
                                 kind: FnKind::Derived,
                                 origin_scope_path: scope.path.clone(),
+                                lazy_body: None,
                             }));
                         }
                         _otherwise => {
@@ -3397,6 +3405,7 @@ impl CType {
                                 microstatements: Vec::new(),
                                 kind: FnKind::Derived,
                                 origin_scope_path: scope.path.clone(),
+                                lazy_body: None,
                             }));
                         }
                     }
@@ -3411,6 +3420,7 @@ impl CType {
                     microstatements: Vec::new(),
                     kind: FnKind::Derived,
                     origin_scope_path: scope.path.clone(),
+                    lazy_body: None,
                 }));
                 // Generate parent constructor functions for each parent type
                 for parent in parents {
@@ -3441,6 +3451,7 @@ impl CType {
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     }));
                 }
             }
@@ -3462,6 +3473,7 @@ impl CType {
                             }],
                             kind: FnKind::Static,
                             origin_scope_path: scope.path.clone(),
+                            lazy_body: None,
                         }));
                     }
                     CType::Int(i) => {
@@ -3478,6 +3490,7 @@ impl CType {
                             }],
                             kind: FnKind::Static,
                             origin_scope_path: scope.path.clone(),
+                            lazy_body: None,
                         }));
                     }
                     CType::Float(f) => {
@@ -3494,6 +3507,7 @@ impl CType {
                             }],
                             kind: FnKind::Static,
                             origin_scope_path: scope.path.clone(),
+                            lazy_body: None,
                         }));
                     }
                     CType::Bool(b) => {
@@ -3513,6 +3527,7 @@ impl CType {
                             }],
                             kind: FnKind::Static,
                             origin_scope_path: scope.path.clone(),
+                            lazy_body: None,
                         }));
                     }
                     _ => {
@@ -3522,6 +3537,7 @@ impl CType {
                             microstatements: Vec::new(),
                             kind: FnKind::Derived,
                             origin_scope_path: scope.path.clone(),
+                            lazy_body: None,
                         }));
                     }
                 }
@@ -3532,6 +3548,7 @@ impl CType {
                     microstatements: Vec::new(),
                     kind: FnKind::Derived,
                     origin_scope_path: scope.path.clone(),
+                    lazy_body: None,
                 }));
             }
 
@@ -3552,6 +3569,7 @@ impl CType {
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     }));
                     // Create a store fn to re-assign-and-auto-wrap a value
                     fs.push(Arc::new(Function {
@@ -3563,6 +3581,7 @@ impl CType {
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     }));
                     if let CType::Void = &**e {
                         // Have a zero-arg constructor function produce the void type, if possible.
@@ -3572,6 +3591,7 @@ impl CType {
                             microstatements: Vec::new(),
                             kind: FnKind::Derived,
                             origin_scope_path: scope.path.clone(),
+                            lazy_body: None,
                         }));
                     }
                     // Create the accessor function, the name of the function will
@@ -3589,6 +3609,7 @@ impl CType {
                             microstatements: Vec::new(),
                             kind: FnKind::Derived,
                             origin_scope_path: scope.path.clone(),
+                            lazy_body: None,
                         })),
                         CType::Type(n, _) => fs.push(Arc::new(Function {
                             name: n.clone(),
@@ -3602,6 +3623,7 @@ impl CType {
                             microstatements: Vec::new(),
                             kind: FnKind::Derived,
                             origin_scope_path: scope.path.clone(),
+                            lazy_body: None,
                         })),
                         _ => {} // We can't make names for other types
                     }
@@ -3640,6 +3662,7 @@ impl CType {
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     }));
                 }
             }
@@ -3655,6 +3678,7 @@ impl CType {
                     microstatements: Vec::new(),
                     kind: FnKind::Derived,
                     origin_scope_path: scope.path.clone(),
+                    lazy_body: None,
                 }));
                 let size = match **s {
                     CType::Int(s) => s as usize,
@@ -3679,6 +3703,7 @@ impl CType {
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     }));
                 }
                 // Also include accessor functions for each
@@ -3689,6 +3714,7 @@ impl CType {
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     }))
                 }
             }
@@ -3706,6 +3732,7 @@ impl CType {
                     microstatements: Vec::new(),
                     kind: FnKind::DerivedVariadic,
                     origin_scope_path: scope.path.clone(),
+                    lazy_body: None,
                 }));
             }
             CType::Shared(s) => {
@@ -3717,6 +3744,7 @@ impl CType {
                     microstatements: Vec::new(),
                     kind: FnKind::Derived,
                     origin_scope_path: scope.path.clone(),
+                    lazy_body: None,
                 }));
             }
             CType::Int(i) => {
@@ -3733,6 +3761,7 @@ impl CType {
                     }],
                     kind: FnKind::Normal,
                     origin_scope_path: scope.path.clone(),
+                    lazy_body: None,
                 }));
             }
             CType::Float(f) => {
@@ -3749,6 +3778,7 @@ impl CType {
                     }],
                     kind: FnKind::Normal,
                     origin_scope_path: scope.path.clone(),
+                    lazy_body: None,
                 }));
             }
             CType::Bool(b) => {
@@ -3771,6 +3801,7 @@ impl CType {
                         }],
                         kind: FnKind::Normal,
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     }));
                 }
             }
@@ -3787,6 +3818,7 @@ impl CType {
                     }],
                     kind: FnKind::Normal,
                     origin_scope_path: scope.path.clone(),
+                    lazy_body: None,
                 }));
                 // Also include the original name if it doesn't match. TODO: Figure out why these
                 // aren't resolving in the same way
@@ -3802,6 +3834,7 @@ impl CType {
                         }],
                         kind: FnKind::Normal,
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     }));
                 }
             }
@@ -3821,6 +3854,7 @@ impl CType {
                         microstatements: Vec::new(),
                         kind: FnKind::Derived,
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     }));
                 }
             }

--- a/alan_compiler/src/program/function.rs
+++ b/alan_compiler/src/program/function.rs
@@ -1,5 +1,5 @@
-use std::cell::RefCell;
-use std::collections::HashSet;
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use super::ctype::{withtypeoperatorslist_to_ctype, CType};
@@ -17,6 +17,61 @@ thread_local! {
     // resolved, so `resolve_lazy` can detect and reject unsupported recursive definitions instead
     // of looping forever.
     static RESOLVING: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
+
+    // A monotonically increasing counter assigning each source-defined function a "definition
+    // order" index reflecting where it appears during evaluation of the source. Alan's function
+    // dispatch is order-sensitive: a function body only "sees" definitions that appear before it,
+    // and the most-recent matching definition wins. We must preserve this under lazy loading.
+    static DEF_COUNTER: Cell<usize> = const { Cell::new(0) };
+    // Maps a source-defined function (by `Arc` identity) to its definition-order index.
+    static FN_DEF_INDEX: RefCell<HashMap<usize, usize>> = RefCell::new(HashMap::new());
+    // A stack of "visibility boundaries" -- the definition index of the (non-generic) function
+    // whose body is currently being resolved. While a boundary is in effect, function lookups only
+    // consider definitions that appear strictly before it, mirroring eager, in-order resolution.
+    static VISIBILITY_STACK: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+}
+
+fn fn_ptr_key(f: &Arc<Function>) -> usize {
+    Arc::as_ptr(f) as *const () as usize
+}
+
+/// Assigns the next definition-order index to a freshly-created source-defined function and records
+/// it, returning the index. Functions created by other means (generic realizations, derived
+/// constructors/accessors, etc.) are intentionally *not* recorded -- they have no source position
+/// and are treated as always-visible.
+fn record_def_index(f: &Arc<Function>) {
+    let idx = DEF_COUNTER.with(|c| {
+        let v = c.get();
+        c.set(v + 1);
+        v
+    });
+    FN_DEF_INDEX.with(|m| m.borrow_mut().insert(fn_ptr_key(f), idx));
+}
+
+/// Looks up a function's definition-order index, if it has one.
+pub fn def_index_of(f: &Arc<Function>) -> Option<usize> {
+    FN_DEF_INDEX.with(|m| m.borrow().get(&fn_ptr_key(f)).copied())
+}
+
+/// Records an explicit definition-order index for a function. Used when a lazily-resolved function
+/// is replaced by its fully-resolved equivalent (a new `Arc`) that persists in the scope -- the
+/// replacement must inherit the original's index so dispatch ordering stays correct.
+pub fn set_def_index(f: &Arc<Function>, idx: usize) {
+    FN_DEF_INDEX.with(|m| m.borrow_mut().insert(fn_ptr_key(f), idx));
+}
+
+/// Whether the given function is visible under the current visibility boundary (see
+/// `VISIBILITY_STACK`). With no boundary in effect (e.g. resolving user code, where the whole root
+/// scope is already loaded) everything is visible. Functions without a definition index (generic
+/// realizations, derived functions, etc.) are always visible.
+pub fn is_visible(f: &Arc<Function>) -> bool {
+    VISIBILITY_STACK.with(|s| match s.borrow().last() {
+        None => true,
+        Some(&boundary) => match def_index_of(f) {
+            Some(idx) => idx < boundary,
+            None => true,
+        },
+    })
 }
 
 #[derive(Clone, Debug)]
@@ -328,6 +383,7 @@ impl Function {
                         origin_scope_path: scope.path.clone(),
                         lazy_body: None,
                     });
+                    record_def_index(&function);
                     if is_export {
                         scope
                             .exports
@@ -604,6 +660,7 @@ impl Function {
             origin_scope_path: scope.path.clone(),
             lazy_body: if defer { Some(statements) } else { None },
         });
+        record_def_index(&function);
         if is_export {
             scope
                 .exports
@@ -651,6 +708,14 @@ impl Function {
         RESOLVING.with(|r| {
             r.borrow_mut().insert(key);
         });
+        // While resolving this (non-generic) function's body, restrict visibility to definitions
+        // that appear before it -- mirroring Alan's order-sensitive dispatch. Generic functions are
+        // *not* resolved through this path; they are realized at their call site and so inherit
+        // whatever boundary is already in effect there.
+        let boundary = def_index_of(&func);
+        if let Some(b) = boundary {
+            VISIBILITY_STACK.with(|s| s.borrow_mut().push(b));
+        }
         let result = (|| {
             let mut typen = func.typen.clone();
             let mut ms = func.microstatements.clone();
@@ -719,6 +784,11 @@ impl Function {
             });
             Ok((scope, resolved))
         })();
+        if boundary.is_some() {
+            VISIBILITY_STACK.with(|s| {
+                s.borrow_mut().pop();
+            });
+        }
         RESOLVING.with(|r| {
             r.borrow_mut().remove(&key);
         });

--- a/alan_compiler/src/program/function.rs
+++ b/alan_compiler/src/program/function.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use super::ctype::{withtypeoperatorslist_to_ctype, CType};
@@ -10,6 +12,13 @@ use super::FnKind;
 use super::Scope;
 use crate::parse;
 
+thread_local! {
+    // Tracks the set of lazy functions (by `Arc` identity) whose bodies are currently being
+    // resolved, so `resolve_lazy` can detect and reject unsupported recursive definitions instead
+    // of looping forever.
+    static RESOLVING: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
+}
+
 #[derive(Clone, Debug)]
 pub struct Function {
     pub name: String,
@@ -17,6 +26,12 @@ pub struct Function {
     pub microstatements: Vec<Microstatement>,
     pub kind: FnKind,
     pub origin_scope_path: String,
+    // When `Some`, this function's body has not yet been resolved into microstatements. It holds
+    // the parsed statements so the body can be resolved on-demand (lazily) the first time the
+    // function is actually referenced during codegen-reachable resolution. This lets us skip
+    // resolving the bodies of the thousands of standard-library functions that a given program
+    // never calls. `None` means the function is fully resolved (the normal, eager state).
+    pub lazy_body: Option<Vec<parse::Statement>>,
 }
 
 pub fn type_to_args(t: Arc<CType>) -> Vec<(String, ArgKind, Arc<CType>)> {
@@ -311,6 +326,7 @@ impl Function {
                         microstatements: Vec::new(),
                         kind,
                         origin_scope_path: scope.path.clone(),
+                        lazy_body: None,
                     });
                     if is_export {
                         scope
@@ -487,14 +503,24 @@ impl Function {
                 }
             },
         }?;
+        // We defer resolving the bodies of non-generic functions in the *root* scope. The root
+        // scope holds thousands of standard-library functions, the vast majority of which any
+        // given program never calls. Resolving all of their bodies up-front dominates compile
+        // latency, so instead we stash the parsed statements in `lazy_body` and resolve them
+        // on-demand the first time the function is actually referenced (see
+        // `Scope::resolve_function`). Functions in user scopes (including `main`) are still
+        // resolved eagerly so that codegen, which only has immutable access to the scope, always
+        // sees fully-resolved functions; their resolution transitively forces resolution of any
+        // root functions they reach.
+        let defer = function_ast.optgenerics.is_none() && scope.path == "@root";
         let microstatements = {
             let mut ms = Vec::new();
             for (name, kind, typen) in type_to_args(typen.clone()) {
                 ms.push(Microstatement::Arg { name, kind, typen });
             }
             // We can't generate the rest of the microstatements while the generic function is
-            // still generic
-            if function_ast.optgenerics.is_none() {
+            // still generic, and we skip it entirely for deferred (lazy) root functions.
+            if function_ast.optgenerics.is_none() && !defer {
                 for statement in &statements {
                     // The construction of microstatements in non-generic functions will never
                     // actually use the provided function for scope resolution, so we just give it
@@ -507,8 +533,11 @@ impl Function {
             ms
         };
         // Determine the actual return type of the function and check if it matches the specified
-        // return type (or update that return type if it's to be inferred
-        if let Some(ms) = microstatements.last() {
+        // return type (or update that return type if it's to be inferred. Skipped for deferred
+        // functions, whose return type is inferred when their body is later resolved.
+        if defer {
+            // Nothing to infer yet; the body is resolved lazily.
+        } else if let Some(ms) = microstatements.last() {
             if let Microstatement::Arg { .. } = ms {
                 // Don't do anything in this path, this is probably a derived function
             } else {
@@ -546,7 +575,9 @@ impl Function {
             CType::Function(i, o) => {
                 match &**o {
                     CType::Void | CType::DerivedVoid(..) => { /* Do nothing */ }
-                    CType::Infer(t, _) if t == "unknown" && function_ast.optgenerics.is_none() => {
+                    CType::Infer(t, _)
+                        if t == "unknown" && function_ast.optgenerics.is_none() && !defer =>
+                    {
                         CType::fail(&format!(
                             "The return type for {}({}) could not be inferred.",
                             name,
@@ -571,6 +602,7 @@ impl Function {
             microstatements,
             kind,
             origin_scope_path: scope.path.clone(),
+            lazy_body: if defer { Some(statements) } else { None },
         });
         if is_export {
             scope
@@ -586,6 +618,111 @@ impl Function {
                 .insert(function.name.clone(), vec![function]);
         }
         Ok(scope)
+    }
+
+    // Resolves the deferred body of a lazily-loaded function (see the `lazy_body` field and
+    // `from_ast_with_name`). It mirrors the body-resolution logic of `from_ast_with_name` for
+    // non-generic functions: it builds the body microstatements (on top of the already-present
+    // `Arg` microstatements), infers/validates the return type, and ensures the return type's
+    // constructor exists in the scope. It returns the fully-resolved function (with `lazy_body`
+    // set to `None`) along with the updated scope (which may have gained realized generic
+    // functions/types reached transitively by the body).
+    pub fn resolve_lazy<'a>(
+        mut scope: Scope<'a>,
+        func: Arc<Function>,
+    ) -> Result<(Scope<'a>, Arc<Function>), Box<dyn std::error::Error>> {
+        let statements = match &func.lazy_body {
+            Some(s) => s,
+            None => return Ok((scope, func)),
+        };
+        // Guard against infinite recursion. Non-generic functions cannot legally recurse by name
+        // (the eager path never had the function in scope while building its own body), so if we
+        // re-enter resolution for the same function it indicates an unsupported recursive
+        // definition rather than a legitimate case. Bail out cleanly so we don't hang the
+        // compiler.
+        let key = Arc::as_ptr(&func) as *const () as usize;
+        if RESOLVING.with(|r| r.borrow().contains(&key)) {
+            return Err(format!(
+                "Function {} appears to be recursively defined, which is not supported.",
+                func.name
+            )
+            .into());
+        }
+        RESOLVING.with(|r| {
+            r.borrow_mut().insert(key);
+        });
+        let result = (|| {
+            let mut typen = func.typen.clone();
+            let mut ms = func.microstatements.clone();
+            for statement in statements {
+                let res = statement_to_microstatements(statement, None, scope, ms)?;
+                scope = res.0;
+                ms = res.1;
+            }
+            // Determine the actual return type of the function and check it against any declared
+            // return type (or infer it if it was left to be inferred).
+            if let Some(last) = ms.last() {
+                if let Microstatement::Arg { .. } = last {
+                    // Don't do anything in this path, this is probably a derived function
+                } else {
+                    let current_rettype = type_to_rettype(typen.clone());
+                    let actual_rettype = match last {
+                        Microstatement::Return { value: Some(v) } => v.get_type(),
+                        _ => Arc::new(CType::Void),
+                    };
+                    if let CType::Infer(..) = &*current_rettype {
+                        let input_type = match &*typen {
+                            CType::Function(i, _) => i.clone(),
+                            _ => Arc::new(CType::Void),
+                        };
+                        typen = Arc::new(CType::Function(input_type, actual_rettype));
+                    } else if current_rettype.clone().to_strict_string(false)
+                        != actual_rettype.clone().to_strict_string(false)
+                    {
+                        CType::fail(&format!(
+                            "Function {} specified to return {} but actually returns {}",
+                            func.name,
+                            current_rettype.to_strict_string(false),
+                            actual_rettype.to_strict_string(false),
+                        ));
+                    }
+                }
+            }
+            // Ensure the return type's constructor exists in the scope.
+            match &*typen {
+                CType::Function(i, o) => match &**o {
+                    CType::Void | CType::DerivedVoid(..) => { /* Do nothing */ }
+                    CType::Infer(t, _) if t == "unknown" => {
+                        CType::fail(&format!(
+                            "The return type for {}({}) could not be inferred.",
+                            func.name,
+                            i.clone().to_strict_string(false)
+                        ));
+                    }
+                    CType::Infer(..) => { /* Do nothing */ }
+                    _otherwise => {
+                        let n = o.clone().to_callable_string();
+                        if scope.resolve_type(&n).is_none() {
+                            scope = CType::from_ctype(scope, n, o.clone());
+                        }
+                    }
+                },
+                _ => unreachable!(),
+            }
+            let resolved = Arc::new(Function {
+                name: func.name.clone(),
+                typen,
+                microstatements: ms,
+                kind: func.kind.clone(),
+                origin_scope_path: func.origin_scope_path.clone(),
+                lazy_body: None,
+            });
+            Ok((scope, resolved))
+        })();
+        RESOLVING.with(|r| {
+            r.borrow_mut().remove(&key);
+        });
+        result
     }
 
     pub fn from_generic_function<'a>(
@@ -697,6 +834,7 @@ impl Function {
                     microstatements,
                     kind,
                     origin_scope_path: scope.path.clone(),
+                    lazy_body: None,
                 });
                 if scope.functions.contains_key(&f.name) {
                     let func_vec = scope.functions.get_mut(&f.name).unwrap();
@@ -818,6 +956,7 @@ impl Function {
                     microstatements,
                     kind,
                     origin_scope_path: scope.path.clone(),
+                    lazy_body: None,
                 });
                 // Insert under suffixed name, deduplicating by both name and signature
                 if scope.functions.contains_key(&f.name) {
@@ -886,6 +1025,7 @@ impl Function {
                     microstatements,
                     kind: FnKind::CfnRealized(cfn_kind.clone()),
                     origin_scope_path: scope.path.clone(),
+                    lazy_body: None,
                 });
                 if scope.functions.contains_key(&f.name) {
                     let func_vec = scope.functions.get_mut(&f.name).unwrap();

--- a/alan_compiler/src/program/microstatement.rs
+++ b/alan_compiler/src/program/microstatement.rs
@@ -665,6 +665,7 @@ pub fn baseassignablelist_to_microstatements<'a>(
                     microstatements: ms,
                     kind,
                     origin_scope_path: scope.path.clone(),
+                    lazy_body: None,
                 });
                 prior_value = Some(Microstatement::Closure { function });
             }

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -376,7 +376,9 @@ impl<'a> Scope<'a> {
             if let Some(s) = scope_to_check {
                 if let Some(funcs) = s.functions.get(function) {
                     for f in funcs {
-                        fs.push(f.clone()); // TODO: Drop this clone
+                        if super::function::is_visible(f) {
+                            fs.push(f.clone()); // TODO: Drop this clone
+                        }
                     }
                 }
                 scope_to_check = match &s.parent {
@@ -387,7 +389,7 @@ impl<'a> Scope<'a> {
         }
         let out_types = fs
             .iter()
-            .map(|f| {
+            .filter_map(|f| {
                 let generics = match &f.kind {
                     FnKind::Normal
                     | FnKind::External(_)
@@ -410,8 +412,26 @@ impl<'a> Scope<'a> {
                     .iter()
                     .map(|(_, _, arg)| arg.clone())
                     .collect::<Vec<Arc<CType>>>();
-                let output = f.rettype();
-                match generics {
+                // When a function is referenced as a *value* (rather than called), we need its
+                // real return type so it can be matched against, e.g., a `(T, T) -> bool` parameter.
+                // A lazily-loaded function hasn't had its body resolved yet, so its return type is
+                // still `Infer("unknown")`; resolve the body in a throwaway child scope to recover
+                // the actual return type. (Only non-generic functions are ever lazy.)
+                let output = if f.lazy_body.is_some() {
+                    match Function::resolve_lazy(self.child(), f.clone()) {
+                        Ok((_, resolved)) => resolved.rettype(),
+                        // The body is currently being resolved -- a cyclic reference, e.g. an array
+                        // overload defined as `arr.map(self)` that maps over its own scalar
+                        // overload. We can't know its return type yet, and including it with an
+                        // `unknown` return type would corrupt the type union and break matching
+                        // against the overloads that *are* known (the ones actually needed here),
+                        // so we omit this overload from the function value's type.
+                        Err(_) => return None,
+                    }
+                } else {
+                    f.rettype()
+                };
+                Some(match generics {
                     None => Arc::new(CType::Function(
                         Arc::new(CType::Tuple(input, Vec::new())),
                         output,
@@ -424,8 +444,17 @@ impl<'a> Scope<'a> {
                             output,
                         )),
                     )),
-                }
+                })
             })
+            .collect::<Vec<Arc<CType>>>();
+        // Deduplicate structurally-identical overload types. The same function can be reachable
+        // through more than one scope in the lookup chain (e.g. once memoized as a resolved
+        // version), and duplicate members in the resulting type union confuse generic inference
+        // when this function value is matched against a higher-order parameter like `(T -> U)`.
+        let mut seen = std::collections::HashSet::new();
+        let out_types = out_types
+            .into_iter()
+            .filter(|t| seen.insert(t.clone().to_strict_string(false)))
             .collect::<Vec<Arc<CType>>>();
         if out_types.is_empty() {
             Arc::new(CType::Void)
@@ -627,10 +656,25 @@ impl<'a> Scope<'a> {
             // subsequent lookups -- including codegen's by-type lookups for function values --
             // find the resolved function instead of the lazy stand-in.
             if f.lazy_body.is_some() {
+                // Preserve the lazy function's definition-order index so the resolved replacement
+                // (a fresh `Arc`) keeps the same visibility position once memoized into the scope.
+                let f_idx = super::function::def_index_of(&f);
+                let f_ptr = Arc::as_ptr(&f);
                 return match Function::resolve_lazy(self, f) {
                     Ok((mut s, resolved)) => {
+                        if let Some(idx) = f_idx {
+                            super::function::set_def_index(&resolved, idx);
+                        }
                         if let Some(v) = s.functions.get_mut(&resolved.name) {
-                            v.insert(0, resolved.clone());
+                            // Replace the lazy stand-in in place rather than prepending a copy --
+                            // otherwise both the lazy and resolved versions linger in the scope and
+                            // get collected together (e.g. by `resolve_function_types`), producing
+                            // duplicate overloads in function-value type unions.
+                            if let Some(pos) = v.iter().position(|g| Arc::as_ptr(g) == f_ptr) {
+                                v[pos] = resolved.clone();
+                            } else {
+                                v.insert(0, resolved.clone());
+                            }
                         } else {
                             s.functions
                                 .insert(resolved.name.clone(), vec![resolved.clone()]);
@@ -716,7 +760,9 @@ impl<'a> Scope<'a> {
                 if let Some(funcs) = s.functions.get(function) {
                     // Why is this okay but cloning funcs and then appending is not?
                     for f in funcs {
-                        fs.push(f);
+                        if super::function::is_visible(f) {
+                            fs.push(f);
+                        }
                     }
                 }
                 // TODO: Types are internally referred to by their structural name, not by the name the
@@ -730,7 +776,9 @@ impl<'a> Scope<'a> {
                     match s.functions.get(&constructor_fn_name) {
                         Some(funcs) => {
                             for f in funcs {
-                                fs.push(f);
+                                if super::function::is_visible(f) {
+                                    fs.push(f);
+                                }
                             }
                         }
                         None => { /* Nothing matched, move on */ }
@@ -820,7 +868,9 @@ impl<'a> Scope<'a> {
                 if let Some(funcs) = s.functions.get(function) {
                     // Why is this okay but cloning funcs and then appending is not?
                     for f in funcs {
-                        fs.push(f);
+                        if super::function::is_visible(f) {
+                            fs.push(f);
+                        }
                     }
                 }
                 // TODO: Types are internally referred to by their structural name, not by the name the
@@ -834,7 +884,9 @@ impl<'a> Scope<'a> {
                     match s.functions.get(&constructor_fn_name) {
                         Some(funcs) => {
                             for f in funcs {
-                                fs.push(f);
+                                if super::function::is_visible(f) {
+                                    fs.push(f);
+                                }
                             }
                         }
                         None => { /* Nothing matched, move on */ }

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -180,6 +180,7 @@ impl<'a> Scope<'a> {
                         microstatements: Vec::new(),
                         kind,
                         origin_scope_path: s.path.clone(),
+                        lazy_body: None,
                     });
                     let key = if is_generic {
                         function.name.clone()
@@ -619,10 +620,27 @@ impl<'a> Scope<'a> {
         // a generic function, if possible.
         // TODO: This boolean *shouldn't* be necessary, but I can't convince the borrow checker
         // otherwise
-        let is_normal = self.resolve_normal_function(function, args).is_some();
-        if is_normal {
-            self.resolve_normal_function(function, args)
-                .map(|f| (self, f))
+        let normal = self.resolve_normal_function(function, args);
+        if let Some(f) = normal {
+            // If the matched function still has a deferred (lazy) body, resolve it now using our
+            // owned (mutable) scope, then memoize the fully-resolved version into the scope so
+            // subsequent lookups -- including codegen's by-type lookups for function values --
+            // find the resolved function instead of the lazy stand-in.
+            if f.lazy_body.is_some() {
+                return match Function::resolve_lazy(self, f) {
+                    Ok((mut s, resolved)) => {
+                        if let Some(v) = s.functions.get_mut(&resolved.name) {
+                            v.insert(0, resolved.clone());
+                        } else {
+                            s.functions
+                                .insert(resolved.name.clone(), vec![resolved.clone()]);
+                        }
+                        Some((s, resolved))
+                    }
+                    Err(_) => None,
+                };
+            }
+            Some((self, f))
         } else {
             match self.resolve_function_generic_args(function, args) {
                 Some(gs) => self.resolve_generic_function(function, &gs, args),
@@ -653,6 +671,7 @@ impl<'a> Scope<'a> {
                                         microstatements: Vec::new(),
                                         kind: FnKind::Derived,
                                         origin_scope_path: self.path.clone(),
+                                        lazy_body: None,
                                     });
                                     let temp_scope = self.child();
                                     let mut temp_scope = temp_scope;


### PR DESCRIPTION
- **Add a fake interpreter mode that just uses an unoptimized compilation**
- **Make the function loading lazy to improve compilation times**
- **Determine the actual location of `cargo` if using `rustup` to shave time off of compilation**
- **Switch to mimalloc to speed up allocations**
- **Fix mistakes in the compilation flow ignoring cached data**
- **Cache the rust toolchain path, invalidated by rustup's `settings.toml` being updated**
- **Add support for shebang lines in source files**
