### PR TITLE
Fix two issues spotted in the new conditional syntax

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -1163,6 +1163,51 @@ test!(conditional_void_async_branch => r#"export fn main {
 "#;
     stdout "waited\ndone\n";
 );
+// A user-defined `if` overload that forwards its branch closures *directly* to the underlying `if`
+// cfn (`if(cond, t, f)`, not re-wrapped as `fn() = t()`). This is the idiomatic way to opt into
+// "DWIM" truthiness for a new condition type -- here `i64` (0 is false) and `string` (empty is
+// false). The branch closures arrive at the cfn as closure-typed *values* rather than literal
+// closures, so codegen must *call* them (`{ t() }` in Rust, `return t()` in JS) rather than emit
+// the bare reference. Covers value-producing (`describe`) and void (`if name`) positions.
+test!(conditional_forwarded_branch_closures => r#"fn if{T}(c: i64, t: () -> T, f: () -> T) = if(c != 0, t, f);
+fn if{T}(c: string, t: () -> T, f: () -> T) = if(c.len > 0, t, f);
+fn describe(n: i64) -> string {
+  if n {
+    return 'nonzero';
+  }
+  return 'zero';
+}
+export fn main {
+  print(describe(0));
+  print(describe(42));
+  let name = '';
+  if name {
+    print('named');
+  } else {
+    print('anonymous');
+  }
+}
+"#;
+    stdout "zero\nnonzero\nanonymous\n";
+);
+// A *value-producing* `if` function call used as a discarded statement (its result is thrown
+// away), followed by more statements. The branch closures' terminal value-`return`s must NOT
+// return from the enclosing function -- otherwise `mid`/`end` would never run. This is the shape
+// the built-in test harness's `it` uses (`if(cond, fn = arr.pop, fn = Maybe{string}(""))`), which
+// previously miscompiled on the JS backend into an early return.
+test!(conditional_discarded_value_if_statement => r#"fn run(n: i64) -> string {
+  let acc = ['start'];
+  if(n > 0, fn = acc.push('pos'), fn = acc.push('neg'));
+  acc.push('end');
+  return acc.join(' ');
+}
+export fn main {
+  print(run(1));
+  print(run(0 - 1));
+}
+"#;
+    stdout "start pos end\nstart neg end\n";
+);
 // Both branches return *and* there is a trailing statement after the conditional: the tail is
 // unreachable, which is a compile error.
 test_compile_error!(conditional_both_arms_return_with_tail => r#"fn f(n: i64) -> string {

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -124,13 +124,21 @@ fn function_codegen_is_async(function: Arc<Function>) -> bool {
     function_codegen_is_async_inner(function, &mut seen)
 }
 
-/// Render a conditional branch closure's body as a sequence of JS statements (with any `return`s
-/// kept intact), suitable for inlining inside a native `if (...) { ... } else { ... }` block.
+/// Render a conditional branch closure's body as a sequence of JS statements for inlining inside a
+/// native `if (...) { ... } else { ... }` block.
+///
+/// When `discard` is set, the conditional's *value* is thrown away (the `if` call sits in a
+/// discarded statement position), so the branch's terminal value-`return X` must become a bare
+/// `X;` -- otherwise the inlined `return` would erroneously return from the *enclosing* function.
+/// When `discard` is unset (value or return position), terminal `return`s are kept intact. A void
+/// `if` is never rendered with `discard` (its branches' `return`s are genuine early-returns from
+/// the enclosing function, e.g. from the `if`/`else` syntax rewrite), so those stay untouched.
 #[allow(clippy::type_complexity)]
 fn render_js_branch_body(
     microstatement: &Microstatement,
     parent_fn: &Function,
     scope: &Scope,
+    discard: bool,
     mut out: OrderedHashMap<String, String>,
     mut deps: OrderedHashMap<String, String>,
 ) -> Result<
@@ -142,8 +150,23 @@ fn render_js_branch_body(
     Box<dyn std::error::Error>,
 > {
     if let Microstatement::Closure { function } = microstatement {
+        let mss = &function.microstatements;
         let mut parts = Vec::new();
-        for ms in &function.microstatements {
+        for (i, ms) in mss.iter().enumerate() {
+            let is_last = i + 1 == mss.len();
+            // In discard position, strip the closure's terminal value-`return` to a bare
+            // expression so the conditional doesn't return out of the enclosing function.
+            if is_last && discard {
+                if let Microstatement::Return { value: Some(v) } = ms {
+                    let (val, o, d) = from_microstatement(v, parent_fn, scope, out, deps)?;
+                    out = o;
+                    deps = d;
+                    if !val.trim().is_empty() {
+                        parts.push(val);
+                    }
+                    continue;
+                }
+            }
             let (val, o, d) = from_microstatement(ms, parent_fn, scope, out, deps)?;
             out = o;
             deps = d;
@@ -153,19 +176,62 @@ fn render_js_branch_body(
         }
         return Ok((parts.join(";\n        "), out, deps));
     }
+    // A branch that is a closure-typed *value* (e.g. a `() -> T` parameter forwarded through a
+    // delegating `if`, rather than a literal closure) is invoked here. In value/return position its
+    // result is `return`ed (a void branch's returned `undefined` is harmless); in discard position
+    // it is called purely for side effects. If the closure is async (its return type is
+    // `Promise{T}`), the call is awaited.
+    if branch_value_is_function(microstatement) {
+        let (val, o, d) = from_microstatement(microstatement, parent_fn, scope, out, deps)?;
+        out = o;
+        deps = d;
+        let awaited = if branch_value_is_async(microstatement) {
+            format!("await {val}()")
+        } else {
+            format!("{val}()")
+        };
+        return Ok((
+            if discard {
+                awaited
+            } else {
+                format!("return {awaited}")
+            },
+            out,
+            deps,
+        ));
+    }
     // Fallback: render normally (e.g. a non-closure expression).
     from_microstatement(microstatement, parent_fn, scope, out, deps)
+}
+
+/// Whether a branch microstatement is a closure-typed *value* (a `() -> T` function passed by
+/// reference, not a literal `Closure`) -- the shape produced when a user-defined `if` overload
+/// forwards its branch parameters directly to the underlying `if` cfn.
+fn branch_value_is_function(ms: &Microstatement) -> bool {
+    !matches!(ms, Microstatement::Closure { .. })
+        && matches!(&*ms.get_type().degroup(), CType::Function(..))
+}
+
+/// Whether invoking a closure-typed value branch yields a `Promise` (i.e. the closure is async).
+fn branch_value_is_async(ms: &Microstatement) -> bool {
+    if let CType::Function(_, o) = &*ms.get_type().degroup() {
+        is_promise_head(o.clone())
+    } else {
+        false
+    }
 }
 
 /// Render a realized `if{T}` cfn call (`args[0]` condition, `args[1]`/`args[2]` branch closures) as
 /// a native `if (cond) { ... } else { ... }` block, inlining each branch closure's body. Used in
 /// statement positions (return / discarded-statement) where the closure overhead can be dropped
-/// entirely so V8 sees a native conditional.
+/// entirely so V8 sees a native conditional. `discard` is set when the conditional's value is
+/// thrown away (see `render_js_branch_body`).
 #[allow(clippy::type_complexity)]
 fn render_js_native_ifelse(
     args: &[Microstatement],
     parent_fn: &Function,
     scope: &Scope,
+    discard: bool,
     mut out: OrderedHashMap<String, String>,
     mut deps: OrderedHashMap<String, String>,
 ) -> Result<
@@ -182,10 +248,10 @@ fn render_js_native_ifelse(
     // The condition is a boxed `alan_std.Bool`; a bare object is always truthy in JS, so unwrap
     // its `.val` (falling back to the value itself if it is already a primitive).
     let cond = format!("({cond})?.val ?? ({cond})");
-    let (then_body, o, d) = render_js_branch_body(&args[1], parent_fn, scope, out, deps)?;
+    let (then_body, o, d) = render_js_branch_body(&args[1], parent_fn, scope, discard, out, deps)?;
     out = o;
     deps = d;
-    let (else_body, o, d) = render_js_branch_body(&args[2], parent_fn, scope, out, deps)?;
+    let (else_body, o, d) = render_js_branch_body(&args[2], parent_fn, scope, discard, out, deps)?;
     out = o;
     deps = d;
     let then_block = if then_body.trim().is_empty() {
@@ -666,18 +732,19 @@ pub fn from_microstatement(
                     // conditional becomes a plain sync IIFE with no `await`, while an awaiting
                     // branch produces an awaited async IIFE. Statement positions (return /
                     // discarded) are special-cased elsewhere to drop the IIFE entirely.
-                    let (inner, o, d) = render_js_native_ifelse(args, parent_fn, scope, out, deps)?;
+                    let (inner, o, d) =
+                        render_js_native_ifelse(args, parent_fn, scope, false, out, deps)?;
                     out = o;
                     deps = d;
-                    let is_async = if let Microstatement::Closure { function } = &args[1] {
-                        function_codegen_is_async(function.clone())
-                    } else {
-                        false
-                    } || if let Microstatement::Closure { function } = &args[2] {
-                        function_codegen_is_async(function.clone())
-                    } else {
-                        false
+                    let branch_async = |ms: &Microstatement| match ms {
+                        Microstatement::Closure { function } => {
+                            function_codegen_is_async(function.clone())
+                        }
+                        // A forwarded closure-typed value branch: async iff calling it yields a
+                        // `Promise` (its return type is `Promise{T}`).
+                        _ => branch_value_is_async(ms),
                     };
+                    let is_async = branch_async(&args[1]) || branch_async(&args[2]);
                     if is_async {
                         Ok((format!("(await (async () => {{ {inner} }})())"), out, deps))
                     } else {
@@ -1870,7 +1937,7 @@ pub fn from_microstatement(
                 // `return`s intact -- no `return ...;` wrapper, no closure/IIFE overhead.
                 if let Microstatement::FnCall { function, args } = &**val {
                     if matches!(&function.kind, FnKind::CfnRealized(CfnKind::IfElse)) {
-                        return render_js_native_ifelse(args, parent_fn, scope, out, deps);
+                        return render_js_native_ifelse(args, parent_fn, scope, false, out, deps);
                     }
                 }
                 let (retval, o, d) = from_microstatement(val, parent_fn, scope, out, deps)?;
@@ -1937,11 +2004,14 @@ pub fn generate(
     )
     .to_string();
     for microstatement in &function.microstatements {
-        // Discarded statement position: a top-level void cfn-`if` emits the native `if/else`
-        // form directly rather than a pointless IIFE statement.
+        // Discarded statement position: a top-level cfn-`if` emits the native `if/else` form
+        // directly rather than a pointless IIFE statement. The conditional's value is thrown away
+        // here (`discard`), so a branch closure's terminal *value*-`return X` becomes a bare `X;`
+        // rather than returning from this enclosing function. A bare `return;` (a genuine void
+        // early-return synthesized by the `if`/`else` rewrite) is kept by `render_js_branch_body`.
         if is_ifelse_call(microstatement) {
             if let Microstatement::FnCall { args, .. } = microstatement {
-                let (stmt, o, d) = render_js_native_ifelse(args, function, scope, out, deps)?;
+                let (stmt, o, d) = render_js_native_ifelse(args, function, scope, true, out, deps)?;
                 out = o;
                 deps = d;
                 fn_string = format!("{fn_string}    {stmt}\n");

--- a/alan_compiler/src/lntors/function.rs
+++ b/alan_compiler/src/lntors/function.rs
@@ -758,6 +758,15 @@ fn render_inline_block(
             ));
         }
     }
+    // A closure-typed *value* branch (a `() -> T` parameter forwarded through a delegating `if`,
+    // rather than a literal closure) is invoked for its side effects here.
+    if matches!(&*microstatement.get_type().degroup(), CType::Function(..)) {
+        let (val, o, d) =
+            from_microstatement(microstatement, parent_fn, shared_vars, scope, out, deps)?;
+        out = o;
+        deps = d;
+        return Ok((format!("{{\n        {val}();\n    }}"), out, deps));
+    }
     // Fallback: render normally and strip the closure prefix textually.
     let (val, o, d) =
         from_microstatement(microstatement, parent_fn, shared_vars, scope, out, deps)?;
@@ -825,6 +834,17 @@ fn render_branch_block(
                 deps,
             ));
         }
+    }
+    // A branch that is a closure-typed *value* (e.g. a `() -> T` function parameter threaded
+    // through a delegating `if`, rather than a literal closure) is invoked here: its call result
+    // becomes the block's tail expression. This lets user-defined `if` overloads forward the
+    // branch closures directly (`if(cond, t, f)`) without re-wrapping them.
+    if matches!(&*microstatement.get_type().degroup(), CType::Function(..)) {
+        let (val, o, d) =
+            from_microstatement(microstatement, parent_fn, shared_vars, scope, out, deps)?;
+        out = o;
+        deps = d;
+        return Ok((format!("{{\n        {val}()\n    }}"), out, deps));
     }
     // Fallback: render normally and strip the closure prefix textually.
     let (val, o, d) =


### PR DESCRIPTION
The two issues:

1. The `if` function syntax no longer allowed to take function/closure references as the true or false path, requiring inline-defined closures, instead. This regression has been reverted.
2. The `if` function for JS only accidentally triggering early return too often, and breaking the functional usage of `if`. No longer early returning when used as a function call.
