### PR TITLE
Better numeric literals

### DIFF
--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -524,6 +524,55 @@ test!(print_function => r#"export fn main() {
     stdout "Hello, World\n";
     status 0;
 );
+// Numeric constant type selection (issue #215): a numeric literal is typed as an `AnyOf` of the
+// numeric types that can hold its value and is narrowed by context (annotation/accessor) or, when
+// unconstrained, collapses to the last candidate in FUI order (Floats, Unsigned, Ints, ascending
+// bit width). See `docs/int-float-constant-selection-plan.md`.
+test!(numeric_const_u64_annotation => r#"export fn main {
+  let big: u64 = 18446744073709551615;
+  print(big);
+}
+"#;
+    stdout "18446744073709551615\n";
+    status 0;
+);
+test!(numeric_const_u64_default => r#"export fn main {
+  // No annotation: above i64::MAX, so the only viable integer type is u64, which (being last in
+  // FUI order among the survivors) becomes the default.
+  let big = 18446744073709551615;
+  print(big);
+}
+"#;
+    stdout "18446744073709551615\n";
+    status 0;
+);
+test!(numeric_const_u64_cast => r#"export fn main {
+  // The original issue #215 repro: casting a literal larger than i64::MAX used to overflow the
+  // intermediate i64. The literal now resolves directly to u64.
+  let big = 18446744073709551615.u64;
+  print(big);
+}
+"#;
+    stdout "18446744073709551615\n";
+    status 0;
+);
+test!(numeric_const_small_unsigned => r#"export fn main {
+  let x: u8 = 200;
+  print(x);
+}
+"#;
+    stdout "200\n";
+    status 0;
+);
+test!(numeric_const_int_literal_as_float => r#"export fn main {
+  // An integer-form literal narrowed to a float type renders as a float literal.
+  let x: f32 = 5;
+  print(x);
+}
+"#;
+    stdout "5\n";
+    status 0;
+);
 test!(duration_print => r#"export fn main() {
   const i = now();
   wait(110); // Increased from 10ms to 110ms because the node.js event loop seems less

--- a/alan/src/compile/integration_tests.rs
+++ b/alan/src/compile/integration_tests.rs
@@ -573,6 +573,26 @@ test!(numeric_const_int_literal_as_float => r#"export fn main {
     stdout "5\n";
     status 0;
 );
+test!(numeric_const_implicit_param => r#"fn foo(x: u8) = print(x);
+export fn main {
+  // A bare literal argument is narrowed to the parameter's concrete type (u8) -- no annotation
+  // or cast needed.
+  foo(200);
+}
+"#;
+    stdout "200\n";
+    status 0;
+);
+test!(numeric_const_implicit_param_pruned => r#"fn foo(x: u8) = print(x);
+fn foo(x: i32) = print(x);
+export fn main {
+  // 300 does not fit u8, so only the i32 overload is viable and is selected.
+  foo(300);
+}
+"#;
+    stdout "300\n";
+    status 0;
+);
 test!(duration_print => r#"export fn main() {
   const i = now();
   wait(110); // Increased from 10ms to 110ms because the node.js event loop seems less

--- a/alan/test.ln
+++ b/alan/test.ln
@@ -568,7 +568,6 @@ export fn{Test} main {
         .assert(eq, 3.u32.ftb, 0.u32)
         .assert(eq, 2_147_483_648.u32.ftb, 31.u32));
 
-  // TODO: u64 representation
   test.describe("Basic math tests u64")
     .it("add")
     .assert(eq, 1.u64 + 2.u64, 3.u64)
@@ -591,26 +590,25 @@ export fn{Test} main {
         .assert(eq, 0.u64.clz, 64.u64)
         .assert(eq, 1.u64.clz, 63.u64)
         .assert(eq, 2.u64.clz, 62.u64)
-        .assert(eq, -9_223_372_036_854_775_808.asU64.clz, 0.u64)) // TODO: Fix u64 representation
+        .assert(eq, 9_223_372_036_854_775_808.u64.clz, 0.u64))
     .it("ones", fn(test: Mut{Testing}) =
       test
         .assert(eq, 1.u64.ones, 1.u64)
         .assert(eq, 2.u64.ones, 1.u64)
         .assert(eq, 3.u64.ones, 2.u64)
-        .assert(eq, -1.asU64.ones, 64.u64)) // TODO: Same u64 representation issue
+        .assert(eq, 18_446_744_073_709_551_615.u64.ones, 64.u64))
     .it("ctz", fn(test: Mut{Testing}) =
       test
         .assert(eq, 0.u64.ctz, 64.u64)
         .assert(eq, 1.u64.ctz, 0.u64)
         .assert(eq, 2.u64.ctz, 1.u64)
-        .assert(eq, -9_223_372_036_854_775_808.asU64.ctz, 63.u64)) // TODO: Same u64 representation
+        .assert(eq, 9_223_372_036_854_775_808.u64.ctz, 63.u64))
     .it('reverseBits', fn(test: Mut{Testing}) =
       test
         .assert(eq, 0.u64.reverseBits, 0.u64)
-        .assert(eq, 1.u64.reverseBits, -9_223_372_036_854_775_808.asU64)        // TODO: u64 representation
-
+        .assert(eq, 1.u64.reverseBits, 9_223_372_036_854_775_808.u64)
         .assert(eq, 2.u64.reverseBits, 4_611_686_018_427_387_904.u64)
-        .assert(eq, -9_223_372_036_854_775_808.asU64.reverseBits, 1.u64))    // TODO: u64 representation
+        .assert(eq, 9_223_372_036_854_775_808.u64.reverseBits, 1.u64))
 
     .it('extractBits', fn(test: Mut{Testing}) =
       test
@@ -638,17 +636,17 @@ export fn{Test} main {
     )
     .it("flb", fn(test: Mut{Testing}) =
       test
-        .assert(eq, 0.u64.flb, -9_223_372_036_854_775_808.asU64) // TODO: Same u64 representation
+        .assert(eq, 0.u64.flb, 9_223_372_036_854_775_808.u64)
         .assert(eq, 1.u64.flb, 0.u64)
         .assert(eq, 2.u64.flb, 1.u64)
-        .assert(eq, -9_223_372_036_854_775_808.asU64.flb, 63.u64)) // TODO: Same u64 representation
+        .assert(eq, 9_223_372_036_854_775_808.u64.flb, 63.u64))
     .it("ftb", fn(test: Mut{Testing}) =
       test
-        .assert(eq, 0.u64.ftb, -9_223_372_036_854_775_808.asU64) // TODO: u64 representation
+        .assert(eq, 0.u64.ftb, 9_223_372_036_854_775_808.u64)
         .assert(eq, 1.u64.ftb, 0.u64)
         .assert(eq, 2.u64.ftb, 1.u64)
         .assert(eq, 3.u64.ftb, 0.u64)
-        .assert(eq, -9_223_372_036_854_775_808.asU64.ftb, 63.u64));
+        .assert(eq, 9_223_372_036_854_775_808.u64.ftb, 63.u64));
 
   test.describe("Basic math tests f32")
     .it("add")
