### PR TITLE
`fmt` fixes

### DIFF
--- a/alan_compiler/src/fmt.rs
+++ b/alan_compiler/src/fmt.rs
@@ -527,7 +527,16 @@ impl Formatter {
                     self.finish_wrapped_gncall(&gc.closecurly);
                 } else {
                     self.write(&gc.opencurly);
+                    // When the generic arguments span multiple lines, indent the continuation
+                    // lines one level past the call so they don't fall back to column 0.
+                    let multiline = typecalllist_multiline(&gc.typecalllist);
+                    if multiline {
+                        self.indent += 1;
+                    }
                     self.fmt_gncall_types(&gc.typecalllist);
+                    if multiline {
+                        self.indent -= 1;
+                    }
                     self.write(&gc.closecurly);
                 }
             }
@@ -1089,7 +1098,13 @@ impl Formatter {
     }
 
     fn fmt_returns(&mut self, r: &Returns) {
-        self.write("return ");
+        // Only emit the space after `return` when there's an actual value, so a bare `return;`
+        // doesn't become `return ;`.
+        if r.retval.is_some() {
+            self.write("return ");
+        } else {
+            self.write("return");
+        }
         self.fmt_retval(&r.retval);
         self.write(";");
     }
@@ -1631,6 +1646,15 @@ fn should_shunt_comment(col: usize, comment: &str) -> bool {
     comment.starts_with("/*") || col + 2 + comment.len() > LINE_WIDTH
 }
 
+/// Whether a generic call's argument list spans multiple lines (a newline appears in the
+/// whitespace around one of its type operators, e.g. after a separating comma).
+fn typecalllist_multiline(list: &[WithTypeOperators]) -> bool {
+    list.iter().any(|wt| match wt {
+        WithTypeOperators::Operators(o) => o.a.contains('\n') || o.b.contains('\n'),
+        WithTypeOperators::TypeBaseList(_) => false,
+    })
+}
+
 pub fn fmt(ln: &Ln) -> String {
     let mut formatter = Formatter::new();
     formatter.fmt_ln(ln);
@@ -1942,6 +1966,33 @@ mod tests {
             "fn normalize (arr: f32[]) {\n  let mag = magnitude(arr);\n  /*\n   * this is a very long trailing comment that definitely exceeds one hundred columns so it must be\n   * shunted\n   */\n  let arr1 = arr.clone;\n  return arr1;\n}\n"
         );
         assert_eq!(canonical_fmt(&long), long);
+    }
+
+    #[test]
+    fn test_bare_return_no_trailing_space() {
+        // A bare `return;` must not gain a space before the semicolon, while a value return keeps
+        // its single space after `return`.
+        let out = canonical_fmt(
+            "fn f(n: i64) {\n  if n > 0 {\n    return;\n  }\n  return;\n}\nfn g(n: i64) -> i64 {\n  return n;\n}\n",
+        );
+        assert_eq!(
+            out,
+            "fn f(n: i64) {\n  if n > 0 {\n    return;\n  }\n  return;\n}\nfn g(n: i64) -> i64 {\n  return n;\n}\n"
+        );
+        assert_eq!(canonical_fmt(&out), out);
+    }
+
+    #[test]
+    fn test_multiline_generic_type_indents() {
+        // Continuation lines of a multi-line generic type call are indented one level past the
+        // call rather than falling back to column 0.
+        let out =
+            canonical_fmt("type Vec{T, L} = If{\n  L < 5,\n  T[L],\n  Fail{\"too long\"}};\n");
+        assert_eq!(
+            out,
+            "type Vec{T, L} = If{L < 5,\n  T[L],\n  Fail{\"too long\"}};\n"
+        );
+        assert_eq!(canonical_fmt(&out), out);
     }
 
     #[test]

--- a/alan_compiler/src/std/root.ln
+++ b/alan_compiler/src/std/root.ln
@@ -1918,17 +1918,29 @@ fn{Js} get{T, S}
   :: (T[S], i64) -> T?;
 fn{Rs} map{T, S, U} "alan_std::mapbuffer_onearg" <- RootBacking :: (T[S], T -> U) -> (U[S]);
 fn{Js} map{T, S, U} (a: T[S], f: T -> U) =
-  {"((a, f) => { let out = []; for (let v of a) { out.push(f(v)); } return out; })" :: (Buffer{T, S}, T -> U) -> Buffer{U, S}}(a, f);
+  {
+    "((a, f) => { let out = []; for (let v of a) { out.push(f(v)); } return out; })"
+    :: (Buffer{T, S}, T -> U) -> Buffer{U, S}
+  }(a, f);
 fn{Js} map{T, S, U} (a: T[S], f: T -> Promise{U}) =
-  {"(async (a, f) => { let out = []; for (let v of a) { out.push(await f(v)); } return out; })" :: (Buffer{T, S}, T -> Promise{U}) -> Promise{Buffer{U, S}}}(a, f);
+  {
+    "(async (a, f) => { let out = []; for (let v of a) { out.push(await f(v)); } return out; })"
+    :: (Buffer{T, S}, T -> Promise{U}) -> Promise{Buffer{U, S}}
+  }(a, f);
 fn{Rs} map{T, S, U}
   "alan_std::mapbuffer_twoarg"
   <- RootBacking
   :: (Buffer{T, S}, (T, i64) -> U) -> Buffer{U, S};
 fn{Js} map{T, S, U} (a: T[S], f: (T, i64) -> U) =
