### PR TITLE
`Promise{T}` annotation for JS bindings

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -889,6 +889,18 @@ export fn{Mac || Js} main {
     stdout "0.33, 1.00, 1.00, 1.00, 2.00, 1.67, 1.67, 3.00, 2.33\n";
 );
 
+test!(map_i32_function_value_sync_dispatch => r#"fn conv(idx: Buffer{i64, 3}) -> Buffer{i32, 3} {
+  return idx.map(i32);
+}
+
+export fn main {
+  let out = conv({i64[3]}(1, 2, 3));
+  out.len.string.print;
+}
+"#;
+    stdout "3\n";
+);
+
 // Functions and Custom Operators
 
 test!(basic_function_usage => r#"fn foo() = print('foo');

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -524,7 +524,7 @@ test!(print_function => r#"export fn main() {
     stdout "Hello, World\n";
     status 0;
 );
-test!(duration_print => r#"export fn main() -> void {
+test!(duration_print => r#"export fn main() {
   const i = now();
   wait(110); // Increased from 10ms to 110ms because the node.js event loop seems less
   // capable of guaranteeing staying below 20ms in the delay here. Adding an extra

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -179,14 +179,21 @@ pub fn from_microstatement(
                 let (val, o, d) = from_microstatement(ms, parent_fn, scope, out, deps)?;
                 out = o;
                 deps = d;
-                inner_statements.push(val);
+                if !val.trim().is_empty() {
+                    inner_statements.push(val);
+                }
             }
+            let body = if inner_statements.is_empty() {
+                "".to_string()
+            } else {
+                format!("\n        {};\n    ", inner_statements.join(";\n        "))
+            };
             Ok((
                 format!(
-                    "{}function ({}) {{\n        {};\n    }}",
+                    "{}function ({}) {{{}}}",
                     async_prefix,
                     arg_names.join(", "),
-                    inner_statements.join(";\n        "),
+                    body,
                 ),
                 out,
                 deps,
@@ -1811,6 +1818,9 @@ pub fn generate(
         let (stmt, o, d) = from_microstatement(microstatement, function, scope, out, deps)?;
         out = o;
         deps = d;
+        if stmt.trim().is_empty() {
+            continue;
+        }
         fn_string = format!("{fn_string}    {stmt};\n");
     }
     fn_string = format!("{fn_string}}}");

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -62,6 +62,17 @@ fn box_native_value(typen: &CType, representation: &str) -> Option<String> {
     }
 }
 
+fn is_promise_head(typen: Arc<CType>) -> bool {
+    let mut t = typen.degroup();
+    while matches!(&*t, CType::Type(..) | CType::Group(_)) {
+        t = match &*t {
+            CType::Type(_, inner) | CType::Group(inner) => inner.clone().degroup(),
+            _ => unreachable!(),
+        };
+    }
+    matches!(&*t, CType::Promise(_))
+}
+
 #[allow(clippy::type_complexity)]
 pub fn from_microstatement(
     microstatement: &Microstatement,
@@ -111,6 +122,11 @@ pub fn from_microstatement(
                 .into_iter()
                 .map(|(n, _, _)| n)
                 .collect::<Vec<String>>();
+            let async_prefix = if is_promise_head(function.rettype()) {
+                "async "
+            } else {
+                ""
+            };
             let mut inner_statements = Vec::new();
             for ms in &function.microstatements {
                 let (val, o, d) = from_microstatement(ms, parent_fn, scope, out, deps)?;
@@ -120,7 +136,8 @@ pub fn from_microstatement(
             }
             Ok((
                 format!(
-                    "async function ({}) {{\n        {};\n    }}",
+                    "{}function ({}) {{\n        {};\n    }}",
+                    async_prefix,
                     arg_names.join(", "),
                     inner_statements.join(";\n        "),
                 ),
@@ -387,8 +404,13 @@ pub fn from_microstatement(
                     if let FnKind::External(d) = &function.kind {
                         super::register_nodejs_dependency(d, &mut deps);
                     }
+                    let call = format!("{}({})", jsname, argstrs.join(", "));
                     Ok((
-                        format!("(await {}({}))", jsname, argstrs.join(", ")).to_string(),
+                        if is_promise_head(function.rettype()) {
+                            format!("(await {call})")
+                        } else {
+                            format!("({call})")
+                        },
                         out,
                         deps,
                     ))
@@ -408,8 +430,13 @@ pub fn from_microstatement(
                     if let FnKind::ExternalBind(_, d) = &function.kind {
                         super::register_nodejs_dependency(d, &mut deps);
                     }
+                    let call = format!("{}({})", jsname, argstrs.join(", "));
                     Ok((
-                        format!("(await {}({}))", jsname, argstrs.join(", ")).to_string(),
+                        if is_promise_head(function.rettype()) {
+                            format!("(await {call})")
+                        } else {
+                            format!("({call})")
+                        },
                         out,
                         deps,
                     ))
@@ -865,9 +892,10 @@ pub fn from_microstatement(
                         }
                     } else if function.name == ret_name {
                         let mut inner_ret_type = ret_type.clone();
-                        while matches!(&*inner_ret_type, CType::Type(..)) {
+                        while matches!(&*inner_ret_type, CType::Type(..) | CType::Promise(_)) {
                             inner_ret_type = match &*inner_ret_type {
                                 CType::Type(_, t) => t.clone(),
+                                CType::Promise(t) => t.clone(),
                                 _ => inner_ret_type,
                             };
                         }
@@ -893,7 +921,7 @@ pub fn from_microstatement(
                             CType::Array(_) => {
                                 return Ok((format!("[{}]", argstrs.join(", ")), out, deps));
                             }
-                            CType::Shared(_) => {
+                            CType::Shared(_) | CType::Promise(_) => {
                                 return Ok((argstrs[0].clone(), out, deps));
                             }
                             CType::Either(ts, _) => {
@@ -1527,6 +1555,7 @@ pub fn from_microstatement(
                                 child_type = match &*child_type {
                                     CType::Type(_, t) => t.clone(),
                                     CType::Group(t) => t.clone(),
+                                    CType::Promise(t) => t.clone(),
                                     _ => break,
                                 };
                             }
@@ -1625,13 +1654,14 @@ pub fn from_microstatement(
                     // Fallback: Check if return type is Shared for constructor generation
                     // when function name doesn't match (e.g., inferred generic constructors)
                     let mut fallback_ret = ret_type.clone();
-                    while matches!(&*fallback_ret, CType::Type(..)) {
+                    while matches!(&*fallback_ret, CType::Type(..) | CType::Promise(_)) {
                         fallback_ret = match &*fallback_ret {
                             CType::Type(_, t) => t.clone(),
+                            CType::Promise(t) => t.clone(),
                             _ => fallback_ret,
                         };
                     }
-                    if let CType::Shared(_) = &*fallback_ret {
+                    if matches!(&*fallback_ret, CType::Shared(_) | CType::Promise(_)) {
                         return Ok((argstrs[0].clone(), out, deps));
                     }
                     Err(format!(
@@ -1642,7 +1672,11 @@ pub fn from_microstatement(
                 }
             }
         }
-        Microstatement::VarCall { name, args, .. } => {
+        Microstatement::VarCall {
+            name,
+            typen,
+            args,
+        } => {
             let mut argstrs = Vec::new();
             for arg in args {
                 let (a, o, d) = from_microstatement(arg, parent_fn, scope, out, deps)?;
@@ -1650,8 +1684,13 @@ pub fn from_microstatement(
                 deps = d;
                 argstrs.push(a);
             }
+            let call = format!("{}({})", name, argstrs.join(", "));
             Ok((
-                format!("(await {}({}))", name, argstrs.join(", ")).to_string(),
+                if is_promise_head(typen.clone()) {
+                    format!("(await {call})")
+                } else {
+                    format!("({call})")
+                },
                 out,
                 deps,
             ))
@@ -1708,9 +1747,15 @@ pub fn generate(
     // a shared library). LLVM *probably* doesn't deduplicate this redundancy, so this will need to
     // be revisited, but it eliminates a whole host of generation problems that I can come back to
     // later.
+    let fn_async = if is_promise_head(function.rettype()) {
+        "async "
+    } else {
+        ""
+    };
     fn_string = format!(
-        "{}async function {}({}) {{\n",
+        "{}{}function {}({}) {{\n",
         fn_string,
+        fn_async,
         jsname.clone(),
         arg_strs.join(", "),
     )

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use nom::combinator::all_consuming;
@@ -73,6 +74,52 @@ fn is_promise_head(typen: Arc<CType>) -> bool {
     matches!(&*t, CType::Promise(_))
 }
 
+fn function_codegen_is_async(function: Arc<Function>) -> bool {
+    fn microstatement_awaits_for_codegen(ms: &Microstatement, seen: &mut HashSet<usize>) -> bool {
+        match ms {
+            Microstatement::Assignment { value, .. } => microstatement_awaits_for_codegen(value, seen),
+            Microstatement::FnCall { function, args } => {
+                function_codegen_is_async_inner(function.clone(), seen)
+                    || args
+                        .iter()
+                        .any(|a| microstatement_awaits_for_codegen(a, seen))
+            }
+            Microstatement::VarCall { typen, args, .. } => {
+                is_promise_head(typen.clone())
+                    || args
+                        .iter()
+                        .any(|a| microstatement_awaits_for_codegen(a, seen))
+            }
+            Microstatement::Array { vals, .. } => vals
+                .iter()
+                .any(|v| microstatement_awaits_for_codegen(v, seen)),
+            Microstatement::Return { value } => value
+                .as_deref()
+                .is_some_and(|v| microstatement_awaits_for_codegen(v, seen)),
+            Microstatement::NativeCall { args, .. } => args
+                .iter()
+                .any(|a| microstatement_awaits_for_codegen(a, seen)),
+            Microstatement::Closure { function } => function_codegen_is_async_inner(function.clone(), seen),
+            Microstatement::Arg { .. } | Microstatement::Value { .. } => false,
+        }
+    }
+
+    fn function_codegen_is_async_inner(function: Arc<Function>, seen: &mut HashSet<usize>) -> bool {
+        let ptr = Arc::as_ptr(&function) as usize;
+        if !seen.insert(ptr) {
+            return false;
+        }
+        is_promise_head(function.rettype())
+            || function
+                .microstatements
+                .iter()
+                .any(|ms| microstatement_awaits_for_codegen(ms, seen))
+    }
+
+    let mut seen = HashSet::new();
+    function_codegen_is_async_inner(function, &mut seen)
+}
+
 #[allow(clippy::type_complexity)]
 pub fn from_microstatement(
     microstatement: &Microstatement,
@@ -122,7 +169,7 @@ pub fn from_microstatement(
                 .into_iter()
                 .map(|(n, _, _)| n)
                 .collect::<Vec<String>>();
-            let async_prefix = if is_promise_head(function.rettype()) {
+            let async_prefix = if function_codegen_is_async(function.clone()) {
                 "async "
             } else {
                 ""
@@ -406,7 +453,7 @@ pub fn from_microstatement(
                     }
                     let call = format!("{}({})", jsname, argstrs.join(", "));
                     Ok((
-                        if is_promise_head(function.rettype()) {
+                        if function_codegen_is_async(function.clone()) {
                             format!("(await {call})")
                         } else {
                             format!("({call})")
@@ -432,7 +479,7 @@ pub fn from_microstatement(
                     }
                     let call = format!("{}({})", jsname, argstrs.join(", "));
                     Ok((
-                        if is_promise_head(function.rettype()) {
+                        if function_codegen_is_async(function.clone()) {
                             format!("(await {call})")
                         } else {
                             format!("({call})")
@@ -1747,7 +1794,7 @@ pub fn generate(
     // a shared library). LLVM *probably* doesn't deduplicate this redundancy, so this will need to
     // be revisited, but it eliminates a whole host of generation problems that I can come back to
     // later.
-    let fn_async = if is_promise_head(function.rettype()) {
+    let fn_async = if function_codegen_is_async(Arc::new(function.clone())) {
         "async "
     } else {
         ""

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -77,7 +77,9 @@ fn is_promise_head(typen: Arc<CType>) -> bool {
 fn function_codegen_is_async(function: Arc<Function>) -> bool {
     fn microstatement_awaits_for_codegen(ms: &Microstatement, seen: &mut HashSet<usize>) -> bool {
         match ms {
-            Microstatement::Assignment { value, .. } => microstatement_awaits_for_codegen(value, seen),
+            Microstatement::Assignment { value, .. } => {
+                microstatement_awaits_for_codegen(value, seen)
+            }
             Microstatement::FnCall { function, args } => {
                 function_codegen_is_async_inner(function.clone(), seen)
                     || args
@@ -99,7 +101,9 @@ fn function_codegen_is_async(function: Arc<Function>) -> bool {
             Microstatement::NativeCall { args, .. } => args
                 .iter()
                 .any(|a| microstatement_awaits_for_codegen(a, seen)),
-            Microstatement::Closure { function } => function_codegen_is_async_inner(function.clone(), seen),
+            Microstatement::Closure { function } => {
+                function_codegen_is_async_inner(function.clone(), seen)
+            }
             Microstatement::Arg { .. } | Microstatement::Value { .. } => false,
         }
     }
@@ -1726,11 +1730,7 @@ pub fn from_microstatement(
                 }
             }
         }
-        Microstatement::VarCall {
-            name,
-            typen,
-            args,
-        } => {
+        Microstatement::VarCall { name, typen, args } => {
             let mut argstrs = Vec::new();
             for arg in args {
                 let (a, o, d) = from_microstatement(arg, parent_fn, scope, out, deps)?;

--- a/alan_compiler/src/lntojs/mod.rs
+++ b/alan_compiler/src/lntojs/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use ordered_hash_map::OrderedHashMap;
 
 use crate::lntojs::function::generate as fn_generate;
@@ -5,6 +7,30 @@ use crate::program::{CType, Program};
 
 mod function;
 mod typen;
+
+fn is_promise_head(typen: Arc<CType>) -> bool {
+    let mut t = typen.degroup();
+    while matches!(&*t, CType::Type(..) | CType::Group(_)) {
+        t = match &*t {
+            CType::Type(_, inner) | CType::Group(inner) => inner.clone().degroup(),
+            _ => unreachable!(),
+        };
+    }
+    matches!(&*t, CType::Promise(_))
+}
+
+fn is_exitcode_type(typen: Arc<CType>) -> bool {
+    let mut t = typen.degroup();
+    loop {
+        match &*t {
+            CType::Type(n, _) if n == "ExitCode" => return true,
+            CType::Type(_, inner) | CType::Group(inner) | CType::Promise(inner) => {
+                t = inner.clone().degroup();
+            }
+            _ => return false,
+        }
+    }
+}
 
 pub(crate) fn register_nodejs_dependency(d: &CType, deps: &mut OrderedHashMap<String, String>) {
     match d {
@@ -87,14 +113,18 @@ pub fn lntojs(
         OrderedHashMap::new(),
         OrderedHashMap::new(),
     )?;
-    let main_call = if let CType::Type(n, _) = &*func[0].rettype() {
-        if n == "ExitCode" {
+    let main_is_async = is_promise_head(func[0].rettype());
+    let main_is_exitcode = is_exitcode_type(func[0].rettype());
+    let main_call = if main_is_async {
+        if main_is_exitcode {
             "main().then(process.exit).catch(e => console.error(e));"
         } else {
             "main().catch(e => console.error(e));"
         }
+    } else if main_is_exitcode {
+        "try { process.exit(main()); } catch (e) { console.error(e); }"
     } else {
-        "main().catch(e => console.error(e));"
+        "try { main(); } catch (e) { console.error(e); }"
     };
     Program::return_program(program);
     Ok((

--- a/alan_compiler/src/lntojs/typen.rs
+++ b/alan_compiler/src/lntojs/typen.rs
@@ -197,6 +197,11 @@ pub fn ctype_to_jtype(
             deps = res.1;
             Ok(("".to_string(), deps))
         }
+        CType::Promise(t) => {
+            let res = ctype_to_jtype(t.clone(), deps)?;
+            deps = res.1;
+            Ok(("".to_string(), deps))
+        }
         CType::Fail(m) => CType::fail(m),
         otherwise => CType::fail(&format!("Lower stage of the compiler received unresolved algebraic type {}, cannot deal with it here. Please report this error.", Arc::new(otherwise.clone()).to_functional_string())),
     }

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -63,6 +63,7 @@ pub enum CType {
     Generic(String, Vec<String>, Arc<CType>),
     Binds(Arc<CType>, Vec<Arc<CType>>),
     Shared(Arc<CType>),
+    Promise(Arc<CType>),
     IntrinsicGeneric(String, usize),
     IntCast(Arc<CType>),
     Int(i128),
@@ -264,6 +265,11 @@ impl CType {
                 }
                 CType::Shared(t) => {
                     str_parts.push("Shared{");
+                    ctype_stack.push(close_brace);
+                    ctype_stack.push(t);
+                }
+                CType::Promise(t) => {
+                    str_parts.push("Promise{");
                     ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
@@ -770,6 +776,11 @@ impl CType {
                 }
                 CType::Shared(t) => {
                     str_parts.push("Shared{");
+                    ctype_stack.push(close_brace);
+                    ctype_stack.push(t);
+                }
+                CType::Promise(t) => {
+                    str_parts.push("Promise{");
                     ctype_stack.push(close_brace);
                     ctype_stack.push(t);
                 }
@@ -1328,6 +1339,7 @@ impl CType {
                     resolved.to_callable_string()
                 }
             }
+            CType::Promise(_) => self.clone().to_functional_string(),
             _ => self.clone().to_functional_string(),
         }
         .chars()
@@ -1380,6 +1392,7 @@ impl CType {
             | CType::Array(t)
             | CType::Field(_, t)
             | CType::Shared(t)
+            | CType::Promise(t)
             | CType::Neg(t)
             | CType::Len(t)
             | CType::Size(t)
@@ -1437,6 +1450,7 @@ impl CType {
                     .collect::<Vec<Arc<CType>>>(),
             )),
             CType::Shared(t) => Arc::new(CType::Shared(t.clone().degroup())),
+            CType::Promise(t) => Arc::new(CType::Promise(t.clone().degroup())),
             CType::IntrinsicGeneric(..) => self,
             CType::IntCast(t) => Arc::new(CType::IntCast(t.clone().degroup())),
             CType::Int(_) => self,
@@ -1680,6 +1694,19 @@ impl CType {
                         input.push(Arc::new(other.clone()));
                     }
                     (other, CType::Shared(b2)) if !matches!(other, CType::Mut(..)) => {
+                        arg.push(Arc::new(other.clone()));
+                        input.push(b2.clone());
+                    }
+                    (CType::Promise(a2), CType::Promise(b2)) => {
+                        arg.push(a2.clone());
+                        input.push(b2.clone());
+                    }
+                    // Transparent Promise: unwrap when only one side is Promise
+                    (CType::Promise(a2), other) => {
+                        arg.push(a2.clone());
+                        input.push(Arc::new(other.clone()));
+                    }
+                    (other, CType::Promise(b2)) => {
                         arg.push(Arc::new(other.clone()));
                         input.push(b2.clone());
                     }
@@ -2852,6 +2879,10 @@ impl CType {
             (CType::Shared(a), CType::Shared(b)) => a.clone().accepts(b.clone()),
             (CType::Shared(a), other) => a.clone().accepts(Arc::new(other.clone())),
             (self_type, CType::Shared(b)) => Arc::new(self_type.clone()).accepts(b.clone()),
+            // Promise{T} is transparent on the argument side: Promise{T} accepts T, and T accepts Promise{T}
+            (CType::Promise(a), CType::Promise(b)) => a.clone().accepts(b.clone()),
+            (CType::Promise(a), other) => a.clone().accepts(Arc::new(other.clone())),
+            (self_type, CType::Promise(b)) => Arc::new(self_type.clone()).accepts(b.clone()),
             (_a, CType::AnyOf(ts)) => {
                 for t in ts {
                     if self.clone().accepts(t.clone()) {
@@ -2859,6 +2890,9 @@ impl CType {
                     }
                 }
                 false
+            }
+            (CType::Function(i1, o1), CType::Function(i2, o2)) => {
+                i1.clone().accepts(i2.clone()) && o1.clone().accepts(o2.clone())
             }
             (CType::Function(i1, _), CType::Generic(_, _, t))
                 if matches!(&**t, CType::Function(..)) =>
@@ -3966,6 +4000,9 @@ impl CType {
                     .collect::<Vec<Arc<CType>>>(),
             )),
             CType::Shared(t) => Arc::new(CType::Shared(t.clone().swap_subtype(old_type, new_type))),
+            CType::Promise(t) => {
+                Arc::new(CType::Promise(t.clone().swap_subtype(old_type, new_type)))
+            }
             CType::IntCast(i) => CType::intcast(i.clone().swap_subtype(old_type, new_type)),
             CType::FloatCast(f) => CType::floatcast(f.clone().swap_subtype(old_type, new_type)),
             CType::BoolCast(b) => CType::boolcast(b.clone().swap_subtype(old_type, new_type)),
@@ -4277,6 +4314,21 @@ impl CType {
                 CType::Type(_, t) | CType::Group(t) | CType::Unwrap(t) => t.clone(),
                 _ => arg,
             }
+        }
+    }
+
+    pub fn promise(arg: Arc<CType>) -> Arc<CType> {
+        let mut t = arg.clone();
+        while matches!(&*t, CType::Type(..) | CType::Group(_)) {
+            t = match &*t {
+                CType::Type(_, inner) | CType::Group(inner) => inner.clone(),
+                _ => unreachable!(),
+            };
+        }
+        if matches!(&*t, CType::Promise(_)) {
+            arg
+        } else {
+            Arc::new(CType::Promise(arg))
         }
     }
 
@@ -5885,6 +5937,7 @@ pub fn typebaselist_to_ctype(
                                     match name.as_str() {
                                         "Binds" => CType::binds(args),
                                         "Shared" => Arc::new(CType::Shared(args[0].clone())),
+                                        "Promise" => CType::promise(args[0].clone()),
                                         "Int" => CType::intcast(args[0].clone()),
                                         "Float" => CType::floatcast(args[0].clone()),
                                         "Bool" => CType::boolcast(args[0].clone()),

--- a/alan_compiler/src/program/function.rs
+++ b/alan_compiler/src/program/function.rs
@@ -163,6 +163,42 @@ pub fn type_to_rettype(t: Arc<CType>) -> Arc<CType> {
     }
 }
 
+fn is_promise_head(t: Arc<CType>) -> bool {
+    let mut t = t.degroup();
+    while matches!(&*t, CType::Type(..)) {
+        t = match &*t {
+            CType::Type(_, inner) => inner.clone().degroup(),
+            _ => unreachable!(),
+        };
+    }
+    matches!(&*t, CType::Promise(_))
+}
+
+fn microstatement_awaits(ms: &Microstatement) -> bool {
+    match ms {
+        Microstatement::Assignment { value, .. } => microstatement_awaits(value),
+        Microstatement::FnCall { function, args } => {
+            is_promise_head(function.rettype()) || args.iter().any(microstatement_awaits)
+        }
+        Microstatement::VarCall { typen, args, .. } => {
+            is_promise_head(typen.clone()) || args.iter().any(microstatement_awaits)
+        }
+        Microstatement::Array { vals, .. } => vals.iter().any(microstatement_awaits),
+        Microstatement::Return { value } => value
+            .as_deref()
+            .is_some_and(microstatement_awaits),
+        Microstatement::NativeCall { args, .. } => args.iter().any(microstatement_awaits),
+        // Deliberately do not descend into nested closures.
+        Microstatement::Closure { .. } | Microstatement::Arg { .. } | Microstatement::Value { .. } => {
+            false
+        }
+    }
+}
+
+fn body_awaits(microstatements: &[Microstatement]) -> bool {
+    microstatements.iter().any(microstatement_awaits)
+}
+
 pub fn args_and_rettype_to_type(
     args: Vec<(String, ArgKind, Arc<CType>)>,
     rettype: Arc<CType>,
@@ -598,10 +634,13 @@ impl Function {
                 // Don't do anything in this path, this is probably a derived function
             } else {
                 let current_rettype = type_to_rettype(typen.clone());
-                let actual_rettype = match ms {
+                let mut actual_rettype = match ms {
                     Microstatement::Return { value: Some(v) } => v.get_type(),
                     _ => Arc::new(CType::Void),
                 };
+                if body_awaits(&microstatements) && !is_promise_head(actual_rettype.clone()) {
+                    actual_rettype = CType::promise(actual_rettype);
+                }
                 if let CType::Infer(..) = &*current_rettype {
                     // We're definitely replacing with the inferred type
                     let input_type = match &*typen {
@@ -731,10 +770,13 @@ impl Function {
                     // Don't do anything in this path, this is probably a derived function
                 } else {
                     let current_rettype = type_to_rettype(typen.clone());
-                    let actual_rettype = match last {
+                    let mut actual_rettype = match last {
                         Microstatement::Return { value: Some(v) } => v.get_type(),
                         _ => Arc::new(CType::Void),
                     };
+                    if body_awaits(&ms) && !is_promise_head(actual_rettype.clone()) {
+                        actual_rettype = CType::promise(actual_rettype);
+                    }
                     if let CType::Infer(..) = &*current_rettype {
                         let input_type = match &*typen {
                             CType::Function(i, _) => i.clone(),
@@ -868,10 +910,13 @@ impl Function {
                     if let Microstatement::Arg { .. } = ms {
                         // Don't do anything in this path, this is probably a derived function
                     } else {
-                        let actual_rettype = match ms {
+                        let mut actual_rettype = match ms {
                             Microstatement::Return { value: Some(v) } => v.get_type(),
                             _ => Arc::new(CType::Void),
                         };
+                        if body_awaits(&microstatements) && !is_promise_head(actual_rettype.clone()) {
+                            actual_rettype = CType::promise(actual_rettype);
+                        }
                         if let CType::Infer(..) = &*rettype {
                             rettype = actual_rettype;
                         } else if rettype.clone().to_strict_string(false)
@@ -999,10 +1044,13 @@ impl Function {
                     if let Microstatement::Arg { .. } = ms {
                         // Don't do anything in this path, this is probably a derived function
                     } else {
-                        let actual_rettype = match ms {
+                        let mut actual_rettype = match ms {
                             Microstatement::Return { value: Some(v) } => v.get_type(),
                             _ => Arc::new(CType::Void),
                         };
+                        if body_awaits(&microstatements) && !is_promise_head(actual_rettype.clone()) {
+                            actual_rettype = CType::promise(actual_rettype);
+                        }
                         if let CType::Infer(..) = &*rettype {
                             rettype = actual_rettype;
                         } else if rettype.clone().to_strict_string(false)

--- a/alan_compiler/src/program/function.rs
+++ b/alan_compiler/src/program/function.rs
@@ -184,9 +184,7 @@ fn microstatement_awaits(ms: &Microstatement) -> bool {
             is_promise_head(typen.clone()) || args.iter().any(microstatement_awaits)
         }
         Microstatement::Array { vals, .. } => vals.iter().any(microstatement_awaits),
-        Microstatement::Return { value } => value
-            .as_deref()
-            .is_some_and(microstatement_awaits),
+        Microstatement::Return { value } => value.as_deref().is_some_and(microstatement_awaits),
         Microstatement::NativeCall { args, .. } => args.iter().any(microstatement_awaits),
         Microstatement::Closure { function } => {
             is_promise_head(function.rettype()) || body_awaits(&function.microstatements)
@@ -914,7 +912,8 @@ impl Function {
                             Microstatement::Return { value: Some(v) } => v.get_type(),
                             _ => Arc::new(CType::Void),
                         };
-                        if body_awaits(&microstatements) && !is_promise_head(actual_rettype.clone()) {
+                        if body_awaits(&microstatements) && !is_promise_head(actual_rettype.clone())
+                        {
                             actual_rettype = CType::promise(actual_rettype);
                         }
                         if let CType::Infer(..) = &*rettype {
@@ -1048,7 +1047,8 @@ impl Function {
                             Microstatement::Return { value: Some(v) } => v.get_type(),
                             _ => Arc::new(CType::Void),
                         };
-                        if body_awaits(&microstatements) && !is_promise_head(actual_rettype.clone()) {
+                        if body_awaits(&microstatements) && !is_promise_head(actual_rettype.clone())
+                        {
                             actual_rettype = CType::promise(actual_rettype);
                         }
                         if let CType::Infer(..) = &*rettype {

--- a/alan_compiler/src/program/function.rs
+++ b/alan_compiler/src/program/function.rs
@@ -188,10 +188,10 @@ fn microstatement_awaits(ms: &Microstatement) -> bool {
             .as_deref()
             .is_some_and(microstatement_awaits),
         Microstatement::NativeCall { args, .. } => args.iter().any(microstatement_awaits),
-        // Deliberately do not descend into nested closures.
-        Microstatement::Closure { .. } | Microstatement::Arg { .. } | Microstatement::Value { .. } => {
-            false
+        Microstatement::Closure { function } => {
+            is_promise_head(function.rettype()) || body_awaits(&function.microstatements)
         }
+        Microstatement::Arg { .. } | Microstatement::Value { .. } => false,
     }
 }
 

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -87,12 +87,10 @@ fn function_dispatch_accepts(expected: Arc<CType>, actual: Arc<CType>) -> bool {
     if !Program::is_target_lang_rs() {
         let expected_head = degroup_type_group(expected.clone());
         let actual_head = degroup_type_group(actual.clone());
-        match (&*expected_head, &*actual_head) {
-            (CType::Function(ei, eo), CType::Function(ai, ao)) => {
-                return function_dispatch_accepts(ei.clone(), ai.clone())
-                    && function_return_dispatch_accepts(eo.clone(), ao.clone());
-            }
-            _ => {}
+        if let (CType::Function(ei, eo), CType::Function(ai, ao)) = (&*expected_head, &*actual_head)
+        {
+            return function_dispatch_accepts(ei.clone(), ai.clone())
+                && function_return_dispatch_accepts(eo.clone(), ao.clone());
         }
     }
     if expected.clone().accepts(actual.clone()) {
@@ -999,11 +997,7 @@ impl<'a> Scope<'a> {
                         if is_function_head(expected.clone()) && !is_function_head(actual.clone()) {
                             continue;
                         }
-                        reduced_fn_args.push((
-                            format!("arg{i}"),
-                            kind.clone(),
-                            expected.clone(),
-                        ));
+                        reduced_fn_args.push((format!("arg{i}"), kind.clone(), expected.clone()));
                         reduced_call_args.push(actual);
                     }
                     if reduced_fn_args.len() < fargs.len() {
@@ -1029,7 +1023,8 @@ impl<'a> Scope<'a> {
                         value_call_args.push(args[i].clone());
                     }
                     if !value_fn_args.is_empty() && value_fn_args.len() < fargs.len() {
-                        if let Ok(gs) = CType::infer_generics(self, g, &value_fn_args, &value_call_args)
+                        if let Ok(gs) =
+                            CType::infer_generics(self, g, &value_fn_args, &value_call_args)
                         {
                             if candidate_matches(&gs) {
                                 return Some(gs);

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -31,6 +31,48 @@ pub struct Scope<'a> {
     // Should we include something for documentation?
 }
 
+fn is_function_head(typen: Arc<CType>) -> bool {
+    let mut t = typen.degroup();
+    while matches!(&*t, CType::Type(..) | CType::Group(_) | CType::Promise(_)) {
+        t = match &*t {
+            CType::Type(_, inner) | CType::Group(inner) | CType::Promise(inner) => {
+                inner.clone().degroup()
+            }
+            _ => unreachable!(),
+        };
+    }
+    matches!(&*t, CType::Function(..))
+}
+
+fn function_dispatch_accepts(expected: Arc<CType>, actual: Arc<CType>) -> bool {
+    if expected.clone().accepts(actual.clone()) {
+        return true;
+    }
+    if !is_function_head(expected.clone()) {
+        return false;
+    }
+    let mut stack = vec![actual];
+    while let Some(candidate) = stack.pop() {
+        let candidate = candidate.degroup();
+        if expected.clone().accepts(candidate.clone()) {
+            return true;
+        }
+        match &*candidate {
+            CType::Type(_, inner) | CType::Group(inner) | CType::Promise(inner) => {
+                stack.push(inner.clone())
+            }
+            CType::AnyOf(ts) | CType::Either(ts, _) => {
+                for t in ts {
+                    stack.push(t.clone());
+                }
+            }
+            CType::Generic(_, _, inner) => stack.push(inner.clone()),
+            _ => {}
+        }
+    }
+    false
+}
+
 impl<'a> Scope<'a> {
     pub fn load_scope(
         mut s: Scope<'a>,
@@ -89,7 +131,7 @@ impl<'a> Scope<'a> {
                         }
                         g @ ("Int" | "Float" | "Bool" | "String" | "Group" | "Unwrap" | "Infix"
                         | "Prefix" | "Method" | "Property" | "Cast" | "Own" | "Deref" | "Mut"
-                        | "Rust" | "Nodejs" | "From" | "Shared" | "Array" | "Fail" | "Neg"
+                        | "Rust" | "Nodejs" | "From" | "Shared" | "Promise" | "Array" | "Fail" | "Neg"
                         | "Len" | "Size" | "FileStr" | "Env" | "EnvExists" | "Not") => {
                             s = CType::from_generic(s, g, 1)
                         }
@@ -585,7 +627,7 @@ impl<'a> Scope<'a> {
             for (i, arg) in args.iter().enumerate() {
                 let fnarg = possible_args[i].2.clone();
                 let callarg = arg.clone();
-                if !fnarg.clone().accepts(callarg.clone()) {
+                if !function_dispatch_accepts(fnarg.clone(), callarg.clone()) {
                     args_match = false;
                     break;
                 }
@@ -799,7 +841,7 @@ impl<'a> Scope<'a> {
                     // actual args are the same type as the function's arg.
                     let mut args_match = true;
                     for arg in args.iter() {
-                        if !f.args()[0].2.clone().accepts(arg.clone()) {
+                        if !function_dispatch_accepts(f.args()[0].2.clone(), arg.clone()) {
                             args_match = false;
                             break;
                         }
@@ -825,7 +867,7 @@ impl<'a> Scope<'a> {
                         // This is pretty cheap, but for now, a "non-strict" string representation
                         // of the CTypes is how we'll match the args against each other. TODO: Do
                         // this without constructing a string to compare against each other.
-                        if !f.args()[i].2.clone().accepts(arg.clone()) {
+                        if !function_dispatch_accepts(f.args()[i].2.clone(), arg.clone()) {
                             args_match = false;
                             break;
                         }
@@ -843,8 +885,79 @@ impl<'a> Scope<'a> {
                     if args.len() != f.args().len() {
                         continue;
                     }
-                    if let Ok(gs) = CType::infer_generics(self, g, &f.args(), args) {
-                        return Some(gs);
+                    let fargs = f.args();
+                    let candidate_matches = |gs: &[Arc<CType>]| {
+                        let possible_args = fargs
+                            .iter()
+                            .map(|(_, _, argtype)| {
+                                let mut a = argtype.clone();
+                                for ((_, o), n) in g.iter().zip(gs.iter()) {
+                                    a = a.swap_subtype(o.clone(), n.clone());
+                                }
+                                a
+                            })
+                            .collect::<Vec<Arc<CType>>>();
+                        possible_args
+                            .iter()
+                            .zip(args.iter())
+                            .all(|(fnarg, callarg)| {
+                                function_dispatch_accepts(fnarg.clone(), callarg.clone())
+                            })
+                    };
+
+                    if let Ok(gs) = CType::infer_generics(self, g, &fargs, args) {
+                        if candidate_matches(&gs) {
+                            return Some(gs);
+                        }
+                    }
+
+                    // Fallback: if a function-typed generic argument receives an overloaded
+                    // function value (not structurally a plain Function head), infer from the
+                    // other arguments first. This preserves first-arg generic HOF resolution such
+                    // as `batchCompare(eq, vals1, vals2)`.
+                    let mut reduced_fn_args: Vec<(String, ArgKind, Arc<CType>)> = Vec::new();
+                    let mut reduced_call_args: Vec<Arc<CType>> = Vec::new();
+                    for (i, (_, kind, expected)) in fargs.iter().enumerate() {
+                        let actual = args[i].clone();
+                        if is_function_head(expected.clone()) && !is_function_head(actual.clone()) {
+                            continue;
+                        }
+                        reduced_fn_args.push((
+                            format!("arg{i}"),
+                            kind.clone(),
+                            expected.clone(),
+                        ));
+                        reduced_call_args.push(actual);
+                    }
+                    if reduced_fn_args.len() < fargs.len() {
+                        if let Ok(gs) =
+                            CType::infer_generics(self, g, &reduced_fn_args, &reduced_call_args)
+                        {
+                            if candidate_matches(&gs) {
+                                return Some(gs);
+                            }
+                        }
+                    }
+
+                    // Second fallback: infer only from non-function parameters. This keeps
+                    // generic inference working when higher-order arguments carry unresolved
+                    // overload sets or generic function aliases.
+                    let mut value_fn_args: Vec<(String, ArgKind, Arc<CType>)> = Vec::new();
+                    let mut value_call_args: Vec<Arc<CType>> = Vec::new();
+                    for (i, (_, kind, expected)) in fargs.iter().enumerate() {
+                        if is_function_head(expected.clone()) {
+                            continue;
+                        }
+                        value_fn_args.push((format!("arg{i}"), kind.clone(), expected.clone()));
+                        value_call_args.push(args[i].clone());
+                    }
+                    if !value_fn_args.is_empty() && value_fn_args.len() < fargs.len() {
+                        if let Ok(gs) = CType::infer_generics(self, g, &value_fn_args, &value_call_args)
+                        {
+                            if candidate_matches(&gs) {
+                                return Some(gs);
+                            }
+                        }
                     }
                 }
             }
@@ -907,7 +1020,7 @@ impl<'a> Scope<'a> {
                     // actual args are the same type as the function's arg.
                     let mut args_match = true;
                     for arg in args.iter() {
-                        if !f.args()[0].2.clone().accepts(arg.clone()) {
+                        if !function_dispatch_accepts(f.args()[0].2.clone(), arg.clone()) {
                             args_match = false;
                             break;
                         }
@@ -931,7 +1044,7 @@ impl<'a> Scope<'a> {
                         // This is pretty cheap, but for now, a "non-strict" string representation
                         // of the CTypes is how we'll match the args against each other. TODO: Do
                         // this without constructing a string to compare against each other.
-                        if !f.args()[i].2.clone().accepts(arg.clone()) {
+                        if !function_dispatch_accepts(f.args()[i].2.clone(), arg.clone()) {
                             args_match = false;
                             break;
                         }

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -108,10 +108,6 @@ fn function_dispatch_accepts(expected: Arc<CType>, actual: Arc<CType>) -> bool {
                     }
                     continue;
                 }
-                CType::Generic(_, _, inner) => {
-                    stack.push(inner.clone());
-                    continue;
-                }
                 _ => {}
             }
             if !Program::is_target_lang_rs() {
@@ -130,6 +126,9 @@ fn function_dispatch_accepts(expected: Arc<CType>, actual: Arc<CType>) -> bool {
             }
             if expected.clone().accepts(candidate.clone()) {
                 return true;
+            }
+            if let CType::Generic(_, _, inner) = &*candidate {
+                stack.push(inner.clone());
             }
         }
         return false;

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -44,7 +44,57 @@ fn is_function_head(typen: Arc<CType>) -> bool {
     matches!(&*t, CType::Function(..))
 }
 
+fn degroup_type_group(typen: Arc<CType>) -> Arc<CType> {
+    let mut t = typen.degroup();
+    while matches!(&*t, CType::Type(..) | CType::Group(_)) {
+        t = match &*t {
+            CType::Type(_, inner) | CType::Group(inner) => inner.clone().degroup(),
+            _ => unreachable!(),
+        };
+    }
+    t
+}
+
+fn is_promise_head_for_dispatch(typen: Arc<CType>) -> bool {
+    let mut t = degroup_type_group(typen);
+    while matches!(&*t, CType::Type(..) | CType::Group(_)) {
+        t = match &*t {
+            CType::Type(_, inner) | CType::Group(inner) => inner.clone().degroup(),
+            _ => unreachable!(),
+        };
+    }
+    matches!(&*t, CType::Promise(_))
+}
+
+fn function_return_dispatch_accepts(expected: Arc<CType>, actual: Arc<CType>) -> bool {
+    if Program::is_target_lang_rs() {
+        return expected.accepts(actual);
+    }
+    if degroup_type_group(expected.clone()).to_strict_string(false)
+        == degroup_type_group(actual.clone()).to_strict_string(false)
+    {
+        return true;
+    }
+    let expected_is_promise = is_promise_head_for_dispatch(expected.clone());
+    let actual_is_promise = is_promise_head_for_dispatch(actual.clone());
+    if expected_is_promise != actual_is_promise {
+        return false;
+    }
+    expected.accepts(actual)
+}
+
 fn function_dispatch_accepts(expected: Arc<CType>, actual: Arc<CType>) -> bool {
+    if !Program::is_target_lang_rs() {
+        let expected_head = degroup_type_group(expected.clone());
+        let actual_head = degroup_type_group(actual.clone());
+        match (&*expected_head, &*actual_head) {
+            (CType::Function(ei, eo), CType::Function(ai, ao)) => {
+                return function_dispatch_accepts(ei.clone(), ai.clone())
+                    && function_return_dispatch_accepts(eo.clone(), ao.clone());
+            }
+            _ => {}
+        }
+    }
     if expected.clone().accepts(actual.clone()) {
         return true;
     }
@@ -71,6 +121,35 @@ fn function_dispatch_accepts(expected: Arc<CType>, actual: Arc<CType>) -> bool {
         }
     }
     false
+}
+
+fn degroup_type_group_promise(typen: Arc<CType>) -> Arc<CType> {
+    let mut t = typen.degroup();
+    while matches!(&*t, CType::Type(..) | CType::Group(_) | CType::Promise(_)) {
+        t = match &*t {
+            CType::Type(_, inner) | CType::Group(inner) | CType::Promise(inner) => {
+                inner.clone().degroup()
+            }
+            _ => unreachable!(),
+        };
+    }
+    t
+}
+
+fn function_type_lookup_match(expected: Arc<CType>, candidate: Arc<CType>) -> bool {
+    let expected = degroup_type_group(expected);
+    let candidate = degroup_type_group(candidate);
+    if expected.clone().to_strict_string(false) == candidate.clone().to_strict_string(false) {
+        return true;
+    }
+    match (&*expected, &*candidate) {
+        (CType::Function(ei, eo), CType::Function(ci, co)) => {
+            ei.clone().to_strict_string(false) == ci.clone().to_strict_string(false)
+                && degroup_type_group_promise(eo.clone()).to_strict_string(false)
+                    == degroup_type_group_promise(co.clone()).to_strict_string(false)
+        }
+        _ => false,
+    }
 }
 
 impl<'a> Scope<'a> {
@@ -514,13 +593,15 @@ impl<'a> Scope<'a> {
     ) -> Option<Arc<Function>> {
         // Iterates through every function with the same name visible from the provided scope and
         // returns the one that matches the provided function type, if any
-        let fn_type_str = fn_type.degroup().to_strict_string(false);
+        let fn_type_str = fn_type.clone().degroup().to_strict_string(false);
         let mut scope_to_check: Option<&Scope> = Some(self);
         while scope_to_check.is_some() {
             if let Some(s) = scope_to_check {
                 if let Some(funcs) = s.functions.get(function) {
                     for f in funcs {
-                        if f.typen.clone().to_strict_string(false) == fn_type_str {
+                        if f.typen.clone().to_strict_string(false) == fn_type_str
+                            || function_type_lookup_match(fn_type.clone(), f.typen.clone())
+                        {
                             return Some(f.clone());
                         }
                     }
@@ -621,24 +702,20 @@ impl<'a> Scope<'a> {
                 }
             }
         }
-        let mut match_index = None;
         for (idx, possible_args) in possible_args_vec.iter().enumerate() {
             let mut args_match = true;
             for (i, arg) in args.iter().enumerate() {
                 let fnarg = possible_args[i].2.clone();
                 let callarg = arg.clone();
-                if !function_dispatch_accepts(fnarg.clone(), callarg.clone()) {
+                if !function_dispatch_accepts(fnarg, callarg) {
                     args_match = false;
                     break;
                 }
             }
-            if args_match {
-                match_index = Some(idx);
-                break;
+            if !args_match {
+                continue;
             }
-        }
-        if let Some(i) = match_index {
-            let generic_f = generic_fs.get(i).unwrap();
+            let generic_f = generic_fs.get(idx).unwrap();
             for arg in args {
                 match &**arg {
                     CType::Generic(n, _, t) if matches!(&**t, CType::Function(..)) => {

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -93,32 +93,48 @@ fn function_dispatch_accepts(expected: Arc<CType>, actual: Arc<CType>) -> bool {
                 && function_return_dispatch_accepts(eo.clone(), ao.clone());
         }
     }
-    if expected.clone().accepts(actual.clone()) {
-        return true;
-    }
-    if !is_function_head(expected.clone()) {
-        return false;
-    }
-    let mut stack = vec![actual];
-    while let Some(candidate) = stack.pop() {
-        let candidate = candidate.degroup();
-        if expected.clone().accepts(candidate.clone()) {
-            return true;
-        }
-        match &*candidate {
-            CType::Type(_, inner) | CType::Group(inner) | CType::Promise(inner) => {
-                stack.push(inner.clone())
+    if is_function_head(expected.clone()) {
+        let mut stack = vec![actual];
+        while let Some(candidate) = stack.pop() {
+            let candidate = candidate.degroup();
+            match &*candidate {
+                CType::Type(_, inner) | CType::Group(inner) | CType::Promise(inner) => {
+                    stack.push(inner.clone());
+                    continue;
+                }
+                CType::AnyOf(ts) | CType::Either(ts, _) => {
+                    for t in ts {
+                        stack.push(t.clone());
+                    }
+                    continue;
+                }
+                CType::Generic(_, _, inner) => {
+                    stack.push(inner.clone());
+                    continue;
+                }
+                _ => {}
             }
-            CType::AnyOf(ts) | CType::Either(ts, _) => {
-                for t in ts {
-                    stack.push(t.clone());
+            if !Program::is_target_lang_rs() {
+                let expected_head = degroup_type_group(expected.clone());
+                let candidate_head = degroup_type_group(candidate.clone());
+                if let (CType::Function(ei, eo), CType::Function(ai, ao)) =
+                    (&*expected_head, &*candidate_head)
+                {
+                    if function_dispatch_accepts(ei.clone(), ai.clone())
+                        && function_return_dispatch_accepts(eo.clone(), ao.clone())
+                    {
+                        return true;
+                    }
+                    continue;
                 }
             }
-            CType::Generic(_, _, inner) => stack.push(inner.clone()),
-            _ => {}
+            if expected.clone().accepts(candidate.clone()) {
+                return true;
+            }
         }
+        return false;
     }
-    false
+    expected.accepts(actual)
 }
 
 fn degroup_type_group_promise(typen: Arc<CType>) -> Arc<CType> {

--- a/alan_compiler/src/std/fs.ln
+++ b/alan_compiler/src/std/fs.ln
@@ -9,5 +9,5 @@ export fn{Rs} string(f: File) =
 export fn{Js} string(f: File) =
   {
     "(async (p) => { try { return new alan_std.Str((await import('node:fs')).readFileSync(p.val, { encoding: 'utf8' })); } catch (e) { return new alan_std.AlanError(e.message); } })"
-    :: string -> string!
+    :: string -> Promise{string!}
   }(f.path);

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -260,7 +260,7 @@ type arm_64 = Env{"ALAN_ARCH"} == "arm_64";
 type Browser = Env{"ALAN_PLATFORM"} == "browser"; // Technically not necessary, always also Js
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
 type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
-type{Js} RootBacking = Nodejs{"alan_std" @ "https://github.com/alantech/alan.git#promise-annotation-for-js"};
+type{Js} RootBacking = Nodejs{"alan_std" @ "https://github.com/alantech/alan.git"};
 // Defining derived types
 type void = ();
 type Self{T} = T;

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -52,6 +52,7 @@ ctype Binds{T}; // A direct reference into the platform language's type system
  * access.
  */
 ctype Shared{T};
+ctype Promise{T};
 ctype Call{N, F}; // A reference to a function call (or method, etc) in the platform language
 ctype Infix{O}; // A reference to a native infix operation in the platform language
 ctype Prefix{O}; // A reference to a native prefix operation in the platform language
@@ -1691,39 +1692,39 @@ fn{Js} pop{T} (a: Mut{T[]}) -> T? {
 fn{Rs} map{T, U} "alan_std::map_onearg" <- RootBacking :: (T[], T -> U) -> U[];
 fn{Js} map{T, U}
   "(async (a, f) => { let out = []; for (let v of a) { out.push(await f(v)); } return out; })"
-  :: (T[], f: T -> U) -> U[];
+  :: (T[], f: T -> U) -> Promise{U[]};
 fn{Rs} map{T, U} "alan_std::map_twoarg" <- RootBacking :: (T[], (T, i64) -> U) -> U[];
 fn{Js} map{T, U}
   "(async (a, f) => { let out = []; for (let i = 0; i < a.length; i++) { out.push(await f(a[i], new alan_std.I64(i))); } return out; })"
   <- RootBacking
-  :: (T[], f: (T, i64) -> U) -> U[];
+  :: (T[], f: (T, i64) -> U) -> Promise{U[]};
 fn{Rs} parmap{T, U} "alan_std::parmap_onearg" <- RootBacking :: (T[], T -> U) -> U[];
 fn{Rs} filter{T} "alan_std::filter_onearg" <- RootBacking :: (T[], T -> bool) -> T[];
 fn{Js} filter{T} (a: T[], f: T -> bool) =
   {
     "(async (a, f) => { let out = []; for (let v of a) { if ((await f(v)).val) { out.push(v); } } return out; })"
-    :: (T[], T -> bool) -> T[]
+    :: (T[], T -> bool) -> Promise{T[]}
   }(a, f);
 fn{Rs} filter{T} "alan_std::filter_twoarg" <- RootBacking :: (T[], (T, i64) -> bool) -> T[];
 fn{Js} filter{T} (a: T[], f: (T, i64) -> bool) =
   {
     "(async (a, f) => { let out = []; for (let i = 0; i < a.length; i++) { if ((await f(a[i], new alan_std.I64(i))).val) { out.push(a[i]); } } return out; })"
     <- RootBacking
-    :: (T[], (T, i64) -> bool) -> T[]
+    :: (T[], (T, i64) -> bool) -> Promise{T[]}
   }(a, f);
 fn{Rs} reduce{T} "alan_std::reduce_sametype" <- RootBacking :: (T[], (T, T) -> T) -> T?;
 fn{Js} reduce{T}
   "(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i]); } return out; })"
-  :: (T[], (T, T) -> T) -> T?;
+  :: (T[], (T, T) -> T) -> Promise{T?};
 fn{Rs} reduce{T} "alan_std::reduce_sametype_idx" <- RootBacking :: (T[], (T, T, i64) -> T) -> T?;
 fn{Js} reduce{T}
   "(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i], new alan_std.I64(i)); } return out; })"
   <- RootBacking
-  :: (T[], (T, T, i64) -> T) -> T?;
+  :: (T[], (T, T, i64) -> T) -> Promise{T?};
 fn{Rs} reduce{T, U} "alan_std::reduce_difftype" <- RootBacking :: (T[], U, (U, T) -> U) -> U;
 fn{Js} reduce{T, U}
   "(async (a, i, f) => { let out = i; for (let i = 0; i < a.length; i++) { out = await f(out, a[i]); } return out; })"
-  :: (T[], U, (U, T) -> U) -> U;
+  :: (T[], U, (U, T) -> U) -> Promise{U};
 fn{Rs} reduce{T, U}
   "alan_std::reduce_difftype_idx"
   <- RootBacking
@@ -1731,7 +1732,7 @@ fn{Rs} reduce{T, U}
 fn{Js} reduce{T, U}
   "(async (a, i, f) => { let out = i; for (let i = 0; i < a.length; i++) { out = await f(out, a[i], new alan_std.I64(i)); } return out; })"
   <- RootBacking
-  :: (T[], U, (U, T, i64) -> U) -> U;
+  :: (T[], U, (U, T, i64) -> U) -> Promise{U};
 fn{Rs} concat{T} "alan_std::concat" <- RootBacking :: (T[], T[]) -> T[];
 fn{Js} concat{T} (a: T[], b: T[]) -> T[] = {Method{"concat"} :: (T[], T[]) -> T[]}(a, b);
 fn{Rs} append{T} "alan_std::append" <- RootBacking :: (Mut{T[]}, T[]);
@@ -1747,13 +1748,13 @@ fn{Js} has{T} (a: T[], f: T -> bool) =
   {
     "(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return new alan_std.Bool(true); } } return new alan_std.Bool(false); })"
     <- RootBacking
-    :: (T[], T -> bool) -> bool
+    :: (T[], T -> bool) -> Promise{bool}
   }(a, f);
 fn{Rs} find{T} "alan_std::findarray" <- RootBacking :: (T[], T -> bool) -> T?;
 fn{Js} find{T} (a: T[], f: T -> bool) -> T? =
   {
     "(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return v; } } return null; })"
-    :: (T[], T -> bool) -> T?
+    :: (T[], T -> bool) -> Promise{T?}
   }(a, f);
 // TODO: The `if` syntactic sugar will make these `if` calls much nicer
 fn index{T}(a: Array{T}, v: T) =
@@ -1773,14 +1774,14 @@ fn{Js} every{T} (a: T[], f: T -> bool) =
   {
     "(async (a, f) => { for (let v of a) { if (!(await f(v)).val) { return new alan_std.Bool(false); } } return new alan_std.Bool(true); })"
     <- RootBacking
-    :: (T[], T -> bool) -> bool
+    :: (T[], T -> bool) -> Promise{bool}
   }(a, f);
 fn{Rs} some{T} "alan_std::somearray" <- RootBacking :: (T[], T -> bool) -> bool;
 fn{Js} some{T} (a: T[], f: T -> bool) =
   {
     "(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return new alan_std.Bool(true); } } return new alan_std.Bool(false); })"
     <- RootBacking
-    :: (T[], T -> bool) -> bool
+    :: (T[], T -> bool) -> Promise{bool}
   }(a, f);
 fn{Rs} repeat{T} "alan_std::repeatarray" <- RootBacking :: (T[], i64) -> T[];
 fn{Js} repeat{T} (a: T[], c: i64) =
@@ -1805,7 +1806,7 @@ fn{Js} last{T} (v: T[]) = {Method{"at"} :: (T[], -1) -> T?}(v);
 fn{Rs} swap{T} "alan_std::swaparray" <- RootBacking :: (Mut{T[]}, i64, i64) -> void!;
 fn{Js} swap{T} "alan_std.swap" <- RootBacking :: (T[], i64, i64) -> void!;
 fn{Rs} sort{T} "alan_std::sortarray" <- RootBacking :: (Mut{T[]}, (T, T) -> i8) -> void;
-fn{Js} sort{T} "alan_std.sort" <- RootBacking :: (Mut{T[]}, (T, T) -> i8) -> void;
+fn{Js} sort{T} "alan_std.sort" <- RootBacking :: (Mut{T[]}, (T, T) -> i8) -> Promise{void};
 fn sort{T} (arr: Mut{T[]}) =
   sort(arr, fn(a: T, b: T) = if(a == b, 0.i8, if(a < b, -1.i8, 1.i8)));
 fn magnitude (arr: f32[]) = (arr.map(fn(v: f32) = v ** 2.0.f32).reduce(add) ?? 0.0.f32).sqrt;
@@ -1848,7 +1849,7 @@ fn{Js} get{T, S}
   :: (T[S], i64) -> T?;
 fn{Rs} map{T, S, U} "alan_std::mapbuffer_onearg" <- RootBacking :: (T[S], T -> U) -> (U[S]);
 fn{Js} map{T, S, U} (a: T[S], f: T -> U) =
-  {"Promise.all" :: Buffer{U, S} -> Buffer{U, S}}({
+  {"Promise.all" :: Buffer{U, S} -> Promise{Buffer{U, S}}}({
     Method{"map"}
     :: (Buffer{T, S}, T -> U) -> Buffer{U, S}
   }(a, f));
@@ -1857,7 +1858,7 @@ fn{Rs} map{T, S, U}
   <- RootBacking
   :: (Buffer{T, S}, (T, i64) -> U) -> Buffer{U, S};
 fn{Js} map{T, S, U} (a: T[S], f: (T, i64) -> U) =
-  {"Promise.all" :: Buffer{U, S} -> Buffer{U, S}}({
+  {"Promise.all" :: Buffer{U, S} -> Promise{Buffer{U, S}}}({
     Method{"map"}
     :: (Buffer{T, S}, (T, i32) -> U) -> Buffer{U, S}
   }(a, fn(v: T, i: i32) = f(v, i.i64)));
@@ -1865,7 +1866,7 @@ fn{Rs} reduce{T, S} "alan_std::reducebuffer_sametype" <- RootBacking :: (T[S], (
 fn{Js} reduce{T, S} (a: T[S], f: (T, T) -> T) =
   {
     "(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i]); } return out; })"
-    :: (T[S], (T, T) -> T) -> T?
+    :: (T[S], (T, T) -> T) -> Promise{T?}
   }(a, f);
 fn{Rs} reduce{T, S, U}
   "alan_std::reducebuffer_difftype"
@@ -1874,7 +1875,7 @@ fn{Rs} reduce{T, S, U}
 fn{Js} reduce{T, S, U} (a: T[S], i: U, f: (U, T) -> U) =
   {
     "(async (a, i, f) => { let out = i; for (let i = 0; i < a.length; i++) { out = await f(out, a[i]); } return out; })"
-    :: (T[S], U, (U, T) -> U) -> U
+    :: (T[S], U, (U, T) -> U) -> Promise{U}
   }(a, i, f);
 fn{Rs} has{T, S} "alan_std::hasbuffer" <- RootBacking :: (T[S], T) -> bool;
 fn{Js} has{T, S} (a: T[S], v: T) = a.reduce(false, fn(out: bool, t: T) = if(out, true, t == v));
@@ -1883,20 +1884,20 @@ fn{Js} has{T, S} (a: T[S], f: T -> bool) =
   {
     "(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return new alan_std.Bool(true); } } return new alan_std.Bool(false); })"
     <- RootBacking
-    :: (T[S], T -> bool) -> bool
+    :: (T[S], T -> bool) -> Promise{bool}
   }(a, f);
 fn{Rs} find{T, S} "alan_std::findbuffer" <- RootBacking :: (T[S], T -> bool) -> T?;
 fn{Js} find{T, S} (a: T[S], f: T -> bool) -> T? =
   {
     "(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return v; } } return null; })"
-    :: (T[S], T -> bool) -> T?
+    :: (T[S], T -> bool) -> Promise{T?}
   }(a, f);
 fn{Rs} every{T, S} "alan_std::everybuffer" <- RootBacking :: (T[S], T -> bool) -> bool;
 fn{Js} every{T, S} (a: T[S], f: T -> bool) =
   {
     "(async (a, f) => { for (let v of a) { if (!(await f(v)).val) { return new alan_std.Bool(false); } } return new alan_std.Bool(true); })"
     <- RootBacking
-    :: (T[S], T -> bool) -> bool
+    :: (T[S], T -> bool) -> Promise{bool}
   }(a, f);
 fn{Rs} concatInner{T, S, N} "alan_std::concatbuffer" <- RootBacking :: (Mut{T[S + N]}, T[S], T[N]);
 fn{Js} concatInner{T, S, N}
@@ -1940,7 +1941,7 @@ fn dot{I}(a: Buffer{I, 4}, b: Buffer{I, 4}) = a.0 * b.0 + a.1 * b.1 + a.2 * b.2 
 fn{Rs} swap{T, S} "alan_std::swapbuffer" <- RootBacking :: (Mut{Buffer{T, S}}, i64, i64) -> void!;
 fn{Js} swap{T, S} "alan_std.swap" <- RootBacking :: (Buffer{T, S}, i64, i64) -> void!;
 fn{Rs} sort{T, S} "alan_std::sortbuffer" <- RootBacking :: (Mut{Buffer{T, S}}, (T, T) -> i8) -> void;
-fn{Js} sort{T, S} "alan_std.sort" <- RootBacking :: (Mut{Buffer{T, S}}, (T, T) -> i8) -> void;
+fn{Js} sort{T, S} "alan_std.sort" <- RootBacking :: (Mut{Buffer{T, S}}, (T, T) -> i8) -> Promise{void};
 fn sort{T, S} (arr: Mut{Buffer{T, S}}) =
   sort(arr, fn(a: T, b: T) = if(a == b, 0.i8, if(a < b, -1.i8, 1.i8)));
 fn magnitude{S} (buf: f32[S]) = (buf.map(fn(v: f32) = v ** 2.0.f32).reduce(add) ?? 0.0.f32).sqrt;
@@ -2335,7 +2336,7 @@ fn{Rs} wait (t: i64) =
   }(t.u64));
 fn{Js} wait
   "((t) => new Promise((r) => setTimeout(() => { r(performance.now()) }, Number(t))))"
-  :: i64 -> f64;
+  :: i64 -> Promise{f64};
 /// Time-related functions
 fn{Rs} now "std::time::Instant::now" :: () -> Instant;
 fn{Js} now "performance.now" :: () -> Performance;
@@ -2379,7 +2380,7 @@ fn{Js} GBuffer{T}(bu: BufferUsages, arr: T[]) {
   let fallibleRawBuffer = {
     "alan_std.createBufferInit"
     <- RootBacking
-    :: (BufferUsages, T[]) -> Fallible{GBufferRaw}
+    :: (BufferUsages, T[]) -> Promise{Fallible{GBufferRaw}}
   }(bu, arr);
   return if(fallibleRawBuffer.exists, fn {
     return Fallible{GBuffer{T}}(GBuffer{T}(fallibleRawBuffer.getOrExit));
@@ -2399,7 +2400,7 @@ fn{Js} GBuffer{T}(bu: BufferUsages, size: i64) {
   let fallibleRawBuffer = {
     "alan_std.createEmptyBuffer"
     <- RootBacking
-    :: (BufferUsages, i32) -> GBufferRaw!
+    :: (BufferUsages, i32) -> Promise{GBufferRaw!}
   }(bu, size.i32);
   return if(fallibleRawBuffer.exists, fn {
     return Fallible{GBuffer{T}}(GBuffer{T}(fallibleRawBuffer.getOrExit));
@@ -2446,9 +2447,9 @@ fn GPGPU{T}(src: string, buf: GBuffer{T}, local: Buffer{i64, 3}) -> GPGPU {
   return GPGPU(src, [[buf.rawBuffer]], {i64[3]}(x, y, z), local);
 }
 fn{Rs} run "alan_std::gpu_run" <- RootBacking :: Mut{GPGPU};
-fn{Js} run "alan_std.gpuRun" <- RootBacking :: GPGPU;
+fn{Js} run "alan_std.gpuRun" <- RootBacking :: Promise{GPGPU};
 fn{Rs} run "alan_std::gpu_run_list" <- RootBacking :: Mut{GPGPU[]};
-fn{Js} run "alan_std.gpuRunList" <- RootBacking :: GPGPU[];
+fn{Js} run "alan_std.gpuRunList" <- RootBacking :: Promise{GPGPU[]};
 fn{Rs} shader Property{"source.clone()"} :: GPGPU -> string;
 fn{Js} shader Property{"source"} :: GPGPU -> string;
 /*
@@ -2459,7 +2460,7 @@ fn{Rs} read{T}(gb: GBuffer{T}) {
   return {"alan_std::read_buffer" <- RootBacking :: GBufferRaw -> T[]}(gb.rawBuffer);
 }
 fn{Js} read{T}(gb: GBuffer{T}) =
-  {"alan_std.readBuffer" <- RootBacking :: (GBufferRaw, string) -> T[]}(
+  {"alan_std.readBuffer" <- RootBacking :: (GBufferRaw, string) -> Promise{T[]}}(
     gb.rawBuffer,
     String{T}()
   );
@@ -2467,7 +2468,7 @@ fn{Js} read{T}(gb: GBuffer{T}) =
 fn{Rs} replace{T}(gb: GBuffer{T}, vals: T[]) =
   {"alan_std::replace_buffer" <- RootBacking :: (GBufferRaw, T[]) -> ()!}(gb.rawBuffer, vals);
 fn{Js} replace{T}(gb: GBuffer{T}, vals: T[]) {
-  return {"alan_std.replaceBuffer" <- RootBacking :: (GBufferRaw, T[]) -> ()!}(gb.rawBuffer, vals);
+  return {"alan_std.replaceBuffer" <- RootBacking :: (GBufferRaw, T[]) -> Promise{()!}}(gb.rawBuffer, vals);
 }
 /// Ergonomic GPGPU-related types and functions
 // The WgpuType provides a mechanism to build up the logic for a compute shader with normal-looking
@@ -5680,7 +5681,7 @@ fn{Rs} window
 fn{Js} window
   "alan_std.runWindow"
   <- RootBacking
-  :: (Window -> (), Window -> u32[], Frame -> GPGPU[]) -> ()!;
+  :: (Window -> (), Window -> u32[], Frame -> GPGPU[]) -> Promise{()!};
 fn{Rs} width Method{"width"} :: Window -> u32;
 fn{Js} width "alan_std.contextWidth" <- RootBacking :: Window -> u32;
 fn{Rs} height Method{"height"} :: Window -> u32;

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -260,7 +260,7 @@ type arm_64 = Env{"ALAN_ARCH"} == "arm_64";
 type Browser = Env{"ALAN_PLATFORM"} == "browser"; // Technically not necessary, always also Js
 // Importing the Root Scope backing implementation and supporting 3rd party libraries
 type{Rs} RootBacking = Rust{"alan_std" @ "https://github.com/alantech/alan.git"};
-type{Js} RootBacking = Nodejs{"alan_std" @ "https://github.com/alantech/alan.git"};
+type{Js} RootBacking = Nodejs{"alan_std" @ "https://github.com/alantech/alan.git#promise-annotation-for-js"};
 // Defining derived types
 type void = ();
 type Self{T} = T;
@@ -1691,48 +1691,80 @@ fn{Js} pop{T} (a: Mut{T[]}) -> T? {
 }
 fn{Rs} map{T, U} "alan_std::map_onearg" <- RootBacking :: (T[], T -> U) -> U[];
 fn{Js} map{T, U}
+  "((a, f) => { let out = []; for (let v of a) { out.push(f(v)); } return out; })"
+  :: (T[], f: T -> U) -> U[];
+fn{Js} map{T, U}
   "(async (a, f) => { let out = []; for (let v of a) { out.push(await f(v)); } return out; })"
-  :: (T[], f: T -> U) -> Promise{U[]};
+  :: (T[], f: T -> Promise{U}) -> Promise{U[]};
 fn{Rs} map{T, U} "alan_std::map_twoarg" <- RootBacking :: (T[], (T, i64) -> U) -> U[];
+fn{Js} map{T, U}
+  "((a, f) => { let out = []; for (let i = 0; i < a.length; i++) { out.push(f(a[i], new alan_std.I64(i))); } return out; })"
+  <- RootBacking
+  :: (T[], f: (T, i64) -> U) -> U[];
 fn{Js} map{T, U}
   "(async (a, f) => { let out = []; for (let i = 0; i < a.length; i++) { out.push(await f(a[i], new alan_std.I64(i))); } return out; })"
   <- RootBacking
-  :: (T[], f: (T, i64) -> U) -> Promise{U[]};
+  :: (T[], f: (T, i64) -> Promise{U}) -> Promise{U[]};
 fn{Rs} parmap{T, U} "alan_std::parmap_onearg" <- RootBacking :: (T[], T -> U) -> U[];
 fn{Rs} filter{T} "alan_std::filter_onearg" <- RootBacking :: (T[], T -> bool) -> T[];
 fn{Js} filter{T} (a: T[], f: T -> bool) =
   {
+    "((a, f) => { let out = []; for (let v of a) { if (f(v).val) { out.push(v); } } return out; })"
+    :: (T[], T -> bool) -> T[]
+  }(a, f);
+fn{Js} filter{T} (a: T[], f: T -> Promise{bool}) =
+  {
     "(async (a, f) => { let out = []; for (let v of a) { if ((await f(v)).val) { out.push(v); } } return out; })"
-    :: (T[], T -> bool) -> Promise{T[]}
+    :: (T[], T -> Promise{bool}) -> Promise{T[]}
   }(a, f);
 fn{Rs} filter{T} "alan_std::filter_twoarg" <- RootBacking :: (T[], (T, i64) -> bool) -> T[];
 fn{Js} filter{T} (a: T[], f: (T, i64) -> bool) =
   {
+    "((a, f) => { let out = []; for (let i = 0; i < a.length; i++) { if (f(a[i], new alan_std.I64(i)).val) { out.push(a[i]); } } return out; })"
+    <- RootBacking
+    :: (T[], (T, i64) -> bool) -> T[]
+  }(a, f);
+fn{Js} filter{T} (a: T[], f: (T, i64) -> Promise{bool}) =
+  {
     "(async (a, f) => { let out = []; for (let i = 0; i < a.length; i++) { if ((await f(a[i], new alan_std.I64(i))).val) { out.push(a[i]); } } return out; })"
     <- RootBacking
-    :: (T[], (T, i64) -> bool) -> Promise{T[]}
+    :: (T[], (T, i64) -> Promise{bool}) -> Promise{T[]}
   }(a, f);
 fn{Rs} reduce{T} "alan_std::reduce_sametype" <- RootBacking :: (T[], (T, T) -> T) -> T?;
 fn{Js} reduce{T}
+  "((a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = f(out, a[i]); } return out; })"
+  :: (T[], (T, T) -> T) -> T?;
+fn{Js} reduce{T}
   "(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i]); } return out; })"
-  :: (T[], (T, T) -> T) -> Promise{T?};
+  :: (T[], (T, T) -> Promise{T}) -> Promise{T?};
 fn{Rs} reduce{T} "alan_std::reduce_sametype_idx" <- RootBacking :: (T[], (T, T, i64) -> T) -> T?;
+fn{Js} reduce{T}
+  "((a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = f(out, a[i], new alan_std.I64(i)); } return out; })"
+  <- RootBacking
+  :: (T[], (T, T, i64) -> T) -> T?;
 fn{Js} reduce{T}
   "(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i], new alan_std.I64(i)); } return out; })"
   <- RootBacking
-  :: (T[], (T, T, i64) -> T) -> Promise{T?};
+  :: (T[], (T, T, i64) -> Promise{T}) -> Promise{T?};
 fn{Rs} reduce{T, U} "alan_std::reduce_difftype" <- RootBacking :: (T[], U, (U, T) -> U) -> U;
 fn{Js} reduce{T, U}
-  "(async (a, i, f) => { let out = i; for (let i = 0; i < a.length; i++) { out = await f(out, a[i]); } return out; })"
-  :: (T[], U, (U, T) -> U) -> Promise{U};
+  "((a, i, f) => { let out = i; for (let idx = 0; idx < a.length; idx++) { out = f(out, a[idx]); } return out; })"
+  :: (T[], U, (U, T) -> U) -> U;
+fn{Js} reduce{T, U}
+  "(async (a, i, f) => { let out = i; for (let idx = 0; idx < a.length; idx++) { out = await f(out, a[idx]); } return out; })"
+  :: (T[], U, (U, T) -> Promise{U}) -> Promise{U};
 fn{Rs} reduce{T, U}
   "alan_std::reduce_difftype_idx"
   <- RootBacking
   :: (T[], U, (U, T, i64) -> U) -> U;
 fn{Js} reduce{T, U}
-  "(async (a, i, f) => { let out = i; for (let i = 0; i < a.length; i++) { out = await f(out, a[i], new alan_std.I64(i)); } return out; })"
+  "((a, i, f) => { let out = i; for (let idx = 0; idx < a.length; idx++) { out = f(out, a[idx], new alan_std.I64(idx)); } return out; })"
   <- RootBacking
-  :: (T[], U, (U, T, i64) -> U) -> Promise{U};
+  :: (T[], U, (U, T, i64) -> U) -> U;
+fn{Js} reduce{T, U}
+  "(async (a, i, f) => { let out = i; for (let idx = 0; idx < a.length; idx++) { out = await f(out, a[idx], new alan_std.I64(idx)); } return out; })"
+  <- RootBacking
+  :: (T[], U, (U, T, i64) -> Promise{U}) -> Promise{U};
 fn{Rs} concat{T} "alan_std::concat" <- RootBacking :: (T[], T[]) -> T[];
 fn{Js} concat{T} (a: T[], b: T[]) -> T[] = {Method{"concat"} :: (T[], T[]) -> T[]}(a, b);
 fn{Rs} append{T} "alan_std::append" <- RootBacking :: (Mut{T[]}, T[]);
@@ -1746,15 +1778,26 @@ fn{Js} has{T} (a: T[], v: T) = a.reduce(false, fn(out: bool, t: T) = if(out, tru
 fn{Rs} has{T} "alan_std::hasfnarray" <- RootBacking :: (T[], T -> bool) -> bool;
 fn{Js} has{T} (a: T[], f: T -> bool) =
   {
+    "((a, f) => { for (let v of a) { if (f(v).val) { return new alan_std.Bool(true); } } return new alan_std.Bool(false); })"
+    <- RootBacking
+    :: (T[], T -> bool) -> bool
+  }(a, f);
+fn{Js} has{T} (a: T[], f: T -> Promise{bool}) =
+  {
     "(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return new alan_std.Bool(true); } } return new alan_std.Bool(false); })"
     <- RootBacking
-    :: (T[], T -> bool) -> Promise{bool}
+    :: (T[], T -> Promise{bool}) -> Promise{bool}
   }(a, f);
 fn{Rs} find{T} "alan_std::findarray" <- RootBacking :: (T[], T -> bool) -> T?;
 fn{Js} find{T} (a: T[], f: T -> bool) -> T? =
   {
+    "((a, f) => { for (let v of a) { if (f(v).val) { return v; } } return null; })"
+    :: (T[], T -> bool) -> T?
+  }(a, f);
+fn{Js} find{T} (a: T[], f: T -> Promise{bool}) -> Promise{T?} =
+  {
     "(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return v; } } return null; })"
-    :: (T[], T -> bool) -> Promise{T?}
+    :: (T[], T -> Promise{bool}) -> Promise{T?}
   }(a, f);
 // TODO: The `if` syntactic sugar will make these `if` calls much nicer
 fn index{T}(a: Array{T}, v: T) =
@@ -1772,16 +1815,28 @@ fn index{T}(a: Array{T}, f: (T, i64) -> bool) =
 fn{Rs} every{T} "alan_std::everyarray" <- RootBacking :: (T[], T -> bool) -> bool;
 fn{Js} every{T} (a: T[], f: T -> bool) =
   {
+    "((a, f) => { for (let v of a) { if (!f(v).val) { return new alan_std.Bool(false); } } return new alan_std.Bool(true); })"
+    <- RootBacking
+    :: (T[], T -> bool) -> bool
+  }(a, f);
+fn{Js} every{T} (a: T[], f: T -> Promise{bool}) =
+  {
     "(async (a, f) => { for (let v of a) { if (!(await f(v)).val) { return new alan_std.Bool(false); } } return new alan_std.Bool(true); })"
     <- RootBacking
-    :: (T[], T -> bool) -> Promise{bool}
+    :: (T[], T -> Promise{bool}) -> Promise{bool}
   }(a, f);
 fn{Rs} some{T} "alan_std::somearray" <- RootBacking :: (T[], T -> bool) -> bool;
 fn{Js} some{T} (a: T[], f: T -> bool) =
   {
+    "((a, f) => { for (let v of a) { if (f(v).val) { return new alan_std.Bool(true); } } return new alan_std.Bool(false); })"
+    <- RootBacking
+    :: (T[], T -> bool) -> bool
+  }(a, f);
+fn{Js} some{T} (a: T[], f: T -> Promise{bool}) =
+  {
     "(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return new alan_std.Bool(true); } } return new alan_std.Bool(false); })"
     <- RootBacking
-    :: (T[], T -> bool) -> Promise{bool}
+    :: (T[], T -> Promise{bool}) -> Promise{bool}
   }(a, f);
 fn{Rs} repeat{T} "alan_std::repeatarray" <- RootBacking :: (T[], i64) -> T[];
 fn{Js} repeat{T} (a: T[], c: i64) =
@@ -1806,7 +1861,12 @@ fn{Js} last{T} (v: T[]) = {Method{"at"} :: (T[], -1) -> T?}(v);
 fn{Rs} swap{T} "alan_std::swaparray" <- RootBacking :: (Mut{T[]}, i64, i64) -> void!;
 fn{Js} swap{T} "alan_std.swap" <- RootBacking :: (T[], i64, i64) -> void!;
 fn{Rs} sort{T} "alan_std::sortarray" <- RootBacking :: (Mut{T[]}, (T, T) -> i8) -> void;
-fn{Js} sort{T} "alan_std.sort" <- RootBacking :: (Mut{T[]}, (T, T) -> i8) -> Promise{void};
+fn{Js} sort{T}
+  "((a, sorter) => { for (let i = 1; i < a.length; i++) { let j = i; while (j > 0 && sorter(a[j], a[j - 1]) < 0) { const tmp = a[j - 1]; a[j - 1] = a[j]; a[j] = tmp; j--; } } })"
+  :: (Mut{T[]}, (T, T) -> i8) -> void;
+fn{Js} sort{T}
+  "(async (a, sorter) => { for (let i = 1; i < a.length; i++) { let j = i; while (j > 0 && (await sorter(a[j], a[j - 1])) < 0) { const tmp = a[j - 1]; a[j - 1] = a[j]; a[j] = tmp; j--; } } })"
+  :: (Mut{T[]}, (T, T) -> Promise{i8}) -> Promise{void};
 fn sort{T} (arr: Mut{T[]}) =
   sort(arr, fn(a: T, b: T) = if(a == b, 0.i8, if(a < b, -1.i8, 1.i8)));
 fn magnitude (arr: f32[]) = (arr.map(fn(v: f32) = v ** 2.0.f32).reduce(add) ?? 0.0.f32).sqrt;
@@ -1849,24 +1909,27 @@ fn{Js} get{T, S}
   :: (T[S], i64) -> T?;
 fn{Rs} map{T, S, U} "alan_std::mapbuffer_onearg" <- RootBacking :: (T[S], T -> U) -> (U[S]);
 fn{Js} map{T, S, U} (a: T[S], f: T -> U) =
-  {"Promise.all" :: Buffer{U, S} -> Promise{Buffer{U, S}}}({
-    Method{"map"}
-    :: (Buffer{T, S}, T -> U) -> Buffer{U, S}
-  }(a, f));
+  {"((a, f) => { let out = []; for (let v of a) { out.push(f(v)); } return out; })" :: (Buffer{T, S}, T -> U) -> Buffer{U, S}}(a, f);
+fn{Js} map{T, S, U} (a: T[S], f: T -> Promise{U}) =
+  {"(async (a, f) => { let out = []; for (let v of a) { out.push(await f(v)); } return out; })" :: (Buffer{T, S}, T -> Promise{U}) -> Promise{Buffer{U, S}}}(a, f);
 fn{Rs} map{T, S, U}
   "alan_std::mapbuffer_twoarg"
   <- RootBacking
   :: (Buffer{T, S}, (T, i64) -> U) -> Buffer{U, S};
 fn{Js} map{T, S, U} (a: T[S], f: (T, i64) -> U) =
-  {"Promise.all" :: Buffer{U, S} -> Promise{Buffer{U, S}}}({
-    Method{"map"}
-    :: (Buffer{T, S}, (T, i32) -> U) -> Buffer{U, S}
-  }(a, fn(v: T, i: i32) = f(v, i.i64)));
+  {"((a, f) => { let out = []; for (let i = 0; i < a.length; i++) { out.push(f(a[i], new alan_std.I64(i))); } return out; })" :: (Buffer{T, S}, (T, i64) -> U) -> Buffer{U, S}}(a, f);
+fn{Js} map{T, S, U} (a: T[S], f: (T, i64) -> Promise{U}) =
+  {"(async (a, f) => { let out = []; for (let i = 0; i < a.length; i++) { out.push(await f(a[i], new alan_std.I64(i))); } return out; })" :: (Buffer{T, S}, (T, i64) -> Promise{U}) -> Promise{Buffer{U, S}}}(a, f);
 fn{Rs} reduce{T, S} "alan_std::reducebuffer_sametype" <- RootBacking :: (T[S], (T, T) -> T) -> T?;
 fn{Js} reduce{T, S} (a: T[S], f: (T, T) -> T) =
   {
+    "((a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = f(out, a[i]); } return out; })"
+    :: (T[S], (T, T) -> T) -> T?
+  }(a, f);
+fn{Js} reduce{T, S} (a: T[S], f: (T, T) -> Promise{T}) =
+  {
     "(async (a, f) => { if (a.length === 0) { return null; } let out = a[0]; for (let i = 1; i < a.length; i++) { out = await f(out, a[i]); } return out; })"
-    :: (T[S], (T, T) -> T) -> Promise{T?}
+    :: (T[S], (T, T) -> Promise{T}) -> Promise{T?}
   }(a, f);
 fn{Rs} reduce{T, S, U}
   "alan_std::reducebuffer_difftype"
@@ -1874,30 +1937,52 @@ fn{Rs} reduce{T, S, U}
   :: (T[S], U, (U, T) -> U) -> U;
 fn{Js} reduce{T, S, U} (a: T[S], i: U, f: (U, T) -> U) =
   {
-    "(async (a, i, f) => { let out = i; for (let i = 0; i < a.length; i++) { out = await f(out, a[i]); } return out; })"
-    :: (T[S], U, (U, T) -> U) -> Promise{U}
+    "((a, i, f) => { let out = i; for (let idx = 0; idx < a.length; idx++) { out = f(out, a[idx]); } return out; })"
+    :: (T[S], U, (U, T) -> U) -> U
+  }(a, i, f);
+fn{Js} reduce{T, S, U} (a: T[S], i: U, f: (U, T) -> Promise{U}) =
+  {
+    "(async (a, i, f) => { let out = i; for (let idx = 0; idx < a.length; idx++) { out = await f(out, a[idx]); } return out; })"
+    :: (T[S], U, (U, T) -> Promise{U}) -> Promise{U}
   }(a, i, f);
 fn{Rs} has{T, S} "alan_std::hasbuffer" <- RootBacking :: (T[S], T) -> bool;
 fn{Js} has{T, S} (a: T[S], v: T) = a.reduce(false, fn(out: bool, t: T) = if(out, true, t == v));
 fn{Rs} has{T, S} "alan_std::hasfnbuffer" <- RootBacking :: (T[S], T -> bool) -> bool;
 fn{Js} has{T, S} (a: T[S], f: T -> bool) =
   {
+    "((a, f) => { for (let v of a) { if (f(v).val) { return new alan_std.Bool(true); } } return new alan_std.Bool(false); })"
+    <- RootBacking
+    :: (T[S], T -> bool) -> bool
+  }(a, f);
+fn{Js} has{T, S} (a: T[S], f: T -> Promise{bool}) =
+  {
     "(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return new alan_std.Bool(true); } } return new alan_std.Bool(false); })"
     <- RootBacking
-    :: (T[S], T -> bool) -> Promise{bool}
+    :: (T[S], T -> Promise{bool}) -> Promise{bool}
   }(a, f);
 fn{Rs} find{T, S} "alan_std::findbuffer" <- RootBacking :: (T[S], T -> bool) -> T?;
 fn{Js} find{T, S} (a: T[S], f: T -> bool) -> T? =
   {
+    "((a, f) => { for (let v of a) { if (f(v).val) { return v; } } return null; })"
+    :: (T[S], T -> bool) -> T?
+  }(a, f);
+fn{Js} find{T, S} (a: T[S], f: T -> Promise{bool}) -> Promise{T?} =
+  {
     "(async (a, f) => { for (let v of a) { if ((await f(v)).val) { return v; } } return null; })"
-    :: (T[S], T -> bool) -> Promise{T?}
+    :: (T[S], T -> Promise{bool}) -> Promise{T?}
   }(a, f);
 fn{Rs} every{T, S} "alan_std::everybuffer" <- RootBacking :: (T[S], T -> bool) -> bool;
 fn{Js} every{T, S} (a: T[S], f: T -> bool) =
   {
+    "((a, f) => { for (let v of a) { if (!f(v).val) { return new alan_std.Bool(false); } } return new alan_std.Bool(true); })"
+    <- RootBacking
+    :: (T[S], T -> bool) -> bool
+  }(a, f);
+fn{Js} every{T, S} (a: T[S], f: T -> Promise{bool}) =
+  {
     "(async (a, f) => { for (let v of a) { if (!(await f(v)).val) { return new alan_std.Bool(false); } } return new alan_std.Bool(true); })"
     <- RootBacking
-    :: (T[S], T -> bool) -> Promise{bool}
+    :: (T[S], T -> Promise{bool}) -> Promise{bool}
   }(a, f);
 fn{Rs} concatInner{T, S, N} "alan_std::concatbuffer" <- RootBacking :: (Mut{T[S + N]}, T[S], T[N]);
 fn{Js} concatInner{T, S, N}
@@ -1941,7 +2026,12 @@ fn dot{I}(a: Buffer{I, 4}, b: Buffer{I, 4}) = a.0 * b.0 + a.1 * b.1 + a.2 * b.2 
 fn{Rs} swap{T, S} "alan_std::swapbuffer" <- RootBacking :: (Mut{Buffer{T, S}}, i64, i64) -> void!;
 fn{Js} swap{T, S} "alan_std.swap" <- RootBacking :: (Buffer{T, S}, i64, i64) -> void!;
 fn{Rs} sort{T, S} "alan_std::sortbuffer" <- RootBacking :: (Mut{Buffer{T, S}}, (T, T) -> i8) -> void;
-fn{Js} sort{T, S} "alan_std.sort" <- RootBacking :: (Mut{Buffer{T, S}}, (T, T) -> i8) -> Promise{void};
+fn{Js} sort{T, S}
+  "((a, sorter) => { for (let i = 1; i < a.length; i++) { let j = i; while (j > 0 && sorter(a[j], a[j - 1]) < 0) { const tmp = a[j - 1]; a[j - 1] = a[j]; a[j] = tmp; j--; } } })"
+  :: (Mut{Buffer{T, S}}, (T, T) -> i8) -> void;
+fn{Js} sort{T, S}
+  "(async (a, sorter) => { for (let i = 1; i < a.length; i++) { let j = i; while (j > 0 && (await sorter(a[j], a[j - 1])) < 0) { const tmp = a[j - 1]; a[j - 1] = a[j]; a[j] = tmp; j--; } } })"
+  :: (Mut{Buffer{T, S}}, (T, T) -> Promise{i8}) -> Promise{void};
 fn sort{T, S} (arr: Mut{Buffer{T, S}}) =
   sort(arr, fn(a: T, b: T) = if(a == b, 0.i8, if(a < b, -1.i8, 1.i8)));
 fn magnitude{S} (buf: f32[S]) = (buf.map(fn(v: f32) = v ** 2.0.f32).reduce(add) ?? 0.0.f32).sqrt;

--- a/alan_compiler/src/std/seq.ln
+++ b/alan_compiler/src/std/seq.ln
@@ -1,8 +1,8 @@
 export fn{Rs} while "whileloophack" :: (() -> bool, () -> ()) -> ();
 export fn{Js} while
   "(async (c, l) => { while ((await c()).val) { await l(); } })"
-  :: (() -> bool, () -> ()) -> ();
-export fn iter{T}(f: Mut{(i64) -> T}, n: i64) -> T[] {
+  :: (() -> bool, () -> ()) -> Promise{()};
+export fn iter{T}(f: Mut{(i64) -> T}, n: i64) {
   let out = {T[]}();
   let i = 0;
   while(fn = i < n, fn {
@@ -12,7 +12,7 @@ export fn iter{T}(f: Mut{(i64) -> T}, n: i64) -> T[] {
   });
   return out;
 }
-export fn iter(f: Mut{(i64) -> ()}, n: i64) -> () {
+export fn iter(f: Mut{(i64) -> ()}, n: i64) {
   let i = 0;
   while(fn = i < n, fn {
     f(i);

--- a/alan_compiler/src/std/seq.ln
+++ b/alan_compiler/src/std/seq.ln
@@ -1,7 +1,16 @@
 export fn{Rs} while "whileloophack" :: (() -> bool, () -> ()) -> ();
 export fn{Js} while
+  "((c, l) => { while (c().val) { l(); } })"
+  :: (() -> bool, () -> ()) -> ();
+export fn{Js} while
+  "(async (c, l) => { while ((await c()).val) { l(); } })"
+  :: (() -> Promise{bool}, () -> ()) -> Promise{()};
+export fn{Js} while
+  "(async (c, l) => { while (c().val) { await l(); } })"
+  :: (() -> bool, () -> Promise{()}) -> Promise{()};
+export fn{Js} while
   "(async (c, l) => { while ((await c()).val) { await l(); } })"
-  :: (() -> bool, () -> ()) -> Promise{()};
+  :: (() -> Promise{bool}, () -> Promise{()}) -> Promise{()};
 export fn iter{T}(f: Mut{(i64) -> T}, n: i64) {
   let out = {T[]}();
   let i = 0;

--- a/alan_std.js
+++ b/alan_std.js
@@ -692,7 +692,19 @@ export function swap(a, i, j) {
   a[j.val] = temp;
 }
 
-async function merge(left, right, sorter) {
+function mergeSync(left, right, sorter) {
+  let arr = [];
+  while (left.length && right.length) {
+    if (sorter(left[0], right[0]) < 0) {
+      arr.push(left.shift());
+    } else {
+      arr.push(right.shift());
+    }
+  }
+  return [ ...arr, ...left, ...right ];
+}
+
+async function mergeAsync(left, right, sorter) {
   let arr = [];
   while (left.length && right.length) {
     if ((await sorter(left[0], right[0])) < 0) {
@@ -704,7 +716,7 @@ async function merge(left, right, sorter) {
   return [ ...arr, ...left, ...right ];
 }
 
-export async function sort(a, sorter) {
+export function sortSync(a, sorter) {
   // I really didn't want to write my own sorter, but here we are. This is a merge sort. It's not a
   // true in-place merge sort, but I fake it at the end. Should be made better in the future.
   if (a.length < 2) {
@@ -713,11 +725,262 @@ export async function sort(a, sorter) {
   let half = Math.floor(a.length / 2);
   let right = [...a];
   let left = right.splice(0, half);
-  await sort(left, sorter);
-  await sort(right, sorter);
-  let res = await merge(left, right, sorter);
+  sortSync(left, sorter);
+  sortSync(right, sorter);
+  let res = mergeSync(left, right, sorter);
   for (let i = 0; i < res.length; i++) {
     a[i] = res[i];
+  }
+}
+
+export async function sortAsync(a, sorter) {
+  // I really didn't want to write my own sorter, but here we are. This is a merge sort. It's not a
+  // true in-place merge sort, but I fake it at the end. Should be made better in the future.
+  if (a.length < 2) {
+    return;
+  }
+  let half = Math.floor(a.length / 2);
+  let right = [...a];
+  let left = right.splice(0, half);
+  await sortAsync(left, sorter);
+  await sortAsync(right, sorter);
+  let res = await mergeAsync(left, right, sorter);
+  for (let i = 0; i < res.length; i++) {
+    a[i] = res[i];
+  }
+}
+
+export const sort = sortAsync;
+
+export function mapSync(a, f) {
+  let out = [];
+  for (let v of a) {
+    out.push(f(v));
+  }
+  return out;
+}
+
+export async function mapAsync(a, f) {
+  let out = [];
+  for (let v of a) {
+    out.push(await f(v));
+  }
+  return out;
+}
+
+export function mapSyncIdx(a, f) {
+  let out = [];
+  for (let i = 0; i < a.length; i++) {
+    out.push(f(a[i], new I64(i)));
+  }
+  return out;
+}
+
+export async function mapAsyncIdx(a, f) {
+  let out = [];
+  for (let i = 0; i < a.length; i++) {
+    out.push(await f(a[i], new I64(i)));
+  }
+  return out;
+}
+
+export function filterSync(a, f) {
+  let out = [];
+  for (let v of a) {
+    if (f(v).val) {
+      out.push(v);
+    }
+  }
+  return out;
+}
+
+export async function filterAsync(a, f) {
+  let out = [];
+  for (let v of a) {
+    if ((await f(v)).val) {
+      out.push(v);
+    }
+  }
+  return out;
+}
+
+export function filterSyncIdx(a, f) {
+  let out = [];
+  for (let i = 0; i < a.length; i++) {
+    if (f(a[i], new I64(i)).val) {
+      out.push(a[i]);
+    }
+  }
+  return out;
+}
+
+export async function filterAsyncIdx(a, f) {
+  let out = [];
+  for (let i = 0; i < a.length; i++) {
+    if ((await f(a[i], new I64(i))).val) {
+      out.push(a[i]);
+    }
+  }
+  return out;
+}
+
+export function reduceSync(a, f) {
+  if (a.length === 0) {
+    return null;
+  }
+  let out = a[0];
+  for (let i = 1; i < a.length; i++) {
+    out = f(out, a[i]);
+  }
+  return out;
+}
+
+export async function reduceAsync(a, f) {
+  if (a.length === 0) {
+    return null;
+  }
+  let out = a[0];
+  for (let i = 1; i < a.length; i++) {
+    out = await f(out, a[i]);
+  }
+  return out;
+}
+
+export function reduceSyncIdx(a, f) {
+  if (a.length === 0) {
+    return null;
+  }
+  let out = a[0];
+  for (let i = 1; i < a.length; i++) {
+    out = f(out, a[i], new I64(i));
+  }
+  return out;
+}
+
+export async function reduceAsyncIdx(a, f) {
+  if (a.length === 0) {
+    return null;
+  }
+  let out = a[0];
+  for (let i = 1; i < a.length; i++) {
+    out = await f(out, a[i], new I64(i));
+  }
+  return out;
+}
+
+export function reduceSyncInit(a, i, f) {
+  let out = i;
+  for (let idx = 0; idx < a.length; idx++) {
+    out = f(out, a[idx]);
+  }
+  return out;
+}
+
+export async function reduceAsyncInit(a, i, f) {
+  let out = i;
+  for (let idx = 0; idx < a.length; idx++) {
+    out = await f(out, a[idx]);
+  }
+  return out;
+}
+
+export function reduceSyncInitIdx(a, i, f) {
+  let out = i;
+  for (let idx = 0; idx < a.length; idx++) {
+    out = f(out, a[idx], new I64(idx));
+  }
+  return out;
+}
+
+export async function reduceAsyncInitIdx(a, i, f) {
+  let out = i;
+  for (let idx = 0; idx < a.length; idx++) {
+    out = await f(out, a[idx], new I64(idx));
+  }
+  return out;
+}
+
+export function hasSync(a, f) {
+  for (let v of a) {
+    if (f(v).val) {
+      return new Bool(true);
+    }
+  }
+  return new Bool(false);
+}
+
+export async function hasAsync(a, f) {
+  for (let v of a) {
+    if ((await f(v)).val) {
+      return new Bool(true);
+    }
+  }
+  return new Bool(false);
+}
+
+export function findSync(a, f) {
+  for (let v of a) {
+    if (f(v).val) {
+      return v;
+    }
+  }
+  return null;
+}
+
+export async function findAsync(a, f) {
+  for (let v of a) {
+    if ((await f(v)).val) {
+      return v;
+    }
+  }
+  return null;
+}
+
+export function everySync(a, f) {
+  for (let v of a) {
+    if (!f(v).val) {
+      return new Bool(false);
+    }
+  }
+  return new Bool(true);
+}
+
+export async function everyAsync(a, f) {
+  for (let v of a) {
+    if (!(await f(v)).val) {
+      return new Bool(false);
+    }
+  }
+  return new Bool(true);
+}
+
+export function someSync(a, f) {
+  for (let v of a) {
+    if (f(v).val) {
+      return new Bool(true);
+    }
+  }
+  return new Bool(false);
+}
+
+export async function someAsync(a, f) {
+  for (let v of a) {
+    if ((await f(v)).val) {
+      return new Bool(true);
+    }
+  }
+  return new Bool(false);
+}
+
+export function whileSync(c, l) {
+  while (c().val) {
+    l();
+  }
+}
+
+export async function whileAsync(c, l) {
+  while ((await c()).val) {
+    await l();
   }
 }
 


### PR DESCRIPTION
- **Add `Promise{T}` for return typing of JS bound functions to generate more optimized JS**
- **Add more sync/async variants to allow more sync JS to be generated**
- **Stop emitting blank lines with just semicolons in the JS codegen**
- **Remove branch from RootBacking**
- **Fix fmt**