@@ -769,7 +767,6 @@ export fn{Test} main {
     .it("string max")
     .assert(eq, max(3.string, 5.string), "5");
 
-  // TODO: u64 numeric constants
   test.describe("Bitwise math test")
     .it("i8")
     .assert(eq, 1.i8 & 2.i8, 0.i8)
@@ -831,10 +828,10 @@ export fn{Test} main {
     .assert(eq, 1.u64 & 2.u64, 0.u64)
     .assert(eq, 1.u64 | 3.u64, 3.u64)
     .assert(eq, 5.u64 ^ 3.u64, 6.u64)
-    .assert(eq, !(0.u64), -1.asU64) // TODO: Fix u64 numeric constants
-    .assert(eq, 1.u64 !& 2.u64, -1.asU64) // TODO: u64 numeric constants
-    .assert(eq, 1.u64 !| 2.u64, -4.asU64) // TODO: u64 numeric constants
-    .assert(eq, 5.u64 !^ 3.u64, -7.asU64);
+    .assert(eq, !(0.u64), 18_446_744_073_709_551_615.u64)
+    .assert(eq, 1.u64 !& 2.u64, 18_446_744_073_709_551_615.u64)
+    .assert(eq, 1.u64 !| 2.u64, 18_446_744_073_709_551_612.u64)
+    .assert(eq, 5.u64 !^ 3.u64, 18_446_744_073_709_551_609.u64);
 
   test.describe("Cross Product").it("")
     .assert(

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -41,20 +41,41 @@ fn box_native_value(typen: &CType, representation: &str) -> Option<String> {
                 None
             }
         }
+        // 64-bit integers wrap a `BigInt` (the `Int` base calls `BigInt(val)`), so the literal needs
+        // an `n` suffix: `new alan_std.I64(1n)`.
         CType::Type(n, _) if n == "i64" || n == "u64" => {
             if all_consuming(integer).parse(representation).is_ok() {
-                if n == "i64" {
-                    Some(format!("new alan_std.I64({representation}n)"))
-                } else {
-                    Some(format!("new alan_std.U64({representation}n)"))
-                }
+                Some(format!(
+                    "new alan_std.{}({representation}n)",
+                    n.to_uppercase()
+                ))
             } else {
                 None
             }
         }
-        CType::Type(n, _) if n == "f64" => {
-            if all_consuming(real).parse(representation).is_ok() {
-                Some(format!("new alan_std.F64({representation})"))
+        // Sub-64-bit integers wrap a plain `Number`. These can now appear as bare literals (e.g.
+        // `5.u8` or `let x: u8 = 5`) since numeric literals adopt the narrowed type directly, so they
+        // must be boxed into their `alan_std` wrapper just like the 64-bit ones.
+        CType::Type(n, _) if matches!(n.as_str(), "i8" | "i16" | "i32" | "u8" | "u16" | "u32") => {
+            if all_consuming(integer).parse(representation).is_ok() {
+                Some(format!(
+                    "new alan_std.{}({representation})",
+                    n.to_uppercase()
+                ))
+            } else {
+                None
+            }
+        }
+        // Both float widths wrap a `Number`. A literal narrowed to a float may be in integer form
+        // (e.g. `5.f32`), so accept either spelling.
+        CType::Type(n, _) if n == "f32" || n == "f64" => {
+            if all_consuming(real).parse(representation).is_ok()
+                || all_consuming(integer).parse(representation).is_ok()
+            {
+                Some(format!(
+                    "new alan_std.{}({representation})",
+                    n.to_uppercase()
+                ))
             } else {
                 None
             }
@@ -375,7 +396,21 @@ pub fn from_microstatement(
             let typen = &typen.clone().collapse_anyof_default();
             match &**typen {
                 CType::Type(n, _)
-                    if n == "string" || n == "i64" || n == "u64" || n == "f64" || n == "bool" =>
+                    if matches!(
+                        n.as_str(),
+                        "string"
+                            | "bool"
+                            | "i8"
+                            | "i16"
+                            | "i32"
+                            | "i64"
+                            | "u8"
+                            | "u16"
+                            | "u32"
+                            | "u64"
+                            | "f32"
+                            | "f64"
+                    ) =>
                 {
                     Ok((
                         box_native_value(typen, representation)

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -370,116 +370,117 @@ pub fn from_microstatement(
             typen,
             representation,
         } => {
-          // A numeric literal whose type was never narrowed by context is an `AnyOf`; collapse it
-          // to its FUI default so it boxes (`new alan_std.I64(..)`) like a concrete literal.
-          let typen = &typen.clone().collapse_anyof_default();
-          match &**typen {
-            CType::Type(n, _)
-                if n == "string" || n == "i64" || n == "u64" || n == "f64" || n == "bool" =>
-            {
-                Ok((
-                    box_native_value(typen, representation)
-                        .unwrap_or_else(|| representation.clone()),
-                    out,
-                    deps,
-                ))
-            }
-            CType::Binds(n, _) => match &**n {
-                CType::TString(_) => Ok((representation.clone(), out, deps)),
-                CType::Import(n, d) => {
-                    super::register_nodejs_dependency(d, &mut deps);
-                    match &**n {
-                        CType::TString(_) => { /* Do nothing */ }
-                        _ => CType::fail("Native import names must be strings"),
-                    }
-                    Ok((representation.clone(), out, deps))
+            // A numeric literal whose type was never narrowed by context is an `AnyOf`; collapse it
+            // to its FUI default so it boxes (`new alan_std.I64(..)`) like a concrete literal.
+            let typen = &typen.clone().collapse_anyof_default();
+            match &**typen {
+                CType::Type(n, _)
+                    if n == "string" || n == "i64" || n == "u64" || n == "f64" || n == "bool" =>
+                {
+                    Ok((
+                        box_native_value(typen, representation)
+                            .unwrap_or_else(|| representation.clone()),
+                        out,
+                        deps,
+                    ))
                 }
-                otherwise => CType::fail(&format!(
-                    "Bound types must be strings or node.js imports: {otherwise:?}"
-                )),
-            },
-            CType::Function(..) => {
-                let f = scope.resolve_function_by_type(representation, typen.clone());
-                let f = match f {
-                    None => {
-                        // If the current scope isn't the original scope for the parent function, maybe the
-                        // function we're looking for is in the original scope
-                        if parent_fn.origin_scope_path != scope.path {
-                            let program = Program::get_program();
-                            let out = match program.scope_by_file(&parent_fn.origin_scope_path) {
-                                Ok(original_scope) => original_scope
-                                    .resolve_function_by_type(representation, typen.clone()),
-                                Err(_) => None,
-                            };
-                            Program::return_program(program);
-                            out
-                        } else {
-                            None
+                CType::Binds(n, _) => match &**n {
+                    CType::TString(_) => Ok((representation.clone(), out, deps)),
+                    CType::Import(n, d) => {
+                        super::register_nodejs_dependency(d, &mut deps);
+                        match &**n {
+                            CType::TString(_) => { /* Do nothing */ }
+                            _ => CType::fail("Native import names must be strings"),
                         }
+                        Ok((representation.clone(), out, deps))
                     }
-                    f => f,
-                };
-                match &f {
-                    None => {
-                        let args = parent_fn.args();
-                        for (name, _, typen) in args {
-                            if &name == representation {
-                                if let CType::Function(_, _) = &*typen {
-                                    // TODO: Do we need better matching? The upper stage should
-                                    // have taken care of this
-                                    return Ok((representation.clone(), out, deps));
-                                }
+                    otherwise => CType::fail(&format!(
+                        "Bound types must be strings or node.js imports: {otherwise:?}"
+                    )),
+                },
+                CType::Function(..) => {
+                    let f = scope.resolve_function_by_type(representation, typen.clone());
+                    let f = match f {
+                        None => {
+                            // If the current scope isn't the original scope for the parent function, maybe the
+                            // function we're looking for is in the original scope
+                            if parent_fn.origin_scope_path != scope.path {
+                                let program = Program::get_program();
+                                let out = match program.scope_by_file(&parent_fn.origin_scope_path)
+                                {
+                                    Ok(original_scope) => original_scope
+                                        .resolve_function_by_type(representation, typen.clone()),
+                                    Err(_) => None,
+                                };
+                                Program::return_program(program);
+                                out
+                            } else {
+                                None
                             }
                         }
-                        Err(format!(
+                        f => f,
+                    };
+                    match &f {
+                        None => {
+                            let args = parent_fn.args();
+                            for (name, _, typen) in args {
+                                if &name == representation {
+                                    if let CType::Function(_, _) = &*typen {
+                                        // TODO: Do we need better matching? The upper stage should
+                                        // have taken care of this
+                                        return Ok((representation.clone(), out, deps));
+                                    }
+                                }
+                            }
+                            Err(format!(
                             "Somehow can't find a definition for function {representation}, {typen:?}"
                         )
                         .into())
+                        }
+                        Some(fun) => match &fun.kind {
+                            FnKind::Normal
+                            | FnKind::External(_)
+                            | FnKind::Generic(..)
+                            | FnKind::Derived
+                            | FnKind::DerivedVariadic
+                            | FnKind::Static
+                            | FnKind::Cfn(..)
+                            | FnKind::CfnRealized(_) => {
+                                let mut arg_strs = Vec::new();
+                                for arg in &fun.args() {
+                                    arg_strs.push(arg.2.clone().to_callable_string());
+                                }
+                                let jsname = format!("{}_{}", fun.name, arg_strs.join("_"));
+                                let (o, d) = generate(jsname.clone(), fun, scope, out, deps)?;
+                                out = o;
+                                deps = d;
+                                if let FnKind::External(d) = &fun.kind {
+                                    super::register_nodejs_dependency(d, &mut deps);
+                                }
+                                Ok((jsname, out, deps))
+                            }
+                            FnKind::Bind(jsname)
+                            | FnKind::BoundGeneric(_, jsname)
+                            | FnKind::ExternalBind(jsname, _)
+                            | FnKind::ExternalGeneric(_, jsname, _) => {
+                                if let FnKind::ExternalGeneric(_, _, d)
+                                | FnKind::ExternalBind(_, d) = &fun.kind
+                                {
+                                    super::register_nodejs_dependency(d, &mut deps);
+                                }
+                                Ok((jsname.clone(), out, deps))
+                            }
+                        },
                     }
-                    Some(fun) => match &fun.kind {
-                        FnKind::Normal
-                        | FnKind::External(_)
-                        | FnKind::Generic(..)
-                        | FnKind::Derived
-                        | FnKind::DerivedVariadic
-                        | FnKind::Static
-                        | FnKind::Cfn(..)
-                        | FnKind::CfnRealized(_) => {
-                            let mut arg_strs = Vec::new();
-                            for arg in &fun.args() {
-                                arg_strs.push(arg.2.clone().to_callable_string());
-                            }
-                            let jsname = format!("{}_{}", fun.name, arg_strs.join("_"));
-                            let (o, d) = generate(jsname.clone(), fun, scope, out, deps)?;
-                            out = o;
-                            deps = d;
-                            if let FnKind::External(d) = &fun.kind {
-                                super::register_nodejs_dependency(d, &mut deps);
-                            }
-                            Ok((jsname, out, deps))
-                        }
-                        FnKind::Bind(jsname)
-                        | FnKind::BoundGeneric(_, jsname)
-                        | FnKind::ExternalBind(jsname, _)
-                        | FnKind::ExternalGeneric(_, jsname, _) => {
-                            if let FnKind::ExternalGeneric(_, _, d) | FnKind::ExternalBind(_, d) =
-                                &fun.kind
-                            {
-                                super::register_nodejs_dependency(d, &mut deps);
-                            }
-                            Ok((jsname.clone(), out, deps))
-                        }
-                    },
+                }
+                _ => {
+                    if representation.as_str() == "var" {
+                        Ok(("__var__".to_string(), out, deps))
+                    } else {
+                        Ok((representation.clone(), out, deps))
+                    }
                 }
             }
-            _ => {
-                if representation.as_str() == "var" {
-                    Ok(("__var__".to_string(), out, deps))
-                } else {
-                    Ok((representation.clone(), out, deps))
-                }
-            }
-          }
         }
         Microstatement::Array { vals, .. } => {
             let mut val_representations = Vec::new();

--- a/alan_compiler/src/lntojs/function.rs
+++ b/alan_compiler/src/lntojs/function.rs
@@ -23,6 +23,13 @@ use crate::program::{
 /// may receive a substituted literal as a method receiver/argument once inlining
 /// is enabled) produce identical, valid output.
 fn box_native_value(typen: &CType, representation: &str) -> Option<String> {
+    // A numeric literal whose type was never narrowed by context is an `AnyOf` candidate set;
+    // box it as its FUI default (the last candidate), matching the type codegen renders for it.
+    if let CType::AnyOf(ts) = typen {
+        return ts
+            .last()
+            .and_then(|t| box_native_value(&t.clone().degroup(), representation));
+    }
     match typen {
         CType::Type(n, _) if n == "string" => {
             if representation.starts_with('"') {
@@ -362,7 +369,11 @@ pub fn from_microstatement(
         Microstatement::Value {
             typen,
             representation,
-        } => match &**typen {
+        } => {
+          // A numeric literal whose type was never narrowed by context is an `AnyOf`; collapse it
+          // to its FUI default so it boxes (`new alan_std.I64(..)`) like a concrete literal.
+          let typen = &typen.clone().collapse_anyof_default();
+          match &**typen {
             CType::Type(n, _)
                 if n == "string" || n == "i64" || n == "u64" || n == "f64" || n == "bool" =>
             {
@@ -468,7 +479,8 @@ pub fn from_microstatement(
                     Ok((representation.clone(), out, deps))
                 }
             }
-        },
+          }
+        }
         Microstatement::Array { vals, .. } => {
             let mut val_representations = Vec::new();
             for val in vals {

--- a/alan_compiler/src/lntojs/typen.rs
+++ b/alan_compiler/src/lntojs/typen.rs
@@ -181,7 +181,9 @@ pub fn ctype_to_jtype(
             }
             Ok(("".to_string(), deps))
         }
-        CType::AnyOf(_) => Ok(("".to_string(), deps)), // Does this make any sense?
+        // A numeric literal whose `AnyOf` type was never narrowed by context resolves to its FUI
+        // default (the last candidate) for codegen. `AnyOf` is otherwise a compile-time-only set.
+        CType::AnyOf(_) => ctype_to_jtype(ctype.clone().collapse_anyof_default(), deps),
         CType::Buffer(t, _) => {
             let res = ctype_to_jtype(t.clone(), deps)?;
             deps = res.1;

--- a/alan_compiler/src/lntors/typen.rs
+++ b/alan_compiler/src/lntors/typen.rs
@@ -382,7 +382,9 @@ pub fn ctype_to_rtype(
                 Ok((Arc::new(CType::Either(ts.clone(), Vec::new())).to_callable_string(), deps))
             }
         }
-        CType::AnyOf(_) => Ok(("".to_string(), deps)), // Does this make any sense in Rust?
+        // A numeric literal whose `AnyOf` type was never narrowed by context resolves to its FUI
+        // default (the last candidate) for codegen. `AnyOf` is otherwise a compile-time-only set.
+        CType::AnyOf(_) => ctype_to_rtype(ctype.clone().collapse_anyof_default(), deps),
         CType::Buffer(t, s) => {
             let res = ctype_to_rtype(t.clone(), deps)?;
             let t = res.0;

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -4574,10 +4574,9 @@ impl CType {
     pub fn strip_value_wrappers(self: Arc<CType>) -> Arc<CType> {
         let t = self.degroup();
         match &*t {
-            CType::Deref(inner)
-            | CType::Mut(inner)
-            | CType::Own(inner)
-            | CType::Shared(inner) => inner.clone().strip_value_wrappers(),
+            CType::Deref(inner) | CType::Mut(inner) | CType::Own(inner) | CType::Shared(inner) => {
+                inner.clone().strip_value_wrappers()
+            }
             _ => t,
         }
     }

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -4551,6 +4551,10 @@ impl CType {
         }
     }
     pub fn anyof(args: Vec<Arc<CType>>) -> Arc<CType> {
+        // `AnyOf{...}` is a type-position construct meaning "resolves to exactly one of these,
+        // chosen by context" (see `CType::AnyOf`). It must produce the `AnyOf` variant -- not
+        // `Either` (a tagged union that physically holds one variant at runtime). Nested `AnyOf`s
+        // are flattened into a single set.
         let mut out_vec = Vec::new();
         for arg in args {
             match &*arg {
@@ -4562,7 +4566,37 @@ impl CType {
                 _other => out_vec.push(arg),
             }
         }
-        Arc::new(CType::Either(out_vec, Vec::new()))
+        Arc::new(CType::AnyOf(out_vec))
+    }
+    /// Collapse an `AnyOf` to its single default type by picking the *last*
+    /// candidate (the highest-priority entry under the FUI ordering used when
+    /// typing numeric literals: Floats, Unsigned ints, signed Ints, ascending bit
+    /// width). This is the "pick last in FUI order" rule that resolves a numeric
+    /// literal whose type was never narrowed by context. Non-`AnyOf` types are
+    /// returned unchanged.
+    pub fn collapse_anyof_default(self: Arc<CType>) -> Arc<CType> {
+        match &*self {
+            CType::AnyOf(ts) => {
+                // Only collapse "value" `AnyOf`s such as numeric-literal candidate sets. `AnyOf`s
+                // whose members are function types come from overload resolution / operator-return
+                // merging and must be left intact so higher-order dispatch can narrow them.
+                fn is_function_like(t: &Arc<CType>) -> bool {
+                    match &*t.clone().degroup() {
+                        CType::Function(..) => true,
+                        CType::Generic(_, _, inner) => is_function_like(inner),
+                        _ => false,
+                    }
+                }
+                if ts.iter().any(is_function_like) {
+                    return self;
+                }
+                match ts.last() {
+                    Some(t) => t.clone().collapse_anyof_default(),
+                    None => self,
+                }
+            }
+            _ => self,
+        }
     }
     pub fn field(mut args: Vec<Arc<CType>>) -> Arc<CType> {
         if args.len() != 2 {

--- a/alan_compiler/src/program/ctype.rs
+++ b/alan_compiler/src/program/ctype.rs
@@ -4568,6 +4568,19 @@ impl CType {
         }
         Arc::new(CType::AnyOf(out_vec))
     }
+    /// Strip the value-position wrappers (`Type`/`Group` aliases plus `Deref`/`Mut`/`Own`/`Shared`)
+    /// from a type to expose the underlying "core" type. Used when matching a numeric-literal
+    /// candidate against a function parameter type (which may be e.g. `Deref{i64}`).
+    pub fn strip_value_wrappers(self: Arc<CType>) -> Arc<CType> {
+        let t = self.degroup();
+        match &*t {
+            CType::Deref(inner)
+            | CType::Mut(inner)
+            | CType::Own(inner)
+            | CType::Shared(inner) => inner.clone().strip_value_wrappers(),
+            _ => t,
+        }
+    }
     /// Collapse an `AnyOf` to its single default type by picking the *last*
     /// candidate (the highest-priority entry under the FUI ordering used when
     /// typing numeric literals: Floats, Unsigned ints, signed Ints, ascending bit

--- a/alan_compiler/src/program/microstatement.rs
+++ b/alan_compiler/src/program/microstatement.rs
@@ -125,7 +125,7 @@ fn narrow_numeric_literal(value: Microstatement, target: Arc<CType>) -> Microsta
                     .cloned();
                 if let Some(matched) = matched {
                     let representation = if ctype_is_float(&matched.clone().degroup())
-                        && !representation.contains(|c| c == '.' || c == 'e' || c == 'E')
+                        && !representation.contains(['.', 'e', 'E'])
                     {
                         format!("{representation}.0")
                     } else {
@@ -950,7 +950,10 @@ pub fn baseassignablelist_to_microstatements<'a>(
                             temp_scope.functions.insert(c.to_string(), vec![f.clone()]);
                             merge!(scope, temp_scope);
                             prior_value = Some(Microstatement::FnCall {
-                                args: narrow_call_arg_literals(&f, constant_accessor_microstatements),
+                                args: narrow_call_arg_literals(
+                                    &f,
+                                    constant_accessor_microstatements,
+                                ),
                                 function: f,
                             })
                         }

--- a/alan_compiler/src/program/microstatement.rs
+++ b/alan_compiler/src/program/microstatement.rs
@@ -12,6 +12,124 @@ use super::Scope;
 use crate::parse;
 use crate::render::Render;
 
+/// FUI ordering (Floats, Unsigned ints, signed Ints, ascending bit width) of the
+/// numeric types an integer literal may resolve to. The *last* surviving entry is
+/// the highest-priority default chosen when the literal's `AnyOf` type is never
+/// narrowed by context ("pick last in FUI order"), which keeps the historical
+/// `i64`/`f64` defaults while allowing e.g. an above-`i64::MAX` literal to land on
+/// `u64`.
+pub const FUI_INT_TYPES: [&str; 10] = [
+    "f32", "f64", "u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64",
+];
+pub const FUI_FLOAT_TYPES: [&str; 2] = ["f32", "f64"];
+
+/// Parse an integer literal's source text (honoring `0b`/`0o`/`0x` prefixes, `_`
+/// digit separators, and a leading `-`) into an `i128` for range checks. Returns
+/// `None` for forms we can't represent in `i128` (e.g. an above-`u64` literal),
+/// in which case the caller falls back to the historical `i64` typing.
+fn parse_int_literal(s: &str) -> Option<i128> {
+    let s = s.replace('_', "");
+    let (neg, rest) = match s.strip_prefix('-') {
+        Some(r) => (true, r.to_string()),
+        None => (false, s.clone()),
+    };
+    let (radix, digits) = if let Some(r) = rest.strip_prefix("0x") {
+        (16, r.to_string())
+    } else if let Some(r) = rest.strip_prefix("0b") {
+        (2, r.to_string())
+    } else if let Some(r) = rest.strip_prefix("0o") {
+        (8, r.to_string())
+    } else {
+        (10, rest.clone())
+    };
+    let v = i128::from_str_radix(&digits, radix).ok()?;
+    Some(if neg { -v } else { v })
+}
+
+/// Returns true if the integer value `v` fits in the numeric type named `name`.
+/// Float types are always considered capable of holding an integer literal
+/// (possibly with precision loss), matching the issue #215 design where a small
+/// integer constant keeps `f32`/`f64` as candidates.
+fn int_fits_type(v: i128, name: &str) -> bool {
+    match name {
+        "f32" | "f64" => true,
+        "u8" => (0..=u8::MAX as i128).contains(&v),
+        "u16" => (0..=u16::MAX as i128).contains(&v),
+        "u32" => (0..=u32::MAX as i128).contains(&v),
+        "u64" => (0..=u64::MAX as i128).contains(&v),
+        "i8" => ((i8::MIN as i128)..=(i8::MAX as i128)).contains(&v),
+        "i16" => ((i16::MIN as i128)..=(i16::MAX as i128)).contains(&v),
+        "i32" => ((i32::MIN as i128)..=(i32::MAX as i128)).contains(&v),
+        "i64" => ((i64::MIN as i128)..=(i64::MAX as i128)).contains(&v),
+        _ => false,
+    }
+}
+
+/// The FUI-ordered list of numeric type names a numeric literal may resolve to,
+/// with candidates pruned by the literal's parsed value/sign. Integers that can't
+/// be parsed into `i128` fall back to `i64` so behavior is no worse than before.
+fn numeric_literal_type_names(repr: &str, is_float: bool) -> Vec<&'static str> {
+    if is_float {
+        return FUI_FLOAT_TYPES.to_vec();
+    }
+    match parse_int_literal(repr) {
+        Some(v) => FUI_INT_TYPES
+            .iter()
+            .copied()
+            .filter(|n| int_fits_type(v, n))
+            .collect(),
+        None => vec!["i64"],
+    }
+}
+
+/// Returns true if the type (after unwrapping `Type`/`Group`) is a bound `f32`/`f64`.
+fn ctype_is_float(t: &CType) -> bool {
+    match t {
+        CType::Binds(inner, _) => {
+            matches!(&**inner, CType::TString(s) if s == "f32" || s == "f64")
+        }
+        CType::Type(_, inner) | CType::Group(inner) => ctype_is_float(inner),
+        _ => false,
+    }
+}
+
+/// If `value` is a numeric literal whose `AnyOf` candidate set contains `target`, narrow its type
+/// to `target`. When narrowing an integer-form literal to a floating-point type, the textual
+/// representation is given a `.0` suffix, since Rust rejects an integer literal in a float position.
+fn narrow_numeric_literal(value: Microstatement, target: Arc<CType>) -> Microstatement {
+    if let Microstatement::Value {
+        typen,
+        representation,
+    } = &value
+    {
+        if let CType::AnyOf(ts) = &**typen {
+            let target_str = target.clone().degroup().to_strict_string(false);
+            // Narrow to the matching *candidate member* (the concrete numeric type, e.g. `i64`)
+            // rather than to `target` itself: the annotation may be a type alias (e.g.
+            // `type DupeI64 = i64 | i64`) that dedups to a numeric type, and downstream codegen
+            // (notably JS literal boxing) keys off the concrete numeric type, not the alias name.
+            let matched = ts
+                .iter()
+                .find(|t| (*t).clone().degroup().to_strict_string(false) == target_str)
+                .cloned();
+            if let Some(matched) = matched {
+                let representation = if ctype_is_float(&matched.clone().degroup())
+                    && !representation.contains(|c| c == '.' || c == 'e' || c == 'E')
+                {
+                    format!("{representation}.0")
+                } else {
+                    representation.clone()
+                };
+                return Microstatement::Value {
+                    typen: matched,
+                    representation,
+                };
+            }
+        }
+    }
+    value
+}
+
 /// Microstatements are a reduced syntax that doesn't have operators, methods, or reassigning to
 /// the same variable. (We'll rely on LLVM to dedupe variables that are never used again.) This
 /// syntax reduction will make generating the final output easier and also simplifies the work
@@ -340,26 +458,36 @@ pub fn baseassignablelist_to_microstatements<'a>(
                             },
                         });
                     }
-                    parse::Constants::Num(n) => match n {
-                        parse::Number::RealNum(r) => {
-                            let float64 = scope.resolve_type("f64").unwrap().clone();
-                            prior_value = Some(Microstatement::Value {
-                                // TODO: Replace this with the `CType::Float` and have built-ins
-                                // that accept them
-                                typen: float64,
-                                representation: r.clone(),
-                            });
+                    parse::Constants::Num(n) => {
+                        // A numeric literal is typed as an `AnyOf` over the numeric types that can
+                        // hold its value (in FUI order), or that single type if only one survives.
+                        // Context (function args, `let`/return annotations) narrows it later; any
+                        // still-ambiguous literal collapses to the last (FUI) candidate before
+                        // codegen. See `docs/int-float-constant-selection-plan.md`.
+                        let (repr, is_float) = match n {
+                            parse::Number::RealNum(r) => (r.clone(), true),
+                            parse::Number::IntNum(i) => (i.clone(), false),
+                        };
+                        let names = numeric_literal_type_names(&repr, is_float);
+                        let mut candidates: Vec<Arc<CType>> = Vec::new();
+                        for nm in &names {
+                            if let Some(t) = scope.resolve_type(nm) {
+                                candidates.push(t.clone());
+                            }
                         }
-                        parse::Number::IntNum(i) => {
-                            let int64 = scope.resolve_type("i64").unwrap().clone();
-                            prior_value = Some(Microstatement::Value {
-                                // TODO: Replace this with `CType::Int` and have built-ins that
-                                // accept them
-                                typen: int64,
-                                representation: i.clone(),
-                            });
-                        }
-                    },
+                        let typen = match candidates.len() {
+                            0 => scope
+                                .resolve_type(if is_float { "f64" } else { "i64" })
+                                .unwrap()
+                                .clone(),
+                            1 => candidates.into_iter().next().unwrap(),
+                            _ => Arc::new(CType::AnyOf(candidates)),
+                        };
+                        prior_value = Some(Microstatement::Value {
+                            typen,
+                            representation: repr,
+                        });
+                    }
                 }
             }
             BaseChunk::Variable(v) => {
@@ -492,7 +620,10 @@ pub fn baseassignablelist_to_microstatements<'a>(
                 }
                 // TODO: Currently assuming all array values are the same type, should check that
                 // better
-                let inner_type = array_vals[0].get_type();
+                // Collapse an `AnyOf` element type (e.g. from numeric literals like `[1, 2, 3]`) to
+                // its FUI default so the array's element type is a concrete, name-able type rather
+                // than the whole candidate set.
+                let inner_type = array_vals[0].get_type().collapse_anyof_default();
                 let inner_type_str = inner_type.clone().to_callable_string();
                 let array_type_name = format!("Array_{inner_type_str}_");
                 let array_type = Arc::new(CType::Array(inner_type));
@@ -763,9 +894,12 @@ pub fn baseassignablelist_to_microstatements<'a>(
                     let constant_accessor_microstatements = vec![prior.clone()];
                     let mut arg_types = Vec::new();
                     for m in &constant_accessor_microstatements {
-                        arg_types.push(m.get_type());
+                        // Collapse an `AnyOf` literal type to its FUI default so the accessor (e.g.
+                        // `5.u64`) dispatches against, and registers, a concrete type rather than
+                        // the whole candidate set.
+                        let t = m.get_type().collapse_anyof_default();
+                        arg_types.push(t.clone());
                         // In case the type constructor has not already been created
-                        let t = m.get_type();
                         temp_scope =
                             CType::from_ctype(temp_scope, t.clone().to_callable_string(), t);
                     }
@@ -1067,7 +1201,7 @@ pub fn baseassignablelist_to_microstatements<'a>(
                                 f,
                                 arg_types
                                     .iter()
-                                    .map(|a| a.clone().to_string())
+                                    .map(|a| a.clone().collapse_anyof_default().to_string())
                                     .collect::<Vec<String>>()
                                     .join(", ")
                             )
@@ -1582,21 +1716,31 @@ pub fn declarations_to_microstatements<'a>(
     mut scope: Scope<'a>,
     mut microstatements: Vec<Microstatement>,
 ) -> Result<(Scope<'a>, Vec<Microstatement>), Box<dyn std::error::Error>> {
-    let (name, assignables, mutable) = match &declarations {
-        parse::Declarations::Const(c) => (c.variable.clone(), &c.assignables, false),
-        parse::Declarations::Let(l) => (l.variable.clone(), &l.assignables, true),
+    let (name, assignables, mutable, typedec) = match &declarations {
+        parse::Declarations::Const(c) => (c.variable.clone(), &c.assignables, false, &c.typedec),
+        parse::Declarations::Let(l) => (l.variable.clone(), &l.assignables, true, &l.typedec),
     };
     // Get all of the assignable microstatements generated
     let res = withoperatorslist_to_microstatements(assignables, parent_fn, scope, microstatements)?;
     scope = res.0;
     microstatements = res.1;
-    let value = match microstatements.pop() {
+    let mut value = match microstatements.pop() {
         None => Err("An assignment without a value should be impossible."),
-        Some(v) => Ok(Box::new(v)),
+        Some(v) => Ok(v),
     }?;
+    // If the declaration carries an explicit type annotation (`let x: u64 = ...`) and the value is
+    // a numeric literal whose `AnyOf` candidate set includes that type, narrow the literal to it.
+    // This makes e.g. `let big: u64 = 18446744073709551615` produce a `u64` constant directly
+    // (no `i64` intermediate, no runtime cast) and is what lets above-`i64::MAX` constants compile.
+    if let Some(td) = typedec {
+        let target_name = td.fulltypename.to_string();
+        if let Some(target) = scope.resolve_type(&target_name) {
+            value = narrow_numeric_literal(value, target);
+        }
+    }
     microstatements.push(Microstatement::Assignment {
         name,
-        value,
+        value: Box::new(value),
         mutable,
     });
     Ok((scope, microstatements))

--- a/alan_compiler/src/program/microstatement.rs
+++ b/alan_compiler/src/program/microstatement.rs
@@ -93,9 +93,23 @@ fn ctype_is_float(t: &CType) -> bool {
     }
 }
 
-/// If `value` is a numeric literal whose `AnyOf` candidate set contains `target`, narrow its type
-/// to `target`. When narrowing an integer-form literal to a floating-point type, the textual
+/// Returns true if `s` is the textual form of a numeric literal (rather than a variable name).
+/// Variable identifiers can't begin with a digit, `-`, or `.`, so this distinguishes a literal
+/// argument (which may be safely retyped) from a reference to a variable (whose storage type is
+/// already fixed at its declaration and must not be retyped here).
+fn is_numeric_literal_repr(s: &str) -> bool {
+    matches!(s.chars().next(), Some(c) if c.is_ascii_digit() || c == '-' || c == '.')
+}
+
+/// If `value` is a numeric *literal* whose `AnyOf` candidate set contains the (wrapper-stripped)
+/// `target` type, narrow its type to the matching candidate member and return it; otherwise return
+/// `value` unchanged. When narrowing an integer-form literal to a floating-point type, the textual
 /// representation is given a `.0` suffix, since Rust rejects an integer literal in a float position.
+///
+/// We narrow to the matching *candidate member* (the concrete numeric type, e.g. `i64`) rather than
+/// to `target` itself, because `target` may be a type alias (e.g. `type DupeI64 = i64 | i64`) that
+/// dedups to a numeric type, and downstream codegen (notably JS literal boxing) keys off the
+/// concrete numeric type, not the alias name.
 fn narrow_numeric_literal(value: Microstatement, target: Arc<CType>) -> Microstatement {
     if let Microstatement::Value {
         typen,
@@ -103,31 +117,47 @@ fn narrow_numeric_literal(value: Microstatement, target: Arc<CType>) -> Microsta
     } = &value
     {
         if let CType::AnyOf(ts) = &**typen {
-            let target_str = target.clone().degroup().to_strict_string(false);
-            // Narrow to the matching *candidate member* (the concrete numeric type, e.g. `i64`)
-            // rather than to `target` itself: the annotation may be a type alias (e.g.
-            // `type DupeI64 = i64 | i64`) that dedups to a numeric type, and downstream codegen
-            // (notably JS literal boxing) keys off the concrete numeric type, not the alias name.
-            let matched = ts
-                .iter()
-                .find(|t| (*t).clone().degroup().to_strict_string(false) == target_str)
-                .cloned();
-            if let Some(matched) = matched {
-                let representation = if ctype_is_float(&matched.clone().degroup())
-                    && !representation.contains(|c| c == '.' || c == 'e' || c == 'E')
-                {
-                    format!("{representation}.0")
-                } else {
-                    representation.clone()
-                };
-                return Microstatement::Value {
-                    typen: matched,
-                    representation,
-                };
+            if is_numeric_literal_repr(representation) {
+                let target_str = target.strip_value_wrappers().to_strict_string(false);
+                let matched = ts
+                    .iter()
+                    .find(|t| (*t).clone().degroup().to_strict_string(false) == target_str)
+                    .cloned();
+                if let Some(matched) = matched {
+                    let representation = if ctype_is_float(&matched.clone().degroup())
+                        && !representation.contains(|c| c == '.' || c == 'e' || c == 'E')
+                    {
+                        format!("{representation}.0")
+                    } else {
+                        representation.clone()
+                    };
+                    return Microstatement::Value {
+                        typen: matched,
+                        representation,
+                    };
+                }
             }
         }
     }
     value
+}
+
+/// Narrow each numeric-literal argument of a resolved call to the concrete parameter type the
+/// function expects, recording the choice made during dispatch so codegen emits a correctly-typed
+/// constant (rather than the global FUI default). Non-literal arguments (e.g. variable references
+/// or nested calls) are left untouched.
+fn narrow_call_arg_literals(f: &Arc<Function>, args: Vec<Microstatement>) -> Vec<Microstatement> {
+    let fargs = f.args();
+    args.into_iter()
+        .enumerate()
+        .map(|(i, a)| {
+            if i < fargs.len() {
+                narrow_numeric_literal(a, fargs[i].2.clone())
+            } else {
+                a
+            }
+        })
+        .collect()
 }
 
 /// Microstatements are a reduced syntax that doesn't have operators, methods, or reassigning to
@@ -867,8 +897,8 @@ pub fn baseassignablelist_to_microstatements<'a>(
                                 .insert("get".to_string(), vec![f.clone()]);
                             merge!(scope, temp_scope);
                             prior_value = Some(Microstatement::FnCall {
+                                args: narrow_call_arg_literals(&f, array_accessor_microstatements),
                                 function: f,
-                                args: array_accessor_microstatements,
                             })
                         }
                         None => {
@@ -909,8 +939,8 @@ pub fn baseassignablelist_to_microstatements<'a>(
                             temp_scope.functions.insert(c.to_string(), vec![f.clone()]);
                             merge!(scope, temp_scope);
                             prior_value = Some(Microstatement::FnCall {
+                                args: narrow_call_arg_literals(&f, constant_accessor_microstatements),
                                 function: f,
-                                args: constant_accessor_microstatements,
                             })
                         }
                         None => {
@@ -982,8 +1012,8 @@ pub fn baseassignablelist_to_microstatements<'a>(
                         temp_scope.functions.insert(name.clone(), vec![f.clone()]);
                         merge!(scope, temp_scope);
                         prior_value = Some(Microstatement::FnCall {
+                            args: narrow_call_arg_literals(&f, arg_microstatements),
                             function: f.clone(),
-                            args: arg_microstatements,
                         })
                     }
                     None => {
@@ -1083,8 +1113,8 @@ pub fn baseassignablelist_to_microstatements<'a>(
                 }
                 if let Some(func) = closure_fn {
                     prior_value = Some(Microstatement::FnCall {
+                        args: narrow_call_arg_literals(&func, arg_microstatements),
                         function: func,
-                        args: arg_microstatements,
                     });
                 } else if let Some((name, typen)) = var_fn {
                     prior_value = Some(Microstatement::VarCall {
@@ -1191,8 +1221,8 @@ pub fn baseassignablelist_to_microstatements<'a>(
                             merge!(scope, temp_scope);
 
                             prior_value = Some(Microstatement::FnCall {
+                                args: narrow_call_arg_literals(&fun, arg_microstatements.clone()),
                                 function: fun.clone(), // TODO: Drop the clone
-                                args: arg_microstatements.clone(),
                             });
                         }
                         None => {
@@ -1275,8 +1305,8 @@ pub fn baseassignablelist_to_microstatements<'a>(
                     (_, Some((temp_scope, func))) => {
                         merge!(scope, temp_scope);
                         prior_value = Some(Microstatement::FnCall {
+                            args: narrow_call_arg_literals(&func, arg_microstatements),
                             function: func.clone(), // TODO: Drop the clone
-                            args: arg_microstatements,
                         });
                     }
                     (Some(_), None) => {
@@ -1335,8 +1365,8 @@ pub fn baseassignablelist_to_microstatements<'a>(
                                                                                        // duplicate
                                 scope = res.0;
                                 prior_value = Some(Microstatement::FnCall {
+                                    args: narrow_call_arg_literals(&func, arg_microstatements),
                                     function: func.clone(), // TODO: Drop the clone?
-                                    args: arg_microstatements,
                                 })
                             }
                             None => {
@@ -1737,6 +1767,17 @@ pub fn declarations_to_microstatements<'a>(
         if let Some(target) = scope.resolve_type(&target_name) {
             value = narrow_numeric_literal(value, target);
         }
+    } else if let Microstatement::Value { typen, .. } = &value {
+        // No annotation: pin an unconstrained numeric-literal `AnyOf` to its global FUI default now,
+        // so the bound variable has a single concrete type. A later reference to this variable must
+        // not be re-narrowed (its storage type is fixed here), so we collapse rather than leave the
+        // `AnyOf` open. (A direct literal *argument* is handled separately, at the call site.)
+        if matches!(&**typen, CType::AnyOf(_)) {
+            let collapsed = typen.clone().collapse_anyof_default();
+            if !matches!(&*collapsed, CType::AnyOf(_)) {
+                value = narrow_numeric_literal(value, collapsed);
+            }
+        }
     }
     microstatements.push(Microstatement::Assignment {
         name,
@@ -1810,8 +1851,8 @@ pub fn statement_to_microstatements<'a>(
                 }?
             };
             ms.push(Microstatement::FnCall {
+                args: narrow_call_arg_literals(&store_fn, args),
                 function: store_fn,
-                args,
             });
             Ok((scope, ms))
         }

--- a/alan_compiler/src/program/microstatement.rs
+++ b/alan_compiler/src/program/microstatement.rs
@@ -920,8 +920,19 @@ pub fn baseassignablelist_to_microstatements<'a>(
             }
             BaseChunk::ConstantAccessor(c) => {
                 if let Some(prior) = &prior_value {
+                    // If the accessor names a numeric type that is one of a numeric literal's
+                    // candidate types (e.g. `5.u64`), narrow the literal to that type directly. This
+                    // turns the accessor into a zero-cost type ascription -- the identity conversion,
+                    // with no runtime `as` cast -- for in-range literals. A variable, a non-numeric
+                    // accessor, or an out-of-range literal (e.g. `300.u8`, where `u8` was pruned from
+                    // the candidate set) is left alone and still goes through the normal
+                    // conversion/cast function.
+                    let prior = match scope.resolve_type(&c.to_string()) {
+                        Some(target) => narrow_numeric_literal(prior.clone(), target),
+                        None => prior.clone(),
+                    };
                     let mut temp_scope = scope.child();
-                    let constant_accessor_microstatements = vec![prior.clone()];
+                    let constant_accessor_microstatements = vec![prior];
                     let mut arg_types = Vec::new();
                     for m in &constant_accessor_microstatements {
                         // Collapse an `AnyOf` literal type to its FUI default so the accessor (e.g.
@@ -1051,6 +1062,18 @@ pub fn baseassignablelist_to_microstatements<'a>(
                             microstatements = res.1;
                             arg_microstatements.push(microstatements.pop().unwrap());
                         }
+                    }
+                }
+                // If this call names a numeric type (e.g. `5.u64` or `u64(5)`) and its first
+                // argument is a numeric literal whose candidate set includes that type, narrow the
+                // literal directly so the *identity* conversion is selected -- a zero-cost type
+                // ascription rather than a runtime `as` cast. A variable argument or an out-of-range
+                // literal (where the type was pruned from the candidate set) is left alone and still
+                // goes through the normal conversion/cast function.
+                if !arg_microstatements.is_empty() {
+                    if let Some(target) = scope.resolve_type(f) {
+                        arg_microstatements[0] =
+                            narrow_numeric_literal(arg_microstatements[0].clone(), target);
                     }
                 }
                 let mut arg_types = Vec::new();

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -855,11 +855,10 @@ impl<'a> Scope<'a> {
         // (highest-priority) one.
         candidates
             .iter()
-            .filter(|c| {
+            .rfind(|c| {
                 let cs = (*c).clone().degroup().to_strict_string(false);
                 demanded.contains(&cs)
             })
-            .next_back()
             .cloned()
     }
 

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -815,18 +815,85 @@ impl<'a> Scope<'a> {
         None
     }
 
+    /// For a numeric-literal `AnyOf` argument at position `argpos` of a call to `function` (with
+    /// `arity` arguments), return the FUI-last candidate that some same-arity overload demands at
+    /// that position, or `None` if no overload constrains it to a concrete numeric type (e.g. a
+    /// generic parameter). `candidates` are the literal's viable types in FUI order. This drives
+    /// implicit narrowing of literals to a function's concrete parameter types.
+    fn context_numeric_collapse(
+        &'a self,
+        function: &str,
+        argpos: usize,
+        arity: usize,
+        candidates: &[Arc<CType>],
+    ) -> Option<Arc<CType>> {
+        // Collect the (wrapper-stripped) parameter types demanded at `argpos` by same-arity
+        // overloads visible from this scope.
+        let mut demanded: Vec<String> = Vec::new();
+        let mut scope_to_check: Option<&Scope> = Some(self);
+        while let Some(s) = scope_to_check {
+            if let Some(funcs) = s.functions.get(function) {
+                for f in funcs {
+                    let fargs = f.args();
+                    if fargs.len() == arity && argpos < fargs.len() {
+                        demanded.push(
+                            fargs[argpos]
+                                .2
+                                .clone()
+                                .strip_value_wrappers()
+                                .to_strict_string(false),
+                        );
+                    }
+                }
+            }
+            scope_to_check = match &s.parent {
+                Some(p) => Some(*p),
+                None => None,
+            };
+        }
+        // Keep the candidates (already in FUI order) demanded by some overload and pick the last
+        // (highest-priority) one.
+        candidates
+            .iter()
+            .filter(|c| {
+                let cs = (*c).clone().degroup().to_strict_string(false);
+                demanded.iter().any(|d| *d == cs)
+            })
+            .next_back()
+            .cloned()
+    }
+
     pub fn resolve_function(
         mut self,
         function: &String,
         args: &[Arc<CType>],
     ) -> Option<(Scope<'a>, Arc<Function>)> {
-        // Collapse any `AnyOf`-typed arguments (e.g. a numeric literal that was not narrowed by an
-        // explicit annotation or accessor) to their FUI default before dispatch, so they match a
-        // single concrete overload (`print(5)` -> `print(i64)`) rather than failing to resolve
-        // against the whole candidate set. See `docs/int-float-constant-selection-plan.md`.
+        // Narrow any numeric-literal `AnyOf` argument to a single concrete type before dispatch.
+        // For each such argument we prefer the candidate that some overload of `function` actually
+        // demands at that position (so `foo(5)` resolves to `foo(u8)` when `u8` is the only
+        // overload, and `5 + 5` -- where every integer overload is viable -- resolves to the FUI
+        // default `i64`); if nothing constrains the position (e.g. a generic parameter) we fall
+        // back to the global FUI default. Function-typed `AnyOf`s (overload sets / operator-return
+        // merges) are left intact so higher-order dispatch can narrow them by signature. See
+        // `docs/int-float-constant-selection-plan.md`.
+        let arity = args.len();
         let collapsed_args: Vec<Arc<CType>> = args
             .iter()
-            .map(|a| a.clone().collapse_anyof_default())
+            .enumerate()
+            .map(|(i, a)| {
+                if let CType::AnyOf(ts) = &**a {
+                    let default = a.clone().collapse_anyof_default();
+                    if matches!(&*default, CType::AnyOf(_)) {
+                        // A function-like `AnyOf` (collapse left it intact): keep it for inference.
+                        a.clone()
+                    } else {
+                        self.context_numeric_collapse(function, i, arity, ts)
+                            .unwrap_or(default)
+                    }
+                } else {
+                    a.clone()
+                }
+            })
             .collect();
         let args = &collapsed_args[..];
         // We should prefer the "normal" function, if it matches, use it, otherwise try to go with

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -857,7 +857,7 @@ impl<'a> Scope<'a> {
             .iter()
             .filter(|c| {
                 let cs = (*c).clone().degroup().to_strict_string(false);
-                demanded.iter().any(|d| *d == cs)
+                demanded.contains(&cs)
             })
             .next_back()
             .cloned()

--- a/alan_compiler/src/program/scope.rs
+++ b/alan_compiler/src/program/scope.rs
@@ -820,6 +820,15 @@ impl<'a> Scope<'a> {
         function: &String,
         args: &[Arc<CType>],
     ) -> Option<(Scope<'a>, Arc<Function>)> {
+        // Collapse any `AnyOf`-typed arguments (e.g. a numeric literal that was not narrowed by an
+        // explicit annotation or accessor) to their FUI default before dispatch, so they match a
+        // single concrete overload (`print(5)` -> `print(i64)`) rather than failing to resolve
+        // against the whole candidate set. See `docs/int-float-constant-selection-plan.md`.
+        let collapsed_args: Vec<Arc<CType>> = args
+            .iter()
+            .map(|a| a.clone().collapse_anyof_default())
+            .collect();
+        let args = &collapsed_args[..];
         // We should prefer the "normal" function, if it matches, use it, otherwise try to go with
         // a generic function, if possible.
         // TODO: This boolean *shouldn't* be necessary, but I can't convince the borrow checker


### PR DESCRIPTION
- **Better numeric literals. Bare `let` declared numbers now work for `u64`**
- **Make bare numeric literals work again when passed directly as a function argument**
- **Allow `<number>.<type>` to act as the type declaration for numbers, as well, and re-enable disabled `u64` tests**