-  {"((a, f) => { let out = []; for (let i = 0; i < a.length; i++) { out.push(f(a[i], new alan_std.I64(i))); } return out; })" :: (Buffer{T, S}, (T, i64) -> U) -> Buffer{U, S}}(a, f);
+  {
+    "((a, f) => { let out = []; for (let i = 0; i < a.length; i++) { out.push(f(a[i], new alan_std.I64(i))); } return out; })"
+    :: (Buffer{T, S}, (T, i64) -> U) -> Buffer{U, S}
+  }(a, f);
 fn{Js} map{T, S, U} (a: T[S], f: (T, i64) -> Promise{U}) =
-  {"(async (a, f) => { let out = []; for (let i = 0; i < a.length; i++) { out.push(await f(a[i], new alan_std.I64(i))); } return out; })" :: (Buffer{T, S}, (T, i64) -> Promise{U}) -> Promise{Buffer{U, S}}}(a, f);
+  {
+    "(async (a, f) => { let out = []; for (let i = 0; i < a.length; i++) { out.push(await f(a[i], new alan_std.I64(i))); } return out; })"
+    :: (Buffer{T, S}, (T, i64) -> Promise{U}) -> Promise{Buffer{U, S}}
+  }(a, f);
 fn{Rs} reduce{T, S} "alan_std::reducebuffer_sametype" <- RootBacking :: (T[S], (T, T) -> T) -> T?;
 fn{Js} reduce{T, S} (a: T[S], f: (T, T) -> T) =
   {
@@ -2582,7 +2594,10 @@ fn{Js} read{T}(gb: GBuffer{T}) =
 fn{Rs} replace{T}(gb: GBuffer{T}, vals: T[]) =
   {"alan_std::replace_buffer" <- RootBacking :: (GBufferRaw, T[]) -> ()!}(gb.rawBuffer, vals);
 fn{Js} replace{T}(gb: GBuffer{T}, vals: T[]) {
-  return {"alan_std.replaceBuffer" <- RootBacking :: (GBufferRaw, T[]) -> Promise{()!}}(gb.rawBuffer, vals);
+  return {"alan_std.replaceBuffer" <- RootBacking :: (GBufferRaw, T[]) -> Promise{()!}}(
+    gb.rawBuffer,
+    vals
+  );
 }
 /// Ergonomic GPGPU-related types and functions
 // The WgpuType provides a mechanism to build up the logic for a compute shader with normal-looking
@@ -5500,13 +5515,13 @@ fn gte(a: gvec4i, b: gvec4i) = gInfix{gvec4i, gvec4i, gvec4b}('>=', 'gte', a, b)
 fn gte(a: gvec4f, b: gvec4f) = gInfix{gvec4f, gvec4f, gvec4b}('>=', 'gte', a, b);
 /// GPGPU Conditional functions
 // Two GPU `if` forms with deliberately different wgsl lowerings:
-//   * The *value* form (`T` arms) receives both arms already evaluated, so there is nothing left to
-//     guard -- it lowers to a branchless `select(false_val, true_val, cond)`.
-//   * The *closure* form (`() -> T` arms) defers evaluation, so it emits a real
-//     `if (c) { ... } else { ... }` block and each arm's statements only run on its branch.
+// * The *value* form (`T` arms) receives both arms already evaluated, so there is nothing left to
+// guard -- it lowers to a branchless `select(false_val, true_val, cond)`.
+// * The *closure* form (`() -> T` arms) defers evaluation, so it emits a real
+// `if (c) { ... } else { ... }` block and each arm's statements only run on its branch.
 // Pick the closure form when an arm has work that must not run on the other branch; pick the value
 // form for cheap, pure expressions.
-//
+// 
 // Ordering matters, exactly as it does for the CPU `if` cfn: a closure-argument call *also* matches
 // the value form (binding `T` to the closure type `() -> T`), which would then try to read
 // `.varName` off a closure and fail. Per "most-recent definition wins", the closure form is
@@ -5547,10 +5562,14 @@ fn if{T}(c: gbool, t: () -> T, f: () -> T) {
     .concat(uuid().string.replace('-', '_'));
   let declaration = "var ".concat(resultVar).concat(": ").concat(typename);
   let tBody = tDelta.Array.map(fn(kv: (string, string)) {
-    return if(kv.1.index("\n").exists, fn = kv.1.concat("\n"), fn = "    ".concat(kv.1).concat(";\n"));
+    return if(kv.1.index("\n").exists, fn = kv.1.concat("\n"), fn {
+      return "    ".concat(kv.1).concat(";\n");
+    });
   }).join("");
   let fBody = fDelta.Array.map(fn(kv: (string, string)) {
-    return if(kv.1.index("\n").exists, fn = kv.1.concat("\n"), fn = "    ".concat(kv.1).concat(";\n"));
+    return if(kv.1.index("\n").exists, fn = kv.1.concat("\n"), fn {
+      return "    ".concat(kv.1).concat(";\n");
+    });
   }).join("");
   let block = "  if ("
     .concat(c.varName)


### PR DESCRIPTION
- **Fix `alan fmt` indentation issues with generic types**
- **Rerun `alan fmt` on the standard library**
